### PR TITLE
Make sure lexed node includes HTML all the way to matching closing tag

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -156,6 +156,7 @@ Lexer.prototype.token = function(src, top, bq) {
     , item
     , space
     , i
+    , re
     , l;
 
   while (src) {
@@ -354,14 +355,27 @@ Lexer.prototype.token = function(src, top, bq) {
 
     // html
     if (cap = this.rules.html.exec(src)) {
-      src = src.substring(cap[0].length);
-      this.tokens.push({
+      item = {
         type: this.options.sanitize
           ? 'paragraph'
           : 'html',
         pre: cap[1] === 'pre' || cap[1] === 'script' || cap[1] === 'style',
-        text: cap[0]
-      });
+      };
+      if (cap[1]) {
+        i = 1;
+        re = new RegExp('<(/' + cap[1] + '|' + cap[1] + '(?:"[^"]*"|\'[^\']*\'|[^\'">])*?/?)>', 'g');
+        // move past the opening tag found by this.rules.html
+        re.exec(src);
+        while (i > 0) {
+          cap = re.exec(src);
+          i += cap[1].charAt(0) === '/' ? -1 : cap[1].charAt(cap[1].length - 1) === '/' ? 0 : 1;
+        }
+        item.text = src.substring(0, re.lastIndex);
+      } else {
+        item.text = cap[0];
+      }
+      src = src.substring(item.text.length);
+      this.tokens.push(item);
       continue;
     }
 

--- a/package.json
+++ b/package.json
@@ -18,5 +18,5 @@
     "showdown": "*",
     "robotskirt": "*"
   },
-  "scripts": { "test": "node test", "bench": "node test --bench" }
+  "scripts": { "test": "node test; node test/lexer", "bench": "node test --bench" }
 }

--- a/test/lexer/index.js
+++ b/test/lexer/index.js
@@ -1,0 +1,31 @@
+var marked = require('../../'),
+    fs = require('fs'),
+    path = require('path');
+var tests = [], failed = 0;
+var test = tests.push;
+
+test(function() {
+  var content = fs.readFileSync(path.join(__dirname, './resources/complex_html.md'), 'utf8');
+  var nodes = marked.lexer(content);
+  assertEqual('heading', nodes[0].type);
+  assertEqual('html', nodes[1].type);
+  assertEqual('<div>\nThis HTML has\n<div>\nNested Divs\n</div>\n\n<div>\nIn a messy structure\n</div>\n\n</div>', nodes[1].text);
+  assertEqual(2, nodes.length);
+});
+
+function assertEqual(expected, actual) {
+  if (expected !== actual) {
+    throw "Expected: "+expected+"\nActual: "+actual;
+  }
+}
+
+console.log('\nLexer tests\n-----------');
+tests.forEach(function(t) {
+  try {
+    t();
+  } catch(e) {
+    console.log("Failed:", e);
+    failed += 1;
+  }
+});
+console.log(failed === 0 ? 'All tests passed' : failed + ' tests failed');

--- a/test/lexer/resources/complex_html.md
+++ b/test/lexer/resources/complex_html.md
@@ -1,0 +1,13 @@
+# A markdown file with complex HTML
+
+<div>
+This HTML has
+<div>
+Nested Divs
+</div>
+
+<div>
+In a messy structure
+</div>
+
+</div>


### PR DESCRIPTION
The lexer assumes an html block finishes at the next matching close tag, which is often not the case. Instead,  the corresponding close tag should be found.
