### PR TITLE
Align td and th with css instead of align property

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -888,7 +888,7 @@ Parser.prototype.tok = function() {
       for (i = 0; i < this.token.header.length; i++) {
         heading = this.inline.output(this.token.header[i]);
         body += this.token.align[i]
-          ? '<th align="' + this.token.align[i] + '">' + heading + '</th>\n'
+          ? '<th style="text-align:' + this.token.align[i] + '">' + heading + '</th>\n'
           : '<th>' + heading + '</th>\n';
       }
       body += '</tr>\n</thead>\n';
@@ -901,7 +901,7 @@ Parser.prototype.tok = function() {
         for (j = 0; j < row.length; j++) {
           cell = this.inline.output(row[j]);
           body += this.token.align[j]
-            ? '<td align="' + this.token.align[j] + '">' + cell + '</td>\n'
+            ? '<td style="text-align:' + this.token.align[j] + '">' + cell + '</td>\n'
             : '<td>' + cell + '</td>\n';
         }
         body += '</tr>\n';


### PR DESCRIPTION
When you align tables with css, <td align="..."> gets overridden. 
Using inline styles keeps alignment no matter what CSS contains.

While this is a departure from what Github currently does, the reference markdown parser they use, [RedCarpet](https://github.com/vmg/redcarpet) has made [this change](https://github.com/vmg/redcarpet/commit/1e61096be1c5e7cd34d19ca65afa2fca87639c5f), and I'm hoping Github will follow at some point in the future.
