### PR TITLE
Add message: token type cannot be found

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1082,6 +1082,14 @@ Parser.prototype.tok = function() {
     case 'text': {
       return this.renderer.paragraph(this.parseText());
     }
+    default: {
+      var errMsg = 'Token with "' + this.token.type + '" type was not found.';
+      if (this.options.silent) {
+        console.log(errMsg);
+      } else {
+        throw new Error(errMsg);
+      }
+    }
   }
 };
 


### PR DESCRIPTION
It seems to me that such a message will be appropriate. If I did not write very English, the wishes for corrections are accepted.