### PR TITLE
Publish sequence update

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,9 +13,9 @@
 - [ ] All tests pass (CI should take care of this, once in place).
 - [ ] All lint checks pass (CI should take care of this, once in place).
 - Tests 
-  - [ ] Test(s) exist to ensure functionaly works (if no new tests added, list which tests cover this funcitonality).
+  - [ ] Test(s) exist to ensure functionality works (if no new tests added, list which tests cover this functionality).
   - [ ] No tests required for this PR.
-- If release:
+- [ ] Is release:
   - [ ] Version in `package.json` has been updated (see [RELEASE.md](RELEASE.md)).
   - [ ] The `marked.min.js` has been updated; or,
   - [ ] release does not change library.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## Description
+
+<!-- describe what the PR does -->
+
+- Fixes ####
+- Fixes list issues fixed by this PR
+- Fixes will automatically close them once merged
+
+## Review
+
+### Submitter
+
+- [ ] All tests pass (CI should take care of this, once in place).
+- [ ] All lint checks pass (CI should take care of this, once in place).
+- Tests 
+  - [ ] Test(s) exist to ensure functionaly works (if no new tests added, list which tests cover this funcitonality).
+  - [ ] No tests required for this PR.
+- If release:
+  - [ ] Version in `package.json` has been updated (see [RELEASE.md](RELEASE.md)).
+  - [ ] The `marked.min.js` has been updated; or,
+  - [ ] release does not change library.
+
+### Reviewer
+
+??

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,6 +18,8 @@ We follow [semantic versioning](https://semver.org) where the following sequence
   - `$ npm version [major|minor|patch]` (updates `package.json` and creates `min` file)
   - `$ npm publish` (publish to NPM)
 - [ ] Commit changes locally -> Submit PR to `origin/master` -> Merge PR
+  - `package.json` should, at minimum, have an updated version number.
+  - If the release contains changes to the library (most likely) you should also see a new `marked.min.js` file.
 - [ ] Navigate to the "Releases" tab on the project main page -> "Draft new release"
   - Add version number matching the one in the `package.json` file after publishing the release
   - Make sure `master` is the branch from which the release will be made

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,7 +17,7 @@ We follow [semantic versioning](https://semver.org) where the following sequence
   - `$ npm test` (run tests)
   - `$ npm version [major|minor|patch]` (updates `package.json` and creates `min` file)
   - `$ npm publish` (publish to NPM)
-- [ ] Commit changes locally -> Submit PR to `origina/master` -> Merge PR
+- [ ] Commit changes locally -> Submit PR to `origin/master` -> Merge PR
 - [ ] Navigate to the "Releases" tab on the project main page -> "Draft new release"
   - Add version number matching the one in the `package.json` file after publishing the release
   - Make sure `master` is the branch from which the release will be made

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,31 @@
+# Releasing Marked
+
+## Versioning
+
+We follow [semantic versioning](https://semver.org) where the following sequence is true `[major].[minor].[patch]` (further, while in beta you may see something like this `0.[major|minor].[minor|patch]`). Therefore, consider the following implications of the relase you are preparing:
+
+1. **Major:** There is at least one change that has been made which is not deemed as backward compatible. While in beta, the major will remain at zero; thereby, alterting consumers to the potentially volatile nature of the package.
+2. **Minor:** There is at least one new feature added to the release. While in beta, the minor will tend be more analagous to a `major` release. For example, we plan to release `0.4.0` once we have fixed most, if not all, known issues related to the CommonMark and GFM specifications because the architecture changes planned during `0.4.0` will most likely introduce breaking changes.
+3. **Patch:** No breaking changes. Should fix a defect found in a feature. While in beta, the patch will tend to be more analagous to a `minor` release.
+
+## Release process
+
+**Master is always shippable:** We try to merge PRs in such a way that `master` is the only branch to really be concerned about *and* `master` can always be released. This allows smoother flow between new fetures, bug fixes, and so on. (Almost a continuous deployment setup, without automation.)
+
+**Version naming:** relatively standard [major].[minor].[patch] where `major` releases represent known breaking changes to the previous release, `minor` represent additions of new funcitonality without breaking changes, and `patch` releases represent changes meant to fix previously released functionality with no new functionality. Note: When the major is a zero, it means the library is still in a beta state wherein the `major` does not get updated; therefore, `minor` releases may introduce breaking changes, and `patch` releases may contain new features.
+
+### Release process
+
+- [ ] Fork `markedjs/marked` -> clone the library locally
+- [ ] Make sure you are on the `master` branch
+- [ ] Create release branch from `master` (`release-##.##.##`)
+- [ ] Run tests using NPM command: `$ npm test`
+- [ ] Run NPM command to update `package.json` version: `$ npm version [major|minor|patch]` (updates `package.json` and creates `min` file)
+- [ ] Publish pack to NPM: `$ npm publish`
+- [ ] Commit changes locally -> Submit PR to `origina/master`
+- [ ] Merge PR (only time where submitter should be "allowed" to merge his or her own)
+- [ ] Navigate to the "Releases" tab on the project main page -> "Draft new release"
+  - Add version number matching the one in the `package.json` file after publishing the release
+  - Make sure `master` is the branch from which the release will be made
+  - Add notes regarding what users should expect from the release
+  - Click "Publish release"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,9 +18,9 @@ We follow [semantic versioning](https://semver.org) where the following sequence
 
 - [ ] Fork `markedjs/marked` -> clone the library locally -> Make sure you are on the `master` branch
 - [ ] Create release branch from `master` (`release-##.##.##`)
-- [ ] `$ npm test` (run tests)
-- [ ] `$ npm version [major|minor|patch]` (updates `package.json` and creates `min` file)
-- [ ] `$ npm publish` (publish to NPM)
+  - `$ npm test` (run tests)
+  - `$ npm version [major|minor|patch]` (updates `package.json` and creates `min` file)
+  - `$ npm publish` (publish to NPM)
 - [ ] Commit changes locally -> Submit PR to `origina/master` -> Merge PR
 - [ ] Navigate to the "Releases" tab on the project main page -> "Draft new release"
   - Add version number matching the one in the `package.json` file after publishing the release

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,7 @@
 # Releasing Marked
 
+**Master is always shippable:** We try to merge PRs in such a way that `master` is the only branch to really be concerned about *and* `master` can always be released. This allows smoother flow between new fetures, bug fixes, and so on. (Almost a continuous deployment setup, without automation.)
+
 ## Versioning
 
 We follow [semantic versioning](https://semver.org) where the following sequence is true `[major].[minor].[patch]` (further, while in beta you may see something like this `0.[major|minor].[minor|patch]`). Therefore, consider the following implications of the relase you are preparing:
@@ -9,12 +11,6 @@ We follow [semantic versioning](https://semver.org) where the following sequence
 3. **Patch:** No breaking changes. Should fix a defect found in a feature. While in beta, the patch will tend to be more analagous to a `minor` release.
 
 ## Release process
-
-**Master is always shippable:** We try to merge PRs in such a way that `master` is the only branch to really be concerned about *and* `master` can always be released. This allows smoother flow between new fetures, bug fixes, and so on. (Almost a continuous deployment setup, without automation.)
-
-**Version naming:** relatively standard [major].[minor].[patch] where `major` releases represent known breaking changes to the previous release, `minor` represent additions of new funcitonality without breaking changes, and `patch` releases represent changes meant to fix previously released functionality with no new functionality. Note: When the major is a zero, it means the library is still in a beta state wherein the `major` does not get updated; therefore, `minor` releases may introduce breaking changes, and `patch` releases may contain new features.
-
-### Release process
 
 - [ ] Fork `markedjs/marked` -> clone the library locally -> Make sure you are on the `master` branch
 - [ ] Create release branch from `master` (`release-##.##.##`)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,14 +16,12 @@ We follow [semantic versioning](https://semver.org) where the following sequence
 
 ### Release process
 
-- [ ] Fork `markedjs/marked` -> clone the library locally
-- [ ] Make sure you are on the `master` branch
+- [ ] Fork `markedjs/marked` -> clone the library locally -> Make sure you are on the `master` branch
 - [ ] Create release branch from `master` (`release-##.##.##`)
-- [ ] Run tests using NPM command: `$ npm test`
-- [ ] Run NPM command to update `package.json` version: `$ npm version [major|minor|patch]` (updates `package.json` and creates `min` file)
-- [ ] Publish pack to NPM: `$ npm publish`
-- [ ] Commit changes locally -> Submit PR to `origina/master`
-- [ ] Merge PR (only time where submitter should be "allowed" to merge his or her own)
+- [ ] `$ npm test` (run tests)
+- [ ] `$ npm version [major|minor|patch]` (updates `package.json` and creates `min` file)
+- [ ] `$ npm publish` (publish to NPM)
+- [ ] Commit changes locally -> Submit PR to `origina/master` -> Merge PR
 - [ ] Navigate to the "Releases" tab on the project main page -> "Draft new release"
   - Add version number matching the one in the `package.json` file after publishing the release
   - Make sure `master` is the branch from which the release will be made

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,10 +4,10 @@
 
 ## Versioning
 
-We follow [semantic versioning](https://semver.org) where the following sequence is true `[major].[minor].[patch]` (further, while in beta you may see something like this `0.[major|minor].[minor|patch]`). Therefore, consider the following implications of the relase you are preparing:
+We follow [semantic versioning](https://semver.org) where the following sequence is true `[major].[minor].[patch]` (further, while in beta, you may see this `0.[major|minor].[minor|patch]`); therefore, consider the following implications of the release you are preparing:
 
-1. **Major:** There is at least one change that has been made which is not deemed as backward compatible. While in beta, the major will remain at zero; thereby, alterting consumers to the potentially volatile nature of the package.
-2. **Minor:** There is at least one new feature added to the release. While in beta, the minor will tend be more analagous to a `major` release. For example, we plan to release `0.4.0` once we have fixed most, if not all, known issues related to the CommonMark and GFM specifications because the architecture changes planned during `0.4.0` will most likely introduce breaking changes.
+1. **Major:** There is at least one change not deemed backward compatible. While in beta, the major will remain at zero; thereby, alerting consumers to the potentially volatile nature of the package.
+2. **Minor:** There is at least one new feature added to the release. While in beta, the minor will tend to be more analagous to a `major` release. For example, we plan to release `0.4.0` once we have fixed most, if not all, known issues related to the CommonMark and GFM specifications because the architecture changes planned during `0.4.0` will most likely introduce breaking changes.
 3. **Patch:** No breaking changes. Should fix a defect found in a feature. While in beta, the patch will tend to be more analagous to a `minor` release.
 
 ## Release process

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "scripts": {
     "test": "node test",
     "bench": "node test --bench",
-    "build": "uglifyjs lib/marked.js -cm  --comments /Copyright/ -o marked.min.js"
+    "build": "uglifyjs lib/marked.js -cm  --comments /Copyright/ -o marked.min.js",
+    "preversion": "npm run build"
   }
 }


### PR DESCRIPTION
## Description

1. Decided to go with `preversion` instead of anything related t publish...version only update the `package.json` file, which needs to be committed anyway; so, thinking anything that needs to be updated and part of a commit should be able to tag along.
2. Created RELEASE.md for instructions on building a release.

This gives us a three step process when we don't include the setup things - and makes us completely within NPM commands:

1. `npm test`
2. `npm version [major|minor|patch]`
3. `npm publish`

Replaces #1064

## Review

### Submitter

- [ ] All tests pass (CI should take care of this, once in place). One known failing test.
- [ ] All lint checks pass (CI should take care of this, once in place). Not in place yet.
- Tests 
  - [ ] Test(s) exist to ensure functionality works (if no new tests added, list which tests cover this functionality).
  - [x] No tests required for this PR.
- [ ] Is release:
  - [ ] Version in `package.json` has been updated (see [RELEASE.md](RELEASE.md)).
  - [ ] The `marked.min.js` has been updated; or,
  - [ ] release does not change library.

### Reviewer

??