### PR TITLE
Fixed marked() callback

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1029,7 +1029,7 @@ function marked(src, opt, callback) {
 
     if (opt) opt = merge({}, marked.defaults, opt);
 
-    var tokens = Lexer.lex(tokens, opt)
+    var tokens = Lexer.lex(src, opt)
       , highlight = opt.highlight
       , pending = 0
       , l = tokens.length


### PR DESCRIPTION
An incorrect first argument was given to `Lexer.lex` on line 1035. thx
