### PR TITLE
Fixed argument typo for Lexer.lex() and bug for async highlighting

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1048,7 +1048,12 @@ function marked(src, opt, callback) {
 
     for (; i < l; i++) {
       (function(token) {
-        if (token.type !== 'code') return;
+        if (token.type !== 'code') {
+          if (i === l - 1 && pending === 0) {
+            done();
+          }
+          return;
+        }
         pending++;
         return highlight(token.text, token.lang, function(err, code) {
           if (code == null || code === token.text) {


### PR DESCRIPTION
My first commit fixes the argument typo for the Lexer.lex() function call for async highlighting, the same as #152.

Additionally, I noticed that when I was doing async highlighting and the markdown content didn't have a code section, it would never call the completion callback.

[This](https://github.com/ChrisWren/marked/blob/0c94d3ab64e70f3dcc2b4b76ed6a66171a6791ee/lib/marked.js#L1064) line of code was the only place where `done()` was invoked, and as you can see it is inside the highlighting callback. What I did is add a check for non-code tokens to see if there is no code highlighting pending when parsing the last token and call `done()` in that case. 
