### PR TITLE
fill unspecified options with defaults for lexers and parser

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -103,7 +103,7 @@ block.tables = merge({}, block.gfm, {
 function Lexer(options) {
   this.tokens = [];
   this.tokens.links = {};
-  this.options = options || marked.defaults;
+  this.options = merge({}, marked.defaults, options || {});
   this.rules = block.normal;
 
   if (this.options.gfm) {
@@ -519,7 +519,7 @@ inline.breaks = merge({}, inline.gfm, {
  */
 
 function InlineLexer(links, options) {
-  this.options = options || marked.defaults;
+  this.options = merge({}, marked.defaults, options || {});
   this.links = links;
   this.rules = inline.normal;
   this.renderer = this.options.renderer || new Renderer;
@@ -916,7 +916,7 @@ Renderer.prototype.text = function(text) {
 function Parser(options) {
   this.tokens = [];
   this.token = null;
-  this.options = options || marked.defaults;
+  this.options = merge({}, marked.defaults, options || {});
   this.options.renderer = this.options.renderer || new Renderer;
   this.renderer = this.options.renderer;
   this.renderer.options = this.options;


### PR DESCRIPTION
This ensures that if a custom Parser or Lexer is made with an options object as an argument, any unspecified options will be set by `marked.defaults` rather than being undefined.

One note:  I ran the test suite before making changes, and there were two failures