### PR TITLE
test lint instead of fixing it in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script: |
     sed -i s/0o755/0755/ test/index.js;
     npm test;
   else
-    npm run lint && npm test;
+    npm run test:lint && npm test;
   fi
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "scripts": {
     "test": "node test",
+    "test:lint": "eslint lib/marked.js test/index.js",
     "bench": "node test --bench",
     "lint": "eslint --fix lib/marked.js test/index.js",
     "build": "uglifyjs lib/marked.js -cm  --comments /Copyright/ -o marked.min.js",


### PR DESCRIPTION
## Description

Tell travis-ci to check for linting errors instead of fixing them.

## Review

### Submitter

- [ ] All tests pass (CI should take care of this, once in place).
- [x] All lint checks pass (CI should take care of this, once in place).
- Tests 
  - [ ] Test(s) exist to ensure functionality works (if no new tests added, list which tests cover this functionality).
  - [x] No tests required for this PR.
- [ ] Is release:
  - [ ] Version in `package.json` has been updated (see [RELEASE.md](https://github.com/markedjs/marked/blob/master/RELEASE.md)).
  - [ ] The `marked.min.js` has been updated; or,
  - [ ] release does not change library.

### Reviewer

??