### PR TITLE
Table width adjustment by dash character

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -213,10 +213,16 @@ Lexer.prototype.token = function(src, top, bq) {
         type: 'table',
         header: cap[1].replace(/^ *| *\| *$/g, '').split(/ *\| */),
         align: cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
-        cells: cap[3].replace(/\n$/, '').split('\n')
+        cells: cap[3].replace(/\n$/, '').split('\n'),
+        width: []
       };
 
+      var widthSum = 0;
+      var width;
       for (i = 0; i < item.align.length; i++) {
+        width = item.align[i].split('-').length - 1;
+        widthSum += width;
+        item.width[i] = width;
         if (/^ *-+: *$/.test(item.align[i])) {
           item.align[i] = 'right';
         } else if (/^ *:-+: *$/.test(item.align[i])) {
@@ -226,6 +232,10 @@ Lexer.prototype.token = function(src, top, bq) {
         } else {
           item.align[i] = null;
         }
+      }
+
+      for (i = 0; i < item.width.length; i++) {
+        item.width[i] = item.width[i] / widthSum * 100;
       }
 
       for (i = 0; i < item.cells.length; i++) {
@@ -385,10 +395,16 @@ Lexer.prototype.token = function(src, top, bq) {
         type: 'table',
         header: cap[1].replace(/^ *| *\| *$/g, '').split(/ *\| */),
         align: cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
-        cells: cap[3].replace(/(?: *\| *)?\n$/, '').split('\n')
+        cells: cap[3].replace(/(?: *\| *)?\n$/, '').split('\n'),
+        width: []
       };
 
+      var widthSum = 0;
+      var width;
       for (i = 0; i < item.align.length; i++) {
+        width = item.align[i].split('-').length - 1;
+        widthSum += width;
+        item.align[i] = width;
         if (/^ *-+: *$/.test(item.align[i])) {
           item.align[i] = 'right';
         } else if (/^ *:-+: *$/.test(item.align[i])) {
@@ -398,6 +414,10 @@ Lexer.prototype.token = function(src, top, bq) {
         } else {
           item.align[i] = null;
         }
+      }
+
+      for (i = 0; i < item.width.length; i++) {
+        item.width[i] = item.width[i] / widthSum * 100;
       }
 
       for (i = 0; i < item.cells.length; i++) {
@@ -839,8 +859,15 @@ Renderer.prototype.tablerow = function(content) {
 
 Renderer.prototype.tablecell = function(content, flags) {
   var type = flags.header ? 'th' : 'td';
-  var tag = flags.align
-    ? '<' + type + ' style="text-align:' + flags.align + '">'
+  var style = [];
+  if (flags.align) {
+    style.push('text-align:' + flags.align);
+  }
+  if (this.options.tableWidth && flags.width) {
+    style.push('width:' + flags.width + '%');
+  }
+  var tag = style.length 
+    ? '<' + type + ' style="' + style.join(';') + '">'
     : '<' + type + '>';
   return tag + content + '</' + type + '>\n';
 };
@@ -1006,7 +1033,7 @@ Parser.prototype.tok = function() {
         flags = { header: true, align: this.token.align[i] };
         cell += this.renderer.tablecell(
           this.inline.output(this.token.header[i]),
-          { header: true, align: this.token.align[i] }
+          { header: true, align: this.token.align[i], width: this.token.width[i] }
         );
       }
       header += this.renderer.tablerow(cell);

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -404,7 +404,7 @@ Lexer.prototype.token = function(src, top, bq) {
       for (i = 0; i < item.align.length; i++) {
         width = item.align[i].split('-').length - 1;
         widthSum += width;
-        item.align[i] = width;
+        item.width[i] = width;
         if (/^ *-+: *$/.test(item.align[i])) {
           item.align[i] = 'right';
         } else if (/^ *:-+: *$/.test(item.align[i])) {

--- a/test/width/width.js
+++ b/test/width/width.js
@@ -1,0 +1,39 @@
+
+const tableMd = `
+Header 1 | Header 2
+--       | ---
+Cell 1   | Cell 2
+Cell 3   | Cell 4
+
+Header 1|Header 2|Header 3|Header 4
+:---    |:--:    |--:     |---
+Cell 1  |Cell 2  |Cell 3  |Cell 4
+*Cell 5*|Cell 6  |Cell 7  |Cell 8
+
+`;
+
+const marked = require('../../lib/marked');
+const Renderer = marked.Renderer;
+
+class MyRenderer extends Renderer {
+
+    table(header, body) {
+        return super.table(header, body);
+    }
+
+    tablerow(content) {
+        return super.tablerow(content);
+    }
+
+    tablecell(content, flags) {
+        return super.tablecell(content, flags);
+    }
+
+}
+
+marked.setOptions({
+    tableWidth: true,
+    renderer: new MyRenderer
+});
+
+console.log(marked(tableMd));

--- a/test/width/width.result.html
+++ b/test/width/width.result.html
@@ -1,0 +1,43 @@
+<table>
+<thead>
+<tr>
+<th style="width:40%">Header 1</th>
+<th style="width:60%">Header 2</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Cell 1</td>
+<td>Cell 2</td>
+</tr>
+<tr>
+<td>Cell 3</td>
+<td>Cell 4</td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th style="text-align:left;width:30%">Header 1</th>
+<th style="text-align:center;width:20%">Header 2</th>
+<th style="text-align:right;width:20%">Header 3</th>
+<th style="width:30%">Header 4</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align:left">Cell 1</td>
+<td style="text-align:center">Cell 2</td>
+<td style="text-align:right">Cell 3</td>
+<td>Cell 4</td>
+</tr>
+<tr>
+<td style="text-align:left"><em>Cell 5</em></td>
+<td style="text-align:center">Cell 6</td>
+<td style="text-align:right">Cell 7</td>
+<td>Cell 8</td>
+</tr>
+</tbody>
+</table>
+


### PR DESCRIPTION
Hi, I have little idea to determine table column width by dash characters.

For example, if you have next table.

```
Header 1|Header 2|Header 3|Header 4
:---    |:--:    |--:     |---
Cell 1  |Cell 2  |Cell 3  |Cell 4
*Cell 5*|Cell 6  |Cell 7  |Cell 8
```

Each column will have 30%, 20%, 20%, 30% width.
The percentage value of width is determined by (row dash count / total dash count) \* 100.
So, if you want to have the same column width, you can adjust dash as below

```
Header 1|Header 2|Header 3|Header 4
:-    |:-:    |-:     |-
Cell 1  |Cell 2  |Cell 3  |Cell 4
*Cell 5*|Cell 6  |Cell 7  |Cell 8
```

Last but not least, to use this feature you can turn on flag "tableWidth" through options.

I hope this is useful.
Thanks.
