### PR TITLE
Add custom attributes to links

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -577,7 +577,9 @@ InlineLexer.prototype.output = function(src) {
       }
       out += '<a href="'
         + href
-        + '">'
+        + '"'
+        + (this.options.customAttributes.a || '')
+        + '>'
         + text
         + '</a>';
       continue;
@@ -590,7 +592,9 @@ InlineLexer.prototype.output = function(src) {
       href = text;
       out += '<a href="'
         + href
-        + '">'
+        + '"'
+        + (this.options.customAttributes.a || '')
+        + '>'
         + text
         + '</a>';
       continue;
@@ -703,6 +707,7 @@ InlineLexer.prototype.outputLink = function(cap, link) {
       + escape(link.title)
       + '"'
       : '')
+      + (this.options.customAttributes.a || '')
       + '>'
       + this.output(cap[1])
       + '</a>';
@@ -1041,7 +1046,8 @@ marked.defaults = {
   smartLists: false,
   silent: false,
   highlight: null,
-  langPrefix: 'lang-'
+  langPrefix: 'lang-',
+  customAttributes: {}
 };
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -87,6 +87,7 @@ main:
     file = files[filename];
 
     if ((~filename.indexOf('.gfm.') && !marked.defaults.gfm)
+        || ((~filename.indexOf('.customAttributes.') && true || false) != (marked.defaults.customAttributes.a && true || false))
         || (~filename.indexOf('.tables.') && !marked.defaults.tables)
         || (~filename.indexOf('.breaks.') && !marked.defaults.breaks)
         || (~filename.indexOf('.pedantic.') && !marked.defaults.pedantic)
@@ -415,6 +416,10 @@ function parseArg(argv) {
       case '-t':
       case '--time':
         options.time = true;
+        break;
+      case 'customAttributes':
+        options.marked = options.marked || {};
+        options.marked.customAttributes = { "a": " target=\"_blank\""};
         break;
       default:
         if (arg.indexOf('--') === 0) {

--- a/test/tests/gfm_links.customAttributes.html
+++ b/test/tests/gfm_links.customAttributes.html
@@ -1,0 +1,2 @@
+<p>This should be a targeted link:
+<a href="http://example.com/hello-world" target="_blank">http://example.com/hello-world</a>.</p>

--- a/test/tests/gfm_links.customAttributes.text
+++ b/test/tests/gfm_links.customAttributes.text
@@ -1,0 +1,1 @@
+This should be a targeted link: http://example.com/hello-world.


### PR DESCRIPTION
This code adds custom attributes to links for things like making all links open in a new window 

```
options.customAttributes = { "a": " target=\"_blank\""}; 

node test/index.js customAttributes
```

Links is the only place I need to do this at the moment (leaving the default link behaviour can cause all sorts of problems in a phonegap app) but it is designed to be easily extended if necessary.

I'd prefer not to need the space at the start of the custom string, but removing that requires either adding a lot more code or always adding a space and changing the expected result of 20 or so of the tests.
