### PR TITLE
GFM supports arbitrary characters in fenced code block language identifier.

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -70,7 +70,7 @@ block.normal = merge({}, block);
  */
 
 block.gfm = merge({}, block.normal, {
-  fences: /^ *(`{3,}|~{3,}) *(\w+)? *\n([\s\S]+?)\s*\1 *(?:\n+|$)/,
+  fences: /^ *(`{3,}|~{3,}) *(\S+)? *\n([\s\S]+?)\s*\1 *(?:\n+|$)/,
   paragraph: /^/
 });
 


### PR DESCRIPTION
``` this:is:a:test:with:the:snowman:☃:
Yep it works
```

GFM supports arbitrary characters in fenced code block language identifier.  Changed a \w to a \S when checking for fenced code blocks

If you want a test case, use the aforementioned snowman block
