### PR TITLE
Properly use async method signature in second example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ A function to highlight code blocks. The function takes three arguments: code, l
 
 ```js
 marked.setOptions({
-  highlight: function (lang, code) {
-    return hljs.highlightAuto(lang, code).value;
+  highlight: function (code, lang) {
+    return hljs.highlightAuto(code, lang).value;
   }
 });
 ```


### PR DESCRIPTION
I didn't use the correct method signature in the second example. Since it is using async highlighting, the async version of marked should be used.
