### PR TITLE
Fixed opt conditional in marked method

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1027,7 +1027,7 @@ function marked(src, opt, callback) {
       opt = null;
     }
 
-    if (opt) opt = merge({}, marked.defaults, opt);
+    if (!opt) opt = merge({}, marked.defaults, opt);
 
     var highlight = opt.highlight
       , tokens


### PR DESCRIPTION
Noticed this bug when writing example usages of marked for the README.
