### PR TITLE
generate id as separate method - can be overwritten or reuse

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -792,12 +792,16 @@ Renderer.prototype.html = function(html) {
   return html;
 };
 
+Renderer.prototype.generateId = function(text, level, raw) {
+  return raw.toLowerCase().replace(/[^\w]+/g, '-')
+};
+
 Renderer.prototype.heading = function(text, level, raw) {
   return '<h'
     + level
     + ' id="'
     + this.options.headerPrefix
-    + raw.toLowerCase().replace(/[^\w]+/g, '-')
+    + this.generateId(text, level, raw)
     + '">'
     + text
     + '</h'


### PR DESCRIPTION
Hi!
This feature would be helpful to me!

Anyway I'm pretty confused with test. I do not find any test on method overwriting master is failing for me.

```
#10. def_blocks.text failed at offset 20. Near: "<blockquote><p>hello</p><p><ahref="foo">1</a>:hell".


Got:
<blockquote><p>hello</p><p><ahref="foo">1</a>:hell


Expected:
<blockquote><p>hello[1]:hello</p></blockquote><hr>
```

Looks like a bug.

Anyway let me know if you're interested in such a feature. If so I'll finish this with proper test and documentation update.

Cheers!
~ Marek
