### PR TITLE
Fixes for displaying multiple line breaks

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -374,6 +374,13 @@ Lexer.prototype.token = function(src, top, bq) {
         href: cap[2],
         title: cap[3]
       };
+ 
+    if (this.tokens == "" && cap[0] != "") {
+        this.tokens.push({
+                type: 'paragraph',
+                text: cap[0]
+                });
+        }
       continue;
     }
 
@@ -420,6 +427,14 @@ Lexer.prototype.token = function(src, top, bq) {
           ? cap[1].slice(0, -1)
           : cap[1]
       });
+      var regex = new RegExp("\n(?=\n)", "gi");
+      var match = cap[0].match(regex);
+      if (match !== null && src != '') {
+          var len = match.length;
+          for (var i = 0; i < len; i++) {
+              this.tokens.push({type: 'paragraph',text: "\n"});
+          }
+      }
       continue;
     }
 
@@ -819,7 +834,11 @@ Renderer.prototype.listitem = function(text) {
 };
 
 Renderer.prototype.paragraph = function(text) {
-  return '<p>' + text + '</p>\n';
+    if (text == "\n") {
+        return '<br>';
+    } else {
+        return '<p>' + text + '</p>\n';
+    }
 };
 
 Renderer.prototype.table = function(header, body) {
@@ -873,10 +892,10 @@ Renderer.prototype.link = function(href, title, text) {
         .replace(/[^\w:]/g, '')
         .toLowerCase();
     } catch (e) {
-      return '';
+      return text;
     }
     if (prot.indexOf('javascript:') === 0 || prot.indexOf('vbscript:') === 0 || prot.indexOf('data:') === 0) {
-      return '';
+      return text;
     }
   }
   var out = '<a href="' + href + '"';
@@ -934,7 +953,7 @@ Parser.prototype.parse = function(src) {
   while (this.next()) {
     out += this.tok();
   }
-
+ 
   return out;
 };
 
@@ -1094,7 +1113,7 @@ function escape(html, encode) {
 }
 
 function unescape(html) {
-	// explicitly match decimal, hex, and named HTML entities 
+    // explicitly match decimal, hex, and named HTML entities
   return html.replace(/&(#(?:\d+)|(?:#x[0-9A-Fa-f]+)|(?:\w+));?/g, function(_, n) {
     n = n.toLowerCase();
     if (n === 'colon') return ':';


### PR DESCRIPTION
Hi Team,

I am creating a pull request for the modifications done for the following :

-- to display multiple line breaks
-- to fix display issue with urls having a single %. (Eg : http://api.google.com/q?exp=a%b)


Could you please review it?

Thanks.