### PR TITLE
Table ending in empty cell

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -412,7 +412,7 @@ Lexer.prototype.token = function(src, top, bq) {
         type: 'table',
         header: cap[1].replace(/^ *| *\| *$/g, '').split(/ *\| */),
         align: cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
-        cells: cap[3].replace(/(?: *\| *)?\n$/, '').split('\n')
+        cells: cap[3].replace(/(?: *\| *)?\n$/, '|').split('\n')
       };
 
       for (i = 0; i < item.align.length; i++) {

--- a/test/new/gfm_tables.html
+++ b/test/new/gfm_tables.html
@@ -35,3 +35,12 @@
 		<tr><td style="text-align:left"><em>Cell 5</em></td><td style="text-align:center">Cell 6</td><td style="text-align:right">Cell 7</td><td>Cell 8</td></tr>
 	</tbody>
 </table>
+<table>
+	<thead>
+		<tr><th>Header 1</th><th>Header 2</th></tr>
+	</thead>
+	<tbody>
+		<tr><td>Cell 1</td><td>Cell 2</td></tr>
+		<tr><td>Cell 3</td><td></td></tr>
+	</tbody>
+</table>

--- a/test/new/gfm_tables.text
+++ b/test/new/gfm_tables.text
@@ -19,3 +19,8 @@ Header 1|Header 2|Header 3|Header 4
 :-------|:------:|-------:|--------
 Cell 1  |Cell 2  |Cell 3  |Cell 4
 *Cell 5*|Cell 6  |Cell 7  |Cell 8
+
+| Header 1 | Header 2 |
+|----------|----------|
+| Cell 1   | Cell 2   |
+| Cell 3   |          |

--- a/test/tests/gfm_tables.html
+++ b/test/tests/gfm_tables.html
@@ -35,3 +35,12 @@
 		<tr><td style="text-align:left"><em>Cell 5</em></td><td style="text-align:center">Cell 6</td><td style="text-align:right">Cell 7</td><td>Cell 8</td></tr>
 	</tbody>
 </table>
+<table>
+	<thead>
+		<tr><th>Header 1</th><th>Header 2</th></tr>
+	</thead>
+	<tbody>
+		<tr><td>Cell 1</td><td>Cell 2</td></tr>
+		<tr><td>Cell 3</td><td></td></tr>
+	</tbody>
+</table>

--- a/test/tests/gfm_tables.text
+++ b/test/tests/gfm_tables.text
@@ -19,3 +19,8 @@ Header 1|Header 2|Header 3|Header 4
 :-------|:------:|-------:|--------
 Cell 1  |Cell 2  |Cell 3  |Cell 4
 *Cell 5*|Cell 6  |Cell 7  |Cell 8
+
+| Header 1 | Header 2 |
+|----------|----------|
+| Cell 1   | Cell 2   |
+| Cell 3   |          |


### PR DESCRIPTION
Currently, if the last cell of a table is empty, it will be dropped from the HTML:

```
| Header 1 | Header 2 |
|----------|----------|
| Cell 1   | Cell 2   |
| Cell 3   |          |
```

This pull request does the following:
1. Add test for situation described above
2. Fix bug causing the the last cell to not be added during conversion to HTML.
