### PR TITLE
`node test` should have non-zero exit code if some tests failed

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -486,7 +486,7 @@ function main(argv) {
 
   if (!module.parent) {
     var passed = runTests(opt);
-    process.exit(!passed)
+    process.exit(!passed);
   } else return runTests(opt);
 }
 


### PR DESCRIPTION
Return the results of testing to a parent process.

Traditionally the exit code is `0` only if everything is okay (“no failing tests” in this case).
