### PR TITLE
fix test for gfm_code_hr_list.text

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -35,7 +35,7 @@ block.item = replace(block.item, 'gm')
 
 block.list = replace(block.list)
   (/bull/g, block.bullet)
-  ('hr', /\n+(?=(?: *[-*_]){3,} *(?:\n+|$))/)
+  ('hr', /(\n+)(?=(?!\1(?: {4,}|\t+))(?: *[-*_]){3,} *(?:\n+|$))/)
   ();
 
 block._tag = '(?!(?:'


### PR DESCRIPTION
The `Regexp` for `list block` could not parse indented `hr` which may exist in code block correctlly, like:

``````
1. foo
    ```
    ---
    bar
    ```
2. two
``````

As it consider the `---` in code block as end of list, this patch fixed that.
