### PR TITLE
Added support for reference hooks

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -616,7 +616,7 @@ InlineLexer.prototype.output = function(src) {
         || (cap = this.rules.nolink.exec(src))) {
       src = src.substring(cap[0].length);
       link = (cap[2] || cap[1]).replace(/\s+/g, ' ');
-      link = this.links[link.toLowerCase()];
+      link = this.links[link.toLowerCase()] || this.renderer.reference(link);
       if (!link || !link.href) {
         out += cap[0].charAt(0);
         src = cap[0].substring(1) + src;
@@ -845,6 +845,9 @@ Renderer.prototype.del = function(text) {
   return '<del>' + text + '</del>';
 };
 
+Renderer.prototype.reference = function(link) {
+  return undefined;
+}
 Renderer.prototype.link = function(href, title, text) {
   if (this.options.sanitize) {
     try {


### PR DESCRIPTION
Allows the renderer to automatically resolve references if they are not defined in the document. This is useful for wiki-type sites.
### Example

``` javascript
renderer.reference = function (name) {
   return { title: name, href: '/articles/' + name.toLowerCase().replace(' ', '-') };
}
```
### Example Input

``` markdown
Node.js is powered by [v8]
```
### Example Output

``` markdown
<p>Node.js is powered by <a href="/articles/v8">v8</a></p>
```
