### PR TITLE
Simplify script’s footer

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1369,14 +1369,11 @@ marked.inlineLexer = InlineLexer.output;
 
 marked.parse = marked;
 
-if (typeof module !== 'undefined' && typeof exports === 'object') {
+if (module !== void 0 && typeof exports === 'object') {
   module.exports = marked;
 } else if (typeof define === 'function' && define.amd) {
   define(function() { return marked; });
 } else {
-  this.marked = marked;
+  (this || (window !== void 0 ? window : global)).marked = marked;
 }
-
-}).call(function() {
-  return this || (typeof window !== 'undefined' ? window : global);
-}());
+})();


### PR DESCRIPTION
1. ‘typeof foo === "undefined"’ is just a convoluted way of writing
   ‘foo === undefined’.  The slight risk of ‘undefined’ being redefined
   (since it’s not a keyword) can be easily averted by using ‘void 0’.
   In the end, ‘typeof foo === "undefined"’ becomes ‘foo === void 0’
   which is shorter and does the same thing.

2. There is really no need to use Function.prototype.call.  Since the
   wrapper function uses it’s ‘this’ variable exactly once, whatever
   function run as call argument does can be moved inside of the wrapper.

This shortens and simplifies script’s footer.