### PR TITLE
marked (as a lib) is supposed to be on require path ?!?

### DIFF
--- a/bin/marked
+++ b/bin/marked
@@ -7,7 +7,7 @@
 
 var fs = require('fs')
   , util = require('util')
-  , marked = require('../');
+  , marked = require('marked');
 
 /**
  * Man Page


### PR DESCRIPTION
The executable could be globally installed.
