### PR TITLE
Allow heading output to have decorated id's

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -835,6 +835,7 @@ Parser.prototype.tok = function() {
     case 'heading': {
       return '<h'
         + this.token.depth
+        + (this.token.id ? ' id="' + this.token.id + '"' : '')
         + '>'
         + this.inline.output(this.token.text)
         + '</h'


### PR DESCRIPTION
Simple tiny change to allow intercepting the lexer results to
decorate the headings in the parser with potentially unique id's.

would be useful for bulk processing of a tree of .md and/or deep linking
to a section via #hash in rendered output
