### PR TITLE
fix: `options` is optional

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1040,7 +1040,7 @@ function marked(src, opt, callback) {
   if (callback || typeof opt === 'function') {
     if (!callback) {
       callback = opt;
-      opt = null;
+      opt = marked.defaults;
     }
 
     opt = merge({}, marked.defaults, opt || {});


### PR DESCRIPTION
when `opt` is not passed, opt should be default options, or an error will be raised when accessing `opt.highlight`. 

Sorry for not adding testcase, I don't know how, wish to see mocha or other testsuit in the future :)
