### PR TITLE
Update release template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -2,6 +2,7 @@
 
 - [ ] `$ npm version` has been run.
 - [ ] Release notes in [draft GitHub release](https://github.com/markedjs/marked/releases) are up to date
+- [ ] Release notes include which flavors and versions of Markdown are supported by this release
 - [ ] Reviewer checklist is complete.
 - [ ] Merge PR.
 - [ ] Publish GitHub release using `master` with correct version number.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,9 +56,6 @@ Marked provides templates for submitting both pull requests and issues. When you
 
 The PR templates include checklists for both the submitter and the reviewer, which, in most cases, will not be the same person.
 
-## Submitting PRs continued
-
-
 ## Scripts
 
 When it comes to NPM commands, we try to use the native scripts provided by the NPM framework.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,10 @@ Marked provides templates for submitting both pull requests and issues. When you
 
 The PR templates include checklists for both the submitter and the reviewer, which, in most cases, will not be the same person.
 
+## Submitting PRs continued
+
+
+
 ## Scripts
 
 When it comes to NPM commands, we try to use the native scripts provided by the NPM framework.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,6 @@ The PR templates include checklists for both the submitter and the reviewer, whi
 ## Submitting PRs continued
 
 
-
 ## Scripts
 
 When it comes to NPM commands, we try to use the native scripts provided by the NPM framework.


### PR DESCRIPTION
**Marked version:** 0.3.17

## Description

See [comment](https://github.com/markedjs/marked/issues/1097#issuecomment-369282046) from @intcreator for context.

> Perhaps we can make clear which version of the spec each version of Marked adheres to so if people want compatibility available in a certain version of the spec they can use the corresponding version of Marked? Potentially even syncing Marked versioning to the spec in some way?

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regresstion (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.
  
## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] cm_autolinks is the only failing test (remove once CI is in place and all tests pass).
- [ ] All lint checks pass (remove once CI is in place).
- [ ] CI is green (no forced merge required).
- [ ] Merge PR