### PR TITLE
Fix GitHub language via override

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+test/* linguist-vendored
+


### PR DESCRIPTION
GitHub shows marked as HTML when in fact, it is a JS project.
This adds an [override](https://github.com/github/linguist#overrides) so the test folder is ignored when detecting the primary language because that is where all the html lives.

### Before

![before](https://user-images.githubusercontent.com/229881/36268394-5adcb636-1244-11e8-9ee4-01d37081cf90.png)


### After

![after](https://user-images.githubusercontent.com/229881/36268381-4feb967a-1244-11e8-89d0-212143871ae8.png)
