### PR TITLE
Update security section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ By supporting the above Markdown flavors, it's possible that Marked can help you
 
 The only completely secure system is the one that doesn't exist in the first place. Having said that, we take the security of Marked very seriously.
 
-Therefore, please disclose potential security issues by email to the project [committers](https://github.com/markedjs/marked/blob/master/AUTHORS.md). We will provide an initial assessment of security reports within 48 hours and should apply patches within 2 weeks (also, feel free to contribute a fix for the issue).
+Therefore, please disclose potential security issues by email to the project [committers](https://github.com/markedjs/marked/blob/master/AUTHORS.md) as well as the [listed owners within NPM](https://docs.npmjs.com/cli/owner). We will provide an initial assessment of security reports within 48 hours and should apply patches within 2 weeks (also, feel free to contribute a fix for the issue).
 
 <h2 id="contributing">Contributing</h2>
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ By supporting the above Markdown flavors, it's possible that Marked can help you
 
 <h2 id="security">Security</h2>
 
-The only completely secure system is the one that doesn't exist in the first place. Having said that, we take the security of Marked very seriously; however, none of us are necessarily security experts, so to speak. Therefore, if you find something, [say something](https://github.com/markedjs/marked/issues), or, better yet, fix the thing! :)
+The only completely secure system is the one that doesn't exist in the first place. Having said that, we take the security of Marked very seriously.
+
+Therefore, please disclose potential security issues by email to the project [committers](https://github.com/markedjs/marked/blob/master/AUTHORS.md). We will provide an initial assessment of security reports within 48 hours and should apply patches within 2 weeks (also, feel free to contribute a fix for the issue).
 
 <h2 id="contributing">Contributing</h2>
 


### PR DESCRIPTION
**Marked version:** 0.3.17

## Description

Recommendation from @davisjam via [comment](https://github.com/markedjs/marked/pull/1083#issuecomment-368924985) on #1083 seemed like a good one to me and more in keeping with standard operating procedures within the broader open source community regarding reporting and resolution of security issues (thanks for the education). Modified language to use "committers" and explicitly call out NPM owners.

Right now @chjj and I get all the security-related emails because we are the listed owners of the package in NPM. Having said that, I'm not sure there's much he and I are able to actually _do_ to resolve them (for various reasons). 

Might be nice to add emails (or something) for the committers on the AUTHORS page (see [Django](https://github.com/django/django/blob/master/AUTHORS), for example)...?? I'm all about consent checks, especially with someone's contact information.

Collaborating with someone like @davisjam becomes difficult to accomplish via the internal discussion board (unless I'm showing my ignorance again) because he is not part of the "team" according to GitHub; so, email might be an appropriate alternative.

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regresstion (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.
  
## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] cm_autolinks is the only failing test (remove once CI is in place and all tests pass).
- [ ] All lint checks pass (remove once CI is in place).
- [ ] CI is green (no forced merge required).
- [ ] Merge PR