### PR TITLE
Allow options JavaScript file to be provided for cli

### DIFF
--- a/bin/marked
+++ b/bin/marked
@@ -86,6 +86,10 @@ function main(argv, callback) {
       case '--tokens':
         tokens = true;
         break;
+      case '--options':
+        var p = require("path").join(process.cwd(), argv.shift());
+        options = require(p);
+        break;
       case '-h':
       case '--help':
         return help();


### PR DESCRIPTION
This adds an `--options` option. The use case is if you want to provide
more advanced options that are possible with the cli options. For
example you might want to provide a syntax highlighting function. You
could define a module like:

``` js
var highlight = require("highlight.js");

module.exports = {
  langPrefix: 'hljs ',
  highlight: function(code){
    return highlight.highlightAuto(code).value;
  }
};
```

and then you can use it from the cli:

``` shell
cat post.md | marked --options marked_options.js
```
