### PR TITLE
Remember any call to setOptions() and authorize partial options application...

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -711,13 +711,18 @@ function marked(src, opt) {
  * Options
  */
 
-var options
-  , defaults;
+var options  = {}
+  , defaults = {
+      gfm: true,
+      pedantic: false,
+      sanitize: false,
+      highlight: null
+    };
 
 function setOptions(opt) {
-  if (!opt) opt = defaults;
-  if (options === opt) return;
-  options = opt;
+  if (!opt) return;
+
+  for (var key in opt) options[key] = opt[key];
 
   if (options.gfm) {
     block.fences = block.gfm.fences;
@@ -742,17 +747,11 @@ function setOptions(opt) {
 
 marked.options =
 marked.setOptions = function(opt) {
-  defaults = opt;
   setOptions(opt);
   return marked;
 };
 
-marked.setOptions({
-  gfm: true,
-  pedantic: false,
-  sanitize: false,
-  highlight: null
-});
+marked.setOptions(defaults);
 
 /**
  * Expose


### PR DESCRIPTION
So, here is my use case :

Different calls to `setOptions()` won't recall the precedent options.
That's not what we usually expect, and it requires that we re-pass every defined option value when we want to only change one. 

The basic use case is :

``` js
// Let's be pedantic..
marked.setOptions({pedantic: true});
var result1 = marked(pedanticInput));  

// Let's add some highlights 
marked.setOptions({
  highlight: function(code, lang) {
    console.log("How wonderful! You talk " + lang);
    return "<blink>" + code + "</blink>";
  }
});
var result2 = marked(pedanticInput);  // << i still expect to be pedantic here ! 
                                    // but in fact, i'm not even gfm (the defaults were erased) 
```

The test suite with the _current_ marked version can be found here : http://codepen.io/zipang/pen/zIoaB
And the same test suite with marked patched is here : http://codepen.io/zipang/pen/cGkIs
