### PR TITLE
Throw an exception when parsing with no links object

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -631,6 +631,9 @@ function parseText() {
 }
 
 function parse(src) {
+  if (!src.links) {
+    throw new Error('SRC tokens for parse should include a `links` property, which should be an object.');
+  }
   tokens = src.reverse();
 
   var out = '';


### PR DESCRIPTION
This bit me hard, when you get the array of tokens, it should also have a `links` property.  This adds a check for that and throws an error if the `links` property is absent.
