### PR TITLE
Setup .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ insert_final_newline = true
 indent_style = space
 indent_size = 2
 
-[*.md]
+[*.md, !test/*md]
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*, *.json, *.js]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+translate_tabs_to_spaces = true
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
**Marked version:** 0.3.16

**Proposal type:** project operations

## What pain point are you perceiving?

Tabs are rendered as literal tab characters, not spaces using Sublime Text 3.

Was working on #1076 and noticed the code samples were rendering funny when it came to whitespace and text wrapping. Realized it was because my editor was using literal tabs instead of spaces.

## What solution are you suggesting?

A `.editorconfig` file following similar rules as lint options...specifically, spaces not tabs.

See also http://editorconfig.org

Could be accepted before or after #1076 