### PR TITLE
Fixed the parameters' order of the hightlightAuto function call

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ A function to highlight code blocks. The function takes three arguments: code, l
 ```js
 marked.setOptions({
   highlight: function (code, lang) {
-    return hljs.highlightAuto(code, lang).value;
+    return hljs.highlightAuto(lang, code).value;
   }
 });
 ```


### PR DESCRIPTION
Fixed the parameters' order of the hightlightAuto function call in the hightlight code example
