### PR TITLE
Fix highlight.js example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ lang, and callback. The above example uses async highlighting with
 ```js
 marked.setOptions({
   highlight: function (code, lang) {
-    return hljs.highlightAuto(lang, code).value;
+    return hljs.highlightAuto(code).value;
   }
 });
 ```


### PR DESCRIPTION
Current highlight.js example not work since highlightAuto doesn't take a lang parameter: 

https://github.com/isagalaev/highlight.js/blob/58fc91edbb83708375bda87c02d0fa09b46f4676/src/highlight.js#L427

Would try to use `hljs.highlight(lang, code)` style to pass in the lang but the marked detected language doesn't nearly have a 1-1 mapping with highlightjs. For example, highlight.js doesn't know what `html` or `js` is, will spit out a cryptic `TypeError: Cannot read property 'compiled' of undefined` error if it doesn't know what language you are talking about. 
