### PR TITLE
Update package.json to new GitHub repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "main": "./lib/marked.js",
   "bin": "./bin/marked",
   "man": "./man/marked.1",
-  "repository": "git://github.com/chjj/marked.git",
-  "homepage": "https://github.com/chjj/marked",
+  "repository": "git://github.com/markedjs/marked.git",
+  "homepage": "https://github.com/markedjs/marked",
   "bugs": {
-    "url": "http://github.com/chjj/marked/issues"
+    "url": "http://github.com/markedjs/marked/issues"
   },
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
We recently moved the github repo from `chjj` to the `markedjs` org.
This fixes the npm `package.json` to point to the new URL.