### PR TITLE
render svg images as <embed> rather than <img>

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -867,9 +867,19 @@ Renderer.prototype.link = function(href, title, text) {
 };
 
 Renderer.prototype.image = function(href, title, text) {
-  var out = '<img src="' + href + '" alt="' + text + '"';
-  if (title) {
-    out += ' title="' + title + '"';
+  var out;
+  var issvg = href.match(/\.svg(\?|$)/);
+  out = issvg ? '<embed' : '<img';
+  out += ' src="' + href + '"'
+  if(issvg) {
+    if (title || text) {
+      out += ' title="' + (title || text) + '"';
+    }
+  } else {
+    out += ' alt="' + text + '"';
+    if (title) {
+      out += ' title="' + title + '"';
+    }
   }
   out += '>';
   return out;


### PR DESCRIPTION
Because text in <embed> svg can be selected and searched, but <img> not.
