### PR TITLE
adding 'highlighter' as an option

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -538,9 +538,12 @@ var tok = function() {
         + '"'
         : '')
         + '>'
-        + (token.escaped
-        ? token.text
-        : escape(token.text, true))
+        + (options.highlighter
+          ? options.highlighter(token.text)
+          : (token.escaped
+            ? token.text
+            : escape(token.text, true))
+        )
         + '</code></pre>\n';
     }
     case 'blockquote_start': {
@@ -744,7 +747,8 @@ marked.setOptions = function(opt) {
 marked.options({
   gfm: true,
   pedantic: false,
-  sanitize: false
+  sanitize: false,
+  highlighter: null
 });
 
 /**


### PR DESCRIPTION
While your readme shows you can fully support a highlighter by wrapping marked and inspecting the tokens manually, it would be more performant to not have to traverse the tokens another time to add highlighting.  The usage also becomes very simple for users:

```
var marked = require('marked').setOptions({
    highlight : require('highlight').Highlight
});
```
