### PR TITLE
fix broken link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,4 +92,4 @@ npm run build
 
 ## Releasing
 
-Creating GitHub releases and publishing to NPM is limited to conributors and owners. If you would like more information, please see our [releasing documentation](https://github.com/markedjs/marked/blob/master/RELEASING.md).
+Creating GitHub releases and publishing to NPM is limited to conributors and owners. If you would like more information, please see our [releasing documentation](https://github.com/markedjs/marked/blob/master/RELEASE.md).


### PR DESCRIPTION
**Marked version:** 0.3.17

## Description

Link from CONTRIBUTING to RELEASE was broken. Consider renaming RELEASE to RELEASING.

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regresstion (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.
  
## Committer

In most cases, this should be a different person than the contributor.

- [x] Draft GitHub release notes have been updated.
- [x] cm_autolinks is the only failing test (remove once CI is in place and all tests pass).
- [x] All lint checks pass (remove once CI is in place).
- [x] CI is green (no forced merge required).
- [x] Merge PR