### PR TITLE
Not generate html links for url in code block

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -591,7 +591,7 @@ InlineLexer.prototype.output = function(src) {
     }
 
     // url (gfm)
-    if (!this.inLink && (cap = this.rules.url.exec(src))) {
+    if (!this.inLink && !this.inCode && (cap = this.rules.url.exec(src))) {
       src = src.substring(cap[0].length);
       text = escape(cap[1]);
       href = text;
@@ -605,6 +605,11 @@ InlineLexer.prototype.output = function(src) {
         this.inLink = true;
       } else if (this.inLink && /^<\/a>/i.test(cap[0])) {
         this.inLink = false;
+      }
+      if (/^<code/i.test(cap[0])) {
+        this.inCode = true;
+      } else if (/^<\/code>/i.test(cap[0])) {
+        this.inCode = false;
       }
       src = src.substring(cap[0].length);
       out += this.options.sanitize


### PR DESCRIPTION
Auto generating links for url in code block doesn't work properly when the url is followed by special characters. For example:

```
<a href="http://test.com">
```
would generate a link for http://test.com&quote

GFM doesn't seem to require url in code block to be converted to links.