### PR TITLE
Option to turn off links syntax

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -359,7 +359,7 @@ inline.lexer = function(src) {
     }
 
     // autolink
-    if (cap = inline.autolink.exec(src)) {
+    if (options.links && (cap = inline.autolink.exec(src))) {
       src = src.substring(cap[0].length);
       if (cap[2] === '@') {
         text = cap[1][6] === ':'
@@ -379,7 +379,7 @@ inline.lexer = function(src) {
     }
 
     // url (gfm)
-    if (cap = inline.url.exec(src)) {
+    if (options.links && (cap = inline.url.exec(src))) {
       src = src.substring(cap[0].length);
       text = escape(cap[1]);
       href = text;
@@ -401,7 +401,7 @@ inline.lexer = function(src) {
     }
 
     // link
-    if (cap = inline.link.exec(src)) {
+    if (options.links && (cap = inline.link.exec(src))) {
       src = src.substring(cap[0].length);
       out += outputLink(cap, {
         href: cap[2],
@@ -411,7 +411,7 @@ inline.lexer = function(src) {
     }
 
     // reflink, nolink
-    if ((cap = inline.reflink.exec(src))
+    if (options.links && (cap = inline.reflink.exec(src))
         || (cap = inline.nolink.exec(src))) {
       src = src.substring(cap[0].length);
       link = (cap[2] || cap[1]).replace(/\s+/g, ' ');
@@ -711,13 +711,26 @@ function marked(src, opt) {
  * Options
  */
 
-var options
-  , defaults;
+var options;
+var defaults = {
+  gfm: true,
+  pedantic: false,
+  sanitize: false,
+  highlight: null,
+  links: true
+};
 
 function setOptions(opt) {
   if (!opt) opt = defaults;
   if (options === opt) return;
-  options = opt;
+  
+  //inherit options from default
+  options = defaults;
+  for (var o in opt) {
+    if (opt.hasOwnProperty(o)) {
+        options[o] = opt[o];
+    }
+  }  
 
   if (options.gfm) {
     block.fences = block.gfm.fences;
@@ -742,17 +755,10 @@ function setOptions(opt) {
 
 marked.options =
 marked.setOptions = function(opt) {
-  defaults = opt;
   setOptions(opt);
   return marked;
 };
 
-marked.setOptions({
-  gfm: true,
-  pedantic: false,
-  sanitize: false,
-  highlight: null
-});
 
 /**
  * Expose


### PR DESCRIPTION
Hi,

we're using marked for a phonegap/cordova app and links in that context is not a good thing. I've added a 'links' option that just turns links parsing off. Also I refactored setOptions a bit so that it "inherits" default options. 

I haven't had time to to run or add tests for this and I understand if you don't want to burden the codebase with yet another option, so take it or leave it as you please :-)

cheers!
