### PR TITLE
Hacked the parser to not wrap in P tags if only one line

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -414,12 +414,17 @@ Lexer.prototype.token = function(src, top, bq) {
     // top-level paragraph
     if (top && (cap = this.rules.paragraph.exec(src))) {
       src = src.substring(cap[0].length);
-      this.tokens.push({
-        type: 'paragraph',
-        text: cap[1].charAt(cap[1].length - 1) === '\n'
-          ? cap[1].slice(0, -1)
-          : cap[1]
-      });
+      if (cap[1].charAt(cap[1].length - 1) === '\n') {
+        this.tokens.push({
+          type: 'paragraph',
+          text: cap[1].slice(0, -1),
+        });
+      } else {
+        this.tokens.push({
+          type: this.tokens.length > 0 ? 'paragraph' : 'html',
+          text: cap[1],
+        });
+      }
       continue;
     }
 
@@ -964,7 +969,6 @@ Parser.prototype.parseText = function() {
   while (this.peek().type === 'text') {
     body += '\n' + this.next().text;
   }
-
   return this.inline.output(body);
 };
 
@@ -1094,7 +1098,7 @@ function escape(html, encode) {
 }
 
 function unescape(html) {
-	// explicitly match decimal, hex, and named HTML entities 
+	// explicitly match decimal, hex, and named HTML entities
   return html.replace(/&(#(?:\d+)|(?:#x[0-9A-Fa-f]+)|(?:\w+));?/g, function(_, n) {
     n = n.toLowerCase();
     if (n === 'colon') return ':';


### PR DESCRIPTION
Maybe this would be better as a configurable option, but I hacked the parser to NOT wrap the block in <p> tags unless there is more than one line, then it functions as normal. 

Using this for my i18n CMS so that language editors can edit blocks inside header tags and others, where we know it will be one line and having a P tag is undesireable.

Welcoming your thoughts and feedback.