### PR TITLE
better handling of list indentation

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -199,14 +199,12 @@ block.token = function(src, tokens, top) {
 
         // Remove the list item's bullet
         // so it is seen as the next token.
-        space = item.length;
         item = item.replace(/^ *([*+-]|\d+\.) */, '');
 
         // Outdent whatever the
         // list item contains. Hacky.
         if (~item.indexOf('\n ')) {
-          space -= item.length;
-          item = item.replace(new RegExp('^ {1,' + space + '}', 'gm'), '');
+          item = item.replace(/^ {1,4}/gm, '');
         }
 
         // Determine whether item is loose or not.


### PR DESCRIPTION
fixes erroneous leading space in `<code>` blocks within list items. eg Ruby/Rails blocks here: https://raw.github.com/mojombo/github-flavored-markdown/gh-pages/_site/sample_content.md

the previous list indentation behavior outdented list items up to the indentation level forced by the leading number or bullet. while this accounted for any number of list items, it also was unable to handle the case with nested code blocks. such as this:

```
1. In Ruby you can map like this:

        ['a', 'b'].map { |x| x.uppercase }

2. In Rails, you can do a shortcut:

        ['a', 'b'].map(&:uppercase)
```

there are 3 chars to outdent according to the first line, but the code blocks are indented 8 spaces, as per spec. this caused the code to also be outdented by 3 spaces, leaving 5. Then 4 are stripped by the `<code>` sub-parser leaving 1 erroneous leading space _inside_ the code block.

while this patch may partially break the handling of 3-digit list items (100+), it fixes a more common scenario of not intentionally needing leading spaces on indent-aligned list sub-items.
