### PR TITLE
Update authors

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,8 @@
 
 <!--
 
+	I no issue exists that you're aware of. The maintainers should be able to figure out if it's a duplicate.
+
 ## Expectation
 
 Describe the output you are expecting from marked

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,9 @@
 
 	If release PR, add ?template=release.md to the PR url to use the release PR template.
 
-	Otherwise, you are stating the this PR fixes an issue that has been submitted; or,
+	If related to badging, add ?template=badges.md to the PR url to use the badges PR template.
+
+	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
 	describes the issue or proposal under considersation.
 
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.
 
 	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
-	describes the issue or proposal under considersation.
+	describes the issue or proposal under considersation and contains the project-related code to implement.
 
 -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 
 	If release PR, add ?template=release.md to the PR url to use the release PR template.
 
-	If related to badging, add ?template=badges.md to the PR url to use the badges PR template.
+	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.
 
 	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
 	describes the issue or proposal under considersation.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,7 @@
 
 <!--
 
-	I no issue exists that you're aware of. The maintainers should be able to figure out if it's a duplicate.
+	If no issue exists that you're aware of. The maintainers should be able to figure out if it's a duplicate.
 
 ## Expectation
 

--- a/.github/PULL_REQUEST_TEMPLATE/badges.md
+++ b/.github/PULL_REQUEST_TEMPLATE/badges.md
@@ -1,0 +1,37 @@
+**@mention the contributor:**
+
+This is a recommendation to:
+
+- [ ] Add a badge
+- [ ] Remove a badge
+
+<!-- 
+
+	Explain your reasoning behind tagging that person. 
+
+	Preferably by citing objective examples, like PRs, Issues, and so on.
+
+-->
+
+If you're the one mentioned in this PR:
+
+- [ ] Submit a comment on whether you will accept the badge or not; or,
+- [ ] whether you will or will not dispute the recommendation to remove.
+
+<!--
+
+	Why would someone not accept a badge? Loads of reasons depending on the circumstances.
+
+	1. If you're a committer and someone puts a badge for you on having decision making authority in an area, do you really a) think you earned it and b) think you can do that *and* all the other stuff you got going as a committer, admin, or publisher? Maybe not. And that's okay. Thank them for the recognition, explain you aren't able to take more on at the moment. It's cool to get recognized though.
+	2. Maybe you don't feel you actually earned it yet. I remember being in an interview once. The interviewer asked me to give an example of going above and beyond the call of duty. I said, "That's hard. Because what you consider going above and beyond may be what I consider to be 'just rising to'. If we're in battle and you get wounded and I pull you out of the frey before heading back into it, I don't consider that going above and beyond; I consider that rising to."
+
+	Why would someone remove their own badge? Loads of reasons...
+
+	1. Maybe you got a lot going on right now and want to broadcast to the Marked community that, "Hey, I don't want to say I'm going to do this unless I can really commit to it right now in a way that serves the project well." That's awesome! That takes courage! Because a) saying no is hard for most humans ("people pleasers") and b) the alternative, well, for those of us here since about October of 2017 (and prior), we know what the alternative can look like.
+	2. Maybe you just think you've done all can to help and learned all you can from the experience. Again, very awesome and courageous. It takes courage to know when to walk away on your own accord.
+
+	Anyway, you get the idea. This isn't about good or bad...it's just about giving the community a simple game mechanic by which to publicly say, "Thank you" or "Here's what my status is" in the community or "Hey, I think something's wrong here" in a civil manner.
+
+-->
+
+Note: All committers must approve via review before mergining.

--- a/.github/PULL_REQUEST_TEMPLATE/badges.md
+++ b/.github/PULL_REQUEST_TEMPLATE/badges.md
@@ -32,6 +32,12 @@ If you're the one mentioned in this PR:
 
 	Anyway, you get the idea. This isn't about good or bad...it's just about giving the community a simple game mechanic by which to publicly say, "Thank you" or "Here's what my status is" in the community or "Hey, I think something's wrong here" in a civil manner.
 
+	Why would you want to remove someone's badge? Loads of reasons...
+
+	1. Maybe they have decision making authority on something. You asked for their advice. And, you ended up waiting almost a month before receiving a response.
+	2. Maybe it was relevant at the time (Master of Marked) but you think they've lost their former level of skill (fell out of practice, for example). They could always get it back.
+	3. Maybe to signal to them that, "Hey, you seem to have forgotten about us. Are you still around (or alive)?"
+
 -->
 
 Note: All committers must approve via review before mergining.

--- a/.github/PULL_REQUEST_TEMPLATE/badges.md
+++ b/.github/PULL_REQUEST_TEMPLATE/badges.md
@@ -15,29 +15,31 @@ This is a recommendation to:
 
 If you're the one mentioned in this PR:
 
-- [ ] Submit a comment on whether you will accept the badge or not; or,
-- [ ] whether you will or will not dispute the recommendation to remove.
+- [ ] whether you will accept the badge or not; or,
+- [ ] whether you will or will not dispute the recommendation to remove
+
+within 30 days (silence is consent at this point, can't have the pull requests page filled with PRs related to badges forever).
 
 <!--
 
 	Why would someone not accept a badge? Loads of reasons depending on the circumstances.
 
-	1. If you're a committer and someone puts a badge for you on having decision making authority in an area, do you really a) think you earned it and b) think you can do that *and* all the other stuff you got going as a committer, admin, or publisher? Maybe not. And that's okay. Thank them for the recognition, explain you aren't able to take more on at the moment. It's cool to get recognized though.
+	1. If you're a committer and someone puts a badge for you on having decision making authority in an area, do you really a) think you earned it and b) think you can do that *and* all the other stuff you got going as a committer, admin, or publisher (not to even mention your outside life)? Maybe not. And that's okay. Thank them for the recognition, explain you aren't able to take more on at the moment. It's cool to get recognized though.
 	2. Maybe you don't feel you actually earned it yet. I remember being in an interview once. The interviewer asked me to give an example of going above and beyond the call of duty. I said, "That's hard. Because what you consider going above and beyond may be what I consider to be 'just rising to'. If we're in battle and you get wounded and I pull you out of the frey before heading back into it, I don't consider that going above and beyond; I consider that rising to."
 
 	Why would someone remove their own badge? Loads of reasons...
 
-	1. Maybe you got a lot going on right now and want to broadcast to the Marked community that, "Hey, I don't want to say I'm going to do this unless I can really commit to it right now in a way that serves the project well." That's awesome! That takes courage! Because a) saying no is hard for most humans ("people pleasers") and b) the alternative, well, for those of us here since about October of 2017 (and prior), we know what the alternative can look like.
-	2. Maybe you just think you've done all can to help and learned all you can from the experience. Again, very awesome and courageous. It takes courage to know when to walk away on your own accord.
-
-	Anyway, you get the idea. This isn't about good or bad...it's just about giving the community a simple game mechanic by which to publicly say, "Thank you" or "Here's what my status is" in the community or "Hey, I think something's wrong here" in a civil manner.
+	1. Maybe you got a lot going on right now and want to broadcast to the Marked community that, "Hey, I don't want to say I'm going to do this unless I can really commit to it right now in a way that serves the project well." That's awesome! That takes courage! Because a) saying "no" is hard for most humans ("people pleasers") and b) the alternative, well, for those of us here since about October of 2017 (and prior), we know what the alternative can look like.
+	2. Maybe you just think you've done all you can to help and learned all you can from the experience. Again, very awesome and courageous. It takes courage to know when to walk away on your own accord.
 
 	Why would you want to remove someone's badge? Loads of reasons...
 
 	1. Maybe they have decision making authority on something. You asked for their advice. And, you ended up waiting almost a month before receiving a response.
-	2. Maybe it was relevant at the time (Master of Marked) but you think they've lost their former level of skill (fell out of practice, for example). They could always get it back.
+	2. Maybe it was relevant at the time (Master of Marked, for example) but you think they've lost their former level of skill (fell out of practice, for example). They could always get it back.
 	3. Maybe to signal to them that, "Hey, you seem to have forgotten about us. Are you still around (or alive)?"
+
+	Anyway, you get the idea. This isn't about good or bad...it's just about giving the community a simple game mechanic by which to publicly say, "Thank you" or "Here's what my status is" in the community or "Hey, I think something's wrong here" in a civil manner.
 
 -->
 
-Note: All committers must approve via review before mergining.
+Note: All committers must approve via review before merging, the disapproving committer can simply close the PR.

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -102,7 +102,7 @@ Badges at play:
 	<dt>GitHub Guru</dt>
 	<dd>Someone who always seems to be able to tell you easier ways to do things with GitHub.</dd>
 	<dt>Humaning Helper</dt>
-	<dd>Someone who goes out of their way to help contributors feel welcomed and valued. Further, someone who take the extra steps(s) necessary to help new contributors get up to speped. Finally, they maintain composure even in times of disagreement and dispute settlement.</dd>
+	<dd>Someone who goes out of their way to help contributors feel welcomed and valued. Further, someone who takes the extra steps(s) necessary to help new contributors get up to speed. Finally, they maintain composure even in times of disagreement and dispute resolution.</dd>
 	<dt>Heckler of Hypertext</dt>
 	<dd>Someone who demonstrates an esoteric level of knowledge when it comes to HTML. In other words, someone who says things like, "Did you know most Markdown flavors don't have a way to render a description list (`dl`)? All the more reason Markdown `!==` HTML."</dd>
 	<dt>Markdown Maestro</dt>

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -75,7 +75,9 @@ Christopher Jeffrey @chjj
 
 <h2 id="badges">Badges</h2>
 
-Badges? You don't *need* no stinkin' badges. Movie references aside. (It was either that or, "Let's play a game", but that would have been creepy&hellip;that's why it will most likely come later.)
+Badges? You don't *need* no stinkin' badges. 
+
+Movie references aside. (It was either that or, "Let's play a game", but that would have been creepy&hellip;that's why it will most likely come later.)
 
 If you *want* 'em, we got 'em, and here's how you get 'em (and&hellip;dramatic paus&hellip;why not two?&hellip; how they can be taken away).
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -108,7 +108,7 @@ Badges at play:
 	<dt>Markdown Maestro</dt>
 	<dd>You know that person who knows about way too many different flavors of Markdown? The one who maybe seems a little too obsessed with the possibilities of Markdown beyond HTML? Come on. You know who they are. Or, at least you could, if you give them this badge.</dd>
 	<dt>Master of Marked</dt>
-	<dd>Someone who demonstrates knows the ins and outs of the codebase for Marked.</dd>
+	<dd>Someone who demonstrates they know the ins and outs of the codebase for Marked.</dd>
 	<dt>Open source, of course</dt>
 	<dd>Someone who advocates for and has a proven understanding of how to operate within open source communities.</dd>
 	<dt>Regent of the Regex</dt>

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -83,7 +83,7 @@ If you *want* 'em, we got 'em, and here's how you get 'em (and&hellip;dramatic p
 
 - [ ] Add the appropriate badge to the desired contributor in the desired column, even if they're not listed here yet.
 - [ ] Submit a PR (we're big on PRs around here, if you haven't noticed, help us help you).
-- [ ] Follow the instructions for submitting a badge PR. (There are more details to find within. Come on. Everybody likes surprise right? Actually, we just try to put documentation where it belongs, closer to the code and part of the sequence of events.)
+- [ ] Follow the instructions for submitting a badge PR. (There are more details to find within. Come on. Everybody likes surprises, right? No? Actually, we just try to put documentation where it belongs, closer to the code and part of the sequence of events.)
 
 Badges at play:
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -81,9 +81,9 @@ Movie references aside. (It was either that or, "Let's play a game", but that wo
 
 If you *want* 'em, we got 'em, and here's how you get 'em (and&hellip;dramatic pause&hellip;why not two dramatic pauses for emphasis?&hellip; how they can be taken away).
 
-1. [ ] Add the appropriate badge to the desired contributor in the desired column, even if they're not listed here yet.
-2. [ ] Submit a PR (we're big on PRs around here, if you haven't noticed, help us help you).
-3. [ ] Follow the instructions for submitting a badge PR. (There are more details to find within. Come on. Everybody likes surprise right? Actually, we just try to put documentation where it belongs, closer to the code and part of the sequence of events.)
+- [ ] Add the appropriate badge to the desired contributor in the desired column, even if they're not listed here yet.
+- [ ] Submit a PR (we're big on PRs around here, if you haven't noticed, help us help you).
+- [ ] Follow the instructions for submitting a badge PR. (There are more details to find within. Come on. Everybody likes surprise right? Actually, we just try to put documentation where it belongs, closer to the code and part of the sequence of events.)
 
 Badges at play:
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -4,7 +4,7 @@ Marked takes an encompassing approach to its community. As such, you can think o
 
 ## Users
 
-Users are anyone using Marked in some fashion.
+Users are anyone using Marked in some fashion, without them, there's no reason for us to exist.
 
 To be listed: please let us know or submit a PR.
 
@@ -14,12 +14,12 @@ To be removed: please let us know or submit a PR.
 
 Contributors are users who submit a [PR](https://github.com/markedjs/marked/pulls), [Issue](https://github.com/markedjs/marked/issues), or collaborate in making Marked a better product and experience for all the users.
 
-|Name                |GitHub handle    |Title and knowledge                                                   |
-|:-------------------|:----------------|:---------------------------------------------------------------------|
-|Karen Yavine        |@karenyavine     |Snyk's Security Saint (helps keep us out of the security penalty box) |
-|Federico Soave      |@Feder1co5oave   |Regent of the Regex, Master of Marked (demonstrates extreme knowledge in how Marked works) |
-|Brandon der Blätter |@intcreator      |Curious Contributor (new contributor asking questions and suggesting things resulting in positive movement) |
-|Костя Третяк        |@KostyaTretyak   |--                                                                    |
+|Name                |GitHub handle    |Badge of honor                        |
+|:-------------------|:----------------|:-------------------------------------|
+|Karen Yavine        |@karenyavine     |Snyk's Security Saint                 |
+|Federico Soave      |@Feder1co5oave   |Regent of the Regex, Master of Marked |
+|Brandon der Blätter |@intcreator      |Curious Contributor                   |
+|Костя Третяк        |@KostyaTretyak   |--                                    |
 
 To be listed: make a contribution and, if it has significant impact, the committers may be able to add you here.
 
@@ -31,12 +31,11 @@ Committers are contributors who also have the responsibility, privilege, some mi
 
 A note on "decision making authority". This is related to submitting PRs and the [advice process](http://www.reinventingorganizationswiki.com/Decision_Making). The person marked as having decision making authority over a certain area should be sought for advice in that area before committing to a course of action.
 
-|Name           |GiHub handle   |Area(s) of decision making authority and knowledge                       |
-|:--------------|:--------------|:------------------------------------------------------------------------|
-|Tony Brix      |@UziTech       |Titan of the test harness and Dr. DevOps                                 |
-|Steven         |@styfle        |Open source, of course and GitHub Guru                                   |
-|Jamie Davis    |@davisjam      |Seeker of Security                                                       |
-|??             |??             |Eye for the CLI, Markdown Maestro, Regent of the Regex, Master of Marked |
+|Name           |GiHub handle   |Decision making                          |Badges of honor (tag for questions) |
+|:--------------|:--------------|:----------------------------------------|------------------------------------|
+|Tony Brix      |@UziTech       |Titan of the test harness and Dr. DevOps |                                    |
+|Steven         |@styfle        |Open source, of course and GitHub Guru   |                                    |
+|Jamie Davis    |@davisjam      |Seeker of Security                       |                                    |
 
 To be listed: Committers are usually selected from contributors who enter the discussions regarding the future direction of Marked (maybe even doing informal reviews of contributions despite not being able to merge them yourself).
 
@@ -56,12 +55,68 @@ Publishers are admins who also have the responsibility, privilege, and burden of
 
 (In other words, while Admins are focused primarily on the internal workings of the project, Publishers are focused on internal *and* external concerns.) 
 
-|Name       | GitHub handle |Area(s) of decision making authority and knowledge          |
-|:----------|:--------------|:-----------------------------------------------------------|
-|Josh Bruce |@joshbruce     |Humaning Helper, Heckler of Hypertext, and Release Wrangler |
+|Name       |GitHub handle  |Decision making          |Badges of honor (tag for questions)   |
+|:----------|:--------------|:------------------------|:-------------------------------------|
+|Josh Bruce |@joshbruce     |Release Wrangler         |Humaning Helper, Heckler of Hypertext |
 
 ## Original author
 
 The original author is the publisher who started it all.
 
-Christopher Jeffrey @chjj
+|Christopher Jeffrey @chjj
+
+<h2 id="badges">Badges</h2>
+
+Badges? You don't *need* no stinkin' badges. Movie references aside. (It was either that or, "Let's play a game", but that would have been creepy&hellip;that's why it will most likely come later.)
+
+If you *want* 'em, we got 'em, and here's how you get 'em (and&hellip;dramatic paus&hellip;why not two?&hellip; how they can be taken away).
+
+1. Adding the appropriate badge to the desired contributor in the desired column, even if they're not listed here yet.
+2. Submit a PR (we're big on PRs around here, if you haven't noticed, help us help you).
+3. Follow the instructions for submitting a badge PR. (There are more details to find within.)
+
+Badges at play:
+
+<dl>
+	<dt>Curious Contributor</dt>
+	<dd>A contributor with less than one year on this page who is actively engaged in submitting PRs, Issues, making recommendations, sharing thoughts&hellip;without being too annoying about it (let's be clear, submitting 100 Issues recommending the Marked Committers send everyone candy is trying for the badge, not honestly earning it).</dd>
+	<dt>Dr. DevOps</dt>
+	<dd>
+		<p>Someone who understands and contributes to improving the developer experience and flow of Marked into the world.</p> 
+		<blockquote>
+			"The main characteristic of the DevOps movement is to strongly advocate automation and monitoring at all steps of software construction, from integration, testing, releasing to deployment and infrastructure management. DevOps aims at shorter development cycles, increased deployment frequency, more dependable releases, in close alignment with business objectives." ~[Wikipedia](https://en.wikipedia.org/wiki/DevOps)
+		</blockquote>
+	</dd>
+	<dt>Eye for the CLI</dt>
+	<dd>At this point? Pretty much anyone who can update that `man` file to the current Marked version without regression in the CLI tool itself.</dd>
+	<dt>GitHub Guru</dt>
+	<dd>Someone who always seems to be able to tell you easier ways to do things with GitHub.</dd>
+	<dt>Humaning Helper</dt>
+	<dd>Someone who goes out of their way to help contributors feel welcomed and valued. Further, someone who take the extra steps(s) necessary to help new contributors get up to speped. Finally, they maintain composure even in times of disagreement and dispute settlement.</dd>
+	<dt>Heckler of Hypertext</dt>
+	<dd>Someone who demonstrates an esoteric level of knowledge when it comes to HTML. In other words, someone who says things like, "Did you know most Markdown flavors don't have a way to render a description list (`dl`)? All the more reason Markdown `!==` HTML."</dd>
+	<dt>Markdown Maestro</dt>
+	<dd>You know that person who knows about way too many different flavors of Markdown? The one who maybe seems a little too obsessed with the possibilities of Markdown beyond HTML? Come on. You know who they are. Or, at least you could, if you give them this badge.</dd>
+	<dt>Master of Marked</dt>
+	<dd>Someone who demonstrates knows the ins and outs of the codebase for Marked.</dd>
+	<dt>Open source, of course</dt>
+	<dd>Someone who advocates for and has a proven understanding of how to operate within open source communities.</dd>
+	<dt>Regent of the Regex</dt>
+	<dd><p>Can you demonstrate you understand the following without Google and Stackoverflow?</p>
+		<p><code>/^( *)(bull) [\s\S]+?(?:hr|def|\n{2,}(?! )(?!\1bull )\n*|\s*$)/</code></p>
+		<p>Because this author can't yet. That's who gets these.</p>
+	</dd>
+	<dt>Seeker of Security</dt>
+	<dd>Someone who has demonstrated a high degree of expertise or authority when it comes to software security.</dd>
+	<dt>Titan of the Test Harness</dt>
+	<dd>Someone who demonstrates high-levels of understanding regarding Marked's test harness.</dd>
+</dl>
+
+Special badges that come with the job:
+
+<dl>
+	<dt>Release Wrangler</dt>
+	<dd>This is a badge given to all Publishers.</dd>
+	<dt>Snyk's Security Saint</dt>
+	<dd>This is a badge given to whomever primarily reaches out from Snyk to let us know about security issues.</dd>
+</dl>

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -81,9 +81,9 @@ Movie references aside. (It was either that or, "Let's play a game", but that wo
 
 If you *want* 'em, we got 'em, and here's how you get 'em (and&hellip;dramatic pause&hellip;why not two dramatic pauses for emphasis?&hellip; how they can be taken away).
 
-- [ ] Add the appropriate badge to the desired contributor in the desired column, even if they're not listed here yet.
-- [ ] Submit a PR (we're big on PRs around here, if you haven't noticed, help us help you).
-- [ ] Follow the instructions for submitting a badge PR. (There are more details to find within. Come on. Everybody likes surprise right? Actually, we just try to put documentation where it belongs, closer to the code and part of the sequence of events.)
+1. [ ] Add the appropriate badge to the desired contributor in the desired column, even if they're not listed here yet.
+2. [ ] Submit a PR (we're big on PRs around here, if you haven't noticed, help us help you).
+3. [ ] Follow the instructions for submitting a badge PR. (There are more details to find within. Come on. Everybody likes surprise right? Actually, we just try to put documentation where it belongs, closer to the code and part of the sequence of events.)
 
 Badges at play:
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -25,6 +25,8 @@ To be listed: make a contribution and, if it has significant impact, the committ
 
 To be removed: please let us know or submit a PR.
 
+[Details on badges](#badges)
+
 ## Committers
 
 Committers are contributors who also have the responsibility, privilege, some might even say burden of being able to review and merge contributions (just usually not their own).
@@ -41,6 +43,8 @@ To be listed: Committers are usually selected from contributors who enter the di
 
 To be removed: You can remove yourself through the [GitHub UI](https://help.github.com/articles/removing-yourself-from-a-collaborator-s-repository/).
 
+[Details on badges](#badges)
+
 ## Admins
 
 Admins are committers who also have the responsibility, privilege, and burden of selecting committers and making sure the project itself runs smoothly, which includes community maintenance, governance, dispute resolution, and so on. (Letting the contributors easily enter into, and work within, the project to begin contributing, with as little friction as possible.)
@@ -48,6 +52,8 @@ Admins are committers who also have the responsibility, privilege, and burden of
 To be listed: Admins are usually selected from the pool of committers who demonstrate good understanding of the marked culture, operations, and do their best to help new contributors get up to speed on how to contribute effectively to the project.
 
 To be removed: You can remove yourself through the [GitHub UI](https://help.github.com/articles/removing-yourself-from-a-collaborator-s-repository/).
+
+[Details on badges](#badges)
 
 ## Publishers
 
@@ -59,11 +65,13 @@ Publishers are admins who also have the responsibility, privilege, and burden of
 |:----------|:--------------|:------------------------|:-------------------------------------|
 |Josh Bruce |@joshbruce     |Release Wrangler         |Humaning Helper, Heckler of Hypertext |
 
+[Details on badges](#badges)
+
 ## Original author
 
 The original author is the publisher who started it all.
 
-|Christopher Jeffrey @chjj
+Christopher Jeffrey @chjj
 
 <h2 id="badges">Badges</h2>
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -81,7 +81,7 @@ Movie references aside. (It was either that or, "Let's play a game", but that wo
 
 If you *want* 'em, we got 'em, and here's how you get 'em (and&hellip;dramatic pause&hellip;why not two dramatic pauses for emphasis?&hellip; how they can be taken away).
 
-1. Adding the appropriate badge to the desired contributor in the desired column, even if they're not listed here yet.
+1. Add the appropriate badge to the desired contributor in the desired column, even if they're not listed here yet.
 2. Submit a PR (we're big on PRs around here, if you haven't noticed, help us help you).
 3. Follow the instructions for submitting a badge PR. (There are more details to find within.)
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -81,9 +81,9 @@ Movie references aside. (It was either that or, "Let's play a game", but that wo
 
 If you *want* 'em, we got 'em, and here's how you get 'em (and&hellip;dramatic pause&hellip;why not two dramatic pauses for emphasis?&hellip; how they can be taken away).
 
-1. Add the appropriate badge to the desired contributor in the desired column, even if they're not listed here yet.
-2. Submit a PR (we're big on PRs around here, if you haven't noticed, help us help you).
-3. Follow the instructions for submitting a badge PR. (There are more details to find within.)
+- [ ] Add the appropriate badge to the desired contributor in the desired column, even if they're not listed here yet.
+- [ ] Submit a PR (we're big on PRs around here, if you haven't noticed, help us help you).
+- [ ] Follow the instructions for submitting a badge PR. (There are more details to find within. Come on. Everybody likes surprise right? Actually, we just try to put documentation where it belongs, closer to the code and part of the sequence of events.)
 
 Badges at play:
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -79,7 +79,7 @@ Badges? You don't *need* no stinkin' badges.
 
 Movie references aside. (It was either that or, "Let's play a game", but that would have been creepy&hellip;that's why it will most likely come later.)
 
-If you *want* 'em, we got 'em, and here's how you get 'em (and&hellip;dramatic paus&hellip;why not two?&hellip; how they can be taken away).
+If you *want* 'em, we got 'em, and here's how you get 'em (and&hellip;dramatic pause&hellip;why not two dramatic pauses for emphasis?&hellip; how they can be taken away).
 
 1. Adding the appropriate badge to the desired contributor in the desired column, even if they're not listed here yet.
 2. Submit a PR (we're big on PRs around here, if you haven't noticed, help us help you).

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -79,9 +79,9 @@ Badges? You don't *need* no stinkin' badges.
 
 Movie references aside. (It was either that or, "Let's play a game", but that would have been creepy&hellip;that's why it will most likely come later.)
 
-If you *want* 'em, we got 'em, and here's how you get 'em (and&hellip;dramatic pause&hellip;why not two dramatic pauses for emphasis?&hellip; how they can be taken away).
+Badges? If you *want* 'em, we got 'em, and here's how you get 'em (and&hellip;dramatic pause&hellip;why not two dramatic pauses for emphasis?&hellip; how they can be taken away).
 
-- [ ] Add the appropriate badge to the desired contributor in the desired column, even if they're not listed here yet.
+- [ ] Add the appropriate badge to the desired contributor in the desired column of this page, even if they're not listed here yet.
 - [ ] Submit a PR (we're big on PRs around here, if you haven't noticed, help us help you).
 - [ ] Follow the instructions for submitting a badge PR. (There are more details to find within. Come on. Everybody likes surprises, right? No? Actually, we just try to put documentation where it belongs, closer to the code and part of the sequence of events.)
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -94,7 +94,7 @@ Badges at play:
 	<dd>
 		<p>Someone who understands and contributes to improving the developer experience and flow of Marked into the world.</p> 
 		<blockquote>
-			"The main characteristic of the DevOps movement is to strongly advocate automation and monitoring at all steps of software construction, from integration, testing, releasing to deployment and infrastructure management. DevOps aims at shorter development cycles, increased deployment frequency, more dependable releases, in close alignment with business objectives." ~ [Wikipedia](https://en.wikipedia.org/wiki/DevOps)
+			"The main characteristic of the DevOps movement is to strongly advocate automation and monitoring at all steps of software construction, from integration, testing, releasing to deployment and infrastructure management. DevOps aims at shorter development cycles, increased deployment frequency, more dependable releases, in close alignment with business objectives." ~ <a href="https://en.wikipedia.org/wiki/DevOps">Wikipedia</a>
 		</blockquote>
 	</dd>
 	<dt>Eye for the CLI</dt>

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -57,7 +57,7 @@ To be removed: You can remove yourself through the [GitHub UI](https://help.gith
 
 ## Publishers
 
-Publishers are admins who also have the responsibility, privilege, and burden of publishing the new releases to NPMJS and performing outreach and external stakeholder communications. Further, when things go pear-shaped, they're the ones taking most of the heat. Finally, when things go well, they're the primary ones praising the contributors who made it possible.
+Publishers are admins who also have the responsibility, privilege, and burden of publishing the new releases to NPM and performing outreach and external stakeholder communications. Further, when things go pear-shaped, they're the ones taking most of the heat. Finally, when things go well, they're the primary ones praising the contributors who made it possible.
 
 (In other words, while Admins are focused primarily on the internal workings of the project, Publishers are focused on internal *and* external concerns.) 
 
@@ -94,7 +94,7 @@ Badges at play:
 	<dd>
 		<p>Someone who understands and contributes to improving the developer experience and flow of Marked into the world.</p> 
 		<blockquote>
-			"The main characteristic of the DevOps movement is to strongly advocate automation and monitoring at all steps of software construction, from integration, testing, releasing to deployment and infrastructure management. DevOps aims at shorter development cycles, increased deployment frequency, more dependable releases, in close alignment with business objectives." ~[Wikipedia](https://en.wikipedia.org/wiki/DevOps)
+			"The main characteristic of the DevOps movement is to strongly advocate automation and monitoring at all steps of software construction, from integration, testing, releasing to deployment and infrastructure management. DevOps aims at shorter development cycles, increased deployment frequency, more dependable releases, in close alignment with business objectives." ~ [Wikipedia](https://en.wikipedia.org/wiki/DevOps)
 		</blockquote>
 	</dd>
 	<dt>Eye for the CLI</dt>


### PR DESCRIPTION
**Marked version:** 0.3.17

## Description

We haven't addressed a formal governance pattern yet, having said that, since inception, Marked has been operating under something that looks like the [benevolent dictator for life](https://opensource.guide/leadership-and-governance/) model, which can work pretty well when the dictator is active and available (product owners, so to speak, must be responsive).

The project seems to have tried to move, not explicitly, toward liberal and consensus-based models. Which can also work, when all the committers are active and responsive in the reviews. (However, getting 100% consensus can cause so much pain and delay over a single word on a page...I've literally been in a meeting where we had a 45 minute debate over whether to use a word and comma in a four page document...in order to gain 100% consensus.)

Think by adding game dynamics to the AUTHORS and badges we can cover a lot of ground. Meritocracy - community driven. Those who contribute more should end up being the ones who end up with authority. And so on.

If you have questions or comments about the game dynamics or maybe something you think isn't covered, say the word. Otherwise, it's easy to change in future, but I think this covers a lot of ground.

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regresstion (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR