### PR TITLE
[testing] Use bem/html-differ to perform tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,14 +23,15 @@
     "html"
   ],
   "devDependencies": {
-    "markdown": "*",
-    "showdown": "*",
-    "markdown-it": "*",
     "front-matter": "^2.3.0",
     "glob-to-regexp": "0.3.0",
     "gulp": "^3.8.11",
+    "gulp-concat": "^2.5.2",
     "gulp-uglify": "^1.1.0",
-    "gulp-concat": "^2.5.2"
+    "html-differ": "^1.3.4",
+    "markdown": "*",
+    "markdown-it": "*",
+    "showdown": "*"
   },
   "scripts": {
     "test": "node test",

--- a/test/index.js
+++ b/test/index.js
@@ -27,11 +27,8 @@ function load(options) {
     , file
     , name
     , content
-    , regex
-    , skip
-    , glob = g2r(options.glob || "*", { extended: true })
+    , glob = g2r(options.glob || '*', { extended: true })
     , i
-    , j
     , l;
 
   list = fs
@@ -44,7 +41,7 @@ function load(options) {
   l = list.length;
 
   for (i = 0; i < l; i++) {
-    name = path.basename(list[i], ".md");
+    name = path.basename(list[i], '.md');
     if (glob.test(name)) {
       file = path.join(dir, list[i]);
       content = fm(fs.readFileSync(file, 'utf8'));
@@ -89,12 +86,12 @@ function load(options) {
 function runTests(engine, options) {
   if (typeof engine !== 'function') {
     options = engine;
-    engine = null;
+    engine = marked;
   }
 
-  var engine = engine || marked
-    , options = options || {}
-    , HtmlDiffer = require('html-differ').HtmlDiffer
+  options = options || {};
+
+  var HtmlDiffer = require('html-differ').HtmlDiffer
     , htmlDiffer = new HtmlDiffer()
     , diffLogger = require('html-differ/lib/logger')
     , files = options.files || load(options)
@@ -109,15 +106,12 @@ function runTests(engine, options) {
     , opts
     , text
     , html
-    , j
-    , l
     , diff;
 
   if (options.marked) {
     marked.setOptions(options.marked);
   }
 
-main:
   for (; i < len; i++) {
     filename = keys[i];
     file = files[filename];
@@ -162,7 +156,7 @@ main:
     }
   }
 
-  console.log('%d/%d tests completed successfully.', complete, len);
+  console.log('\n%d/%d tests completed successfully.', complete, len);
   if (failed) console.log('%d/%d tests failed.', failed, len);
 
   return !failed;
@@ -197,8 +191,8 @@ function bench(name, files, func) {
  */
 
 function runBench(options) {
-  var options = options || {}
-    , files = load(options);
+  options = options || {}
+  var files = load(options);
 
   // Non-GFM, Non-pedantic
   marked.setOptions({
@@ -319,9 +313,7 @@ function fix() {
   ['compiled_tests', 'original', 'new'].forEach(function(dir) {
     try {
       fs.mkdirSync(path.resolve(__dirname, dir), 0o755);
-    } catch (e) {
-      ;
-    }
+    } catch (e) { }
   });
 
   // rm -rf tests
@@ -346,8 +338,8 @@ function fix() {
   fs.readdirSync(dir).filter(function(file) {
     return path.extname(file) === '.html';
   }).forEach(function(file) {
-    var file = path.join(dir, file)
-      , html = fs.readFileSync(file, 'utf8');
+    file = path.join(dir, file);
+    var html = fs.readFileSync(file, 'utf8');
 
     // fix unencoded quotes
     html = html
@@ -407,9 +399,9 @@ function fix() {
  */
 
 function parseArg(argv) {
-  var argv = process.argv.slice(2)
-    , options = {}
-    , opt = ""
+  argv = process.argv.slice(2)
+  var options = {}
+    , opt = ''
     , orphans = []
     , arg;
 

--- a/test/new/main.html
+++ b/test/new/main.html
@@ -1,4 +1,17 @@
-<h1 id="a-heading">A heading</h1> <p>Just a note, I&#39;ve found that I can&#39;t test my markdown parser vs others. For example, both markdown.js and showdown code blocks in lists wrong. They&#39;re  also completely <a href="http://google.com/" title="Google">inconsistent</a> with regards to paragraphs in list items.</p> <p>A link. Not anymore.</p> <aside>This will make me fail the test because
-markdown.js doesnt acknowledge arbitrary html blocks =/</aside> <ul><li><p>List Item 1</p></li><li><p>List Item 2 </p><ul><li>New List Item 1 Hi, this is a list item.</li><li>New List Item 2 Another item <pre><code>Code goes here.
-Lots of it...</code></pre></li><li>New List Item 3 The last item</li></ul></li><li><p>List Item 3 The final item.</p></li><li><p>List Item 4 The real final item.</p></li></ul> <p>Paragraph.</p> <blockquote><ul><li>bq Item 1</li><li>bq Item 2 <ul><li>New bq Item 1</li><li>New bq Item 2 Text here</li></ul></li></ul></blockquote> <hr> <blockquote><p> Another blockquote!  I really need to get  more creative with  mockup text..  markdown.js breaks here again</p></blockquote> <h2 id="another-heading">Another Heading</h2> <p>Hello <em>world</em>. Here is a <a href="//hello">link</a>. And an image <img src="src" alt="alt">.</p> <pre><code>Code goes here.
+<h1 id="a-heading">A heading</h1> <p>Just a note, I&#39;ve found that I can&#39;t test my markdown parser vs others.
+For example, both markdown.js and showdown code blocks in lists wrong. They&#39;re
+also completely <a href="http://google.com/" title="Google">inconsistent</a> with regards to paragraphs in list items.</p> <p>A link. Not anymore.</p> <aside>This will make me fail the test because
+markdown.js doesnt acknowledge arbitrary html blocks =/</aside> <ul><li><p>List Item 1</p></li><li><p>List Item 2 </p><ul><li>New List Item 1
+Hi, this is a list item.</li><li>New List Item 2
+Another item <pre><code>Code goes here.
+Lots of it...</code></pre></li><li>New List Item 3
+The last item</li></ul></li><li><p>List Item 3
+The final item.</p></li><li><p>List Item 4
+The real final item.</p></li></ul> <p>Paragraph.</p> <blockquote><ul><li>bq Item 1</li><li>bq Item 2 <ul><li>New bq Item 1</li><li>New bq Item 2
+Text here</li></ul></li></ul></blockquote> <hr> <blockquote><p> Another blockquote!
+I really need to get
+more creative with
+mockup text..
+markdown.js breaks here again</p></blockquote> <h2 id="another-heading">Another Heading</h2> <p>Hello <em>world</em>. Here is a <a href="//hello">link</a>.
+And an image <img src="src" alt="alt">.</p> <pre><code>Code goes here.
 Lots of it...</code></pre>

--- a/test/new/uppercase_hex.html
+++ b/test/new/uppercase_hex.html
@@ -1,2 +1,2 @@
-<p>lowerclickmelower
-upperclickmeupper</p>
+<p>lowerclick melower
+upperclick meupper</p>


### PR DESCRIPTION
I never liked the strategy of [stripping all whitespace][strip] before comparing generated html code against the expected one. Taking into account whitespace when testing is important as it is often meaningful and leads to different results in the browser. For example, #1013 and #1011 fix issues that consist in different whitespace in the output, so even if tests are added they are not checked.

So, I thought we needed a more html-aware comparison algorithm that takes (meaningful) space into account. [html-differ] seemed to do the trick. It uses [parse5] under the hood, which looks stable enough.

Also, the current text comparison algorithm is broken: whenever the expected html is shorter than the generated one, and matches everything up until its end, the test is marked as complete, even though `marked` outputted something more.

For more details about the proposed comparison algorithm, head over [here][comparison algorithm]. As an option, html-differ allows to ignore whitespace differences, html comments, and certain node attributes. I was thinking about taking advantage of this last feature to ignore headings' `id` attribute. Currently, header tags that do not have an `id` are "fixed" by the preprocessing phase of the test system, and `id`s are [inserted] into the expected html code automatically. This allows to test headings' `id`s when necessary, by specifying them in the `.html` file of the test case. (I used this in #456)

As an added benefit, when tests fail, we get a nice colored diff between the expected and the actual output, _with_ space included, which wasn't before. As an example:

![screenshot from 2018-01-18 01-39-26](https://user-images.githubusercontent.com/1869444/35075386-1472d174-fbf3-11e7-997e-858fcd6ced9f.png)

I took the opportunity to _lint_ the `test/index.js` source file and remove unused variables and so on.

Since html-differ treats space and newlines differently (I'm not sure this is in accordance to Html/CSS specs, see my inquiry at bem/html-differ#150), in order to make the `main` test case pass, I had to replace some simple spaces with newlines, when newlines were to be expected.
The `uppercase_hex` test case was plain wrong as it lacked some space which should have been there but was not required by the current comparison algorithm.

As addendum, I myself am not enthusiastic about **yet another npm package dependency** pulled in at startup. Including parse5 and a bunch of other packages for mere testing may seem overkilling. But the fact is that testing is the most important development phase of `marked`, especially if our goal is to adhere to commonmark as much as possible (their current [test suite] includes 624 test cases) and I think it needs to be done correctly. Comparing two _different_ html codes and determining if they are _equivalent_ is no easy task. It involves parsing html and checking the AST according to some very verbose specification that we cannot take care of all by ourselves.
Stripping all whitespace was a quick&easy solution to allow _some_ testing, now's the time to step away from it.

/cc to @UziTech who was the kind author of the recent upgrade to the test system and may know it very well.

[strip]: https://github.com/chjj/marked/blob/7b6e2ef53d4e7770ed989245e488d23a35a16cd1/test/index.js#L141
[html-differ]: https://github.com/bem/html-differ
[parse5]: https://github.com/inikulin/parse5
[comparison algorithm]: https://github.com/bem/html-differ#the-comparison-algorithm
[inserted]: https://github.com/chjj/marked/blob/7b6e2ef53d4e7770ed989245e488d23a35a16cd1/test/index.js#L380
[test suite]: http://spec.commonmark.org/0.28/spec.json