### PR TITLE
Easy usage on client side with Ender.js

### DIFF
--- a/lib/ender.js
+++ b/lib/ender.js
@@ -1,0 +1,5 @@
+!function($) {
+  $.ender({
+    marked: require('./marked.js')
+  });
+}(ender);

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "version": "0.1.7",
   "main": "./lib/marked.js",
   "bin": { "marked": "./bin/marked" },
+  "ender": "./lib/ender.js",
   "repository": "git://github.com/chjj/marked.git",
   "bugs" : {
     "url": "http://github.com/chjj/marked/issues"


### PR DESCRIPTION
I added a bridge to [Ender](http://ender.no.de/). This way, you can easily use marked on the client-side by running

```
ender build marked
```

This will compile an ender.js and an ender.min.js for client-side usage.

You can use it like this in the browser:

``` html
<script src="ender.min.js"></script>
<script>
var marked = require('marked');
document.write(marked('# Heading'));
</script>
```

This will write `<h1>Heading</h1>` to the document.

PS: This doesn't add any overhead. You also don't have to adjust anything in the bridge, when you change something in marked, since the interface stays always the same.
