### PR TITLE
Add urlFormatter option

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -347,6 +347,10 @@ inline.gfm = {
   text: /^[^\0]+?(?=[\\<!\[_*`]|https?:\/\/| {2,}\n|$)/
 };
 
+inline.formatUrl = function(href) {
+  return href;
+};
+
 /**
  * Inline Lexer
  */
@@ -380,7 +384,7 @@ inline.lexer = function(src) {
         href = text;
       }
       out += '<a href="'
-        + href
+        + inline.formatUrl(href)
         + '">'
         + text
         + '</a>';
@@ -393,7 +397,7 @@ inline.lexer = function(src) {
       text = escape(cap[1]);
       href = text;
       out += '<a href="'
-        + href
+        + inline.formatUrl(href)
         + '">'
         + text
         + '</a>';
@@ -482,7 +486,7 @@ inline.lexer = function(src) {
 var outputLink = function(cap, link) {
   if (cap[0][0] !== '!') {
     return '<a href="'
-      + escape(link.href)
+      + escape(inline.formatUrl(link.href))
       + '"'
       + (link.title
       ? ' title="'
@@ -494,7 +498,7 @@ var outputLink = function(cap, link) {
       + '</a>';
   } else {
     return '<img src="'
-      + escape(link.href)
+      + escape(inline.formatUrl(link.href))
       + '" alt="'
       + escape(cap[1])
       + '"'
@@ -745,6 +749,10 @@ var setOptions = function(opt) {
   } else {
     inline.em = inline.normal.em;
     inline.strong = inline.normal.strong;
+  }
+
+  if (options.urlFormatter) {
+    inline.formatUrl = options.urlFormatter;
   }
 };
 


### PR DESCRIPTION
This allows to specify a url formatter function. Example:

``` javascript
var url = require('url');
var source = "[mylink](path/to/somewhere)";

marked.setOptions({
  urlFormatter: function(href) {
    return url.resolve('http://mydomain.com', href);
  }
});

console.log(marked(source)); // <p><a href="http://mydomain.com/path/to/somewhere">mylink</a></p>
```
