### PR TITLE
Marked Defibrillator Challenge (alpha)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -122,6 +122,13 @@ Badges at play:
 	<dd>Someone who demonstrates high-levels of understanding regarding Marked's test harness.</dd>
 </dl>
 
+Limited time or number badges:
+
+<dl>
+	<dt>Defibrillator</dt>
+	<dd>This badge indicates you helped us make our test suite more complete regarding the CommonMark specification.</dd>
+</dl>
+
 Special badges that come with the job:
 
 <dl>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,41 @@
+## Marked wants you!
+
+In case you haven't noticed, and judging by attendance you haven't&hellip; (Movie. Major League. No? Anyway.)
+
+In case you haven't noticed, after years of [being mostly dead](https://github.com/markedjs/marked/issues/1106) (not to be confused with stable), Marked is trying to come back to life. We're about at the "You just wiggled your finger" stage ([The Princess Bride](https://youtu.be/yokQ0_8__ts). No? Come on!)
+
+There are four of us on the core team and we have one curious contributor helping us make moves (see [AUTHORS](https://github.com/markedjs/marked/blob/master/AUTHORS.md) page).
+
+We've stirred the tanks a bit and, Houston, we have a problem. ([Apollo 13](https://youtu.be/Bti9_deF5gs). No? Where have y'all been!? Seriously, we haven't talked in a while, where have you been? Oh, right, better question, where has the *marked* community been? Again, mostly dead&hellip;)
+
+After careful analysis and consideration we have determined the marked test suite to be&hellip;ummmmm&hellip;incomplete. We run about 63 tests during our continuous integration cycle. We say we support the [CommonMark specification](http://spec.commonmark.org/0.28/). The CommonMark specification has roughly 625 testable scenarios. We're prioritizing spec comliance before going to a 1.0 release.
+
+So, yeah, that's a thing.
+
+It will take the four or five of us god only knows how long to write the tests, before even considering what to do to fix them. 
+
+That's where you come in.
+
+We're introducing **the Marked Defibrillator Challenge**.
+
+### Defib. Details
+
+Not too long ago we introduced our [AUTHORS](https://github.com/markedjs/marked/blob/master/AUTHORS.md) page. We also brought in badges to help identify who does or has done what.
+
+We're introducing a new, limited badge: Defibrilator.
+
+One of these will be given to anyone who submits a PR testing an example not already covered by other PRs or our test suite. It's pretty simple (maybe), just following [this example](https://github.com/markedjs/marked/pull/1104).
+
+1. Follow our [CONTRIBUTING](https://github.com/markedjs/marked/blob/master/CONTRIBUTING.md) guidelines.
+2. The test files must following the naming convention of cm_example_## (where `cm` indicates that it is the CommonMark Specification, `example` just means example, and the `##` should be replaced of the example number from the specification).
+3. Must include a both the Markdown and the HTML from the exammple.
+4. If the PR passes our continuous integration build, then we (and you) know that Marked can do the thing, and we can merge it in almost immediately; otherwise,
+5. if the PR fails our continuous integration build, then we (and you) know that Marked cannot do the thing, and you can either let it sit (you'll still get the badge); or, if you can fix it, great! update the PR and we'll review the solution before merging.
+
+Note: The failing PRs will take us longer to merge; so, it may take longer to get the badge and have your GitHub handle listed on the [AUTHORS](https://github.com/markedjs/marked/blob/master/AUTHORS.md) page; but those failing ones are bit more valuable to us in order to improve marked for our users.
+
+## Read me
+
 <ul>
   <li><a href="#marked">About</a></li>
   <li><a href="#install">Installation</a></li>

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ We're introducing a new, limited badge: Defibrilator.
 One of these will be given to anyone who submits a PR testing a single example not already covered by other PRs or our test suite. It's pretty simple (maybe), just follow [this example](https://github.com/markedjs/marked/pull/1104).
 
 1. Follow our [CONTRIBUTING](https://github.com/markedjs/marked/blob/master/CONTRIBUTING.md) guidelines.
-2. The test files must following the naming convention of cm_example_## (where `cm` indicates that it is the CommonMark Specification, `example` just means example, and the `##` should be replaced of the example number from the specification).
+2. The test files must follow the naming convention of cm_example_## (where `cm` indicates that it is the CommonMark Specification, `example` just means example, and the `##` should be replaced of the example number from the specification).
 3. Must include a both the Markdown and the HTML from the exammple.
 4. If the PR passes our continuous integration build, then we (and you) know that Marked can do the thing, and we can merge it in almost immediately; otherwise,
 5. if the PR fails our continuous integration build, then we (and you) know that Marked cannot do the thing, and you can either let it sit (you'll still get the badge); or, if you can fix it, great! update the PR and we'll review the solution before merging.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Not too long ago we introduced our [AUTHORS](https://github.com/markedjs/marked/
 
 We're introducing a new, limited badge: Defibrilator.
 
-One of these will be given to anyone who submits a PR testing an example not already covered by other PRs or our test suite. It's pretty simple (maybe), just following [this example](https://github.com/markedjs/marked/pull/1104).
+One of these will be given to anyone who submits a PR testing an example not already covered by other PRs or our test suite. It's pretty simple (maybe), just follow [this example](https://github.com/markedjs/marked/pull/1104).
 
 1. Follow our [CONTRIBUTING](https://github.com/markedjs/marked/blob/master/CONTRIBUTING.md) guidelines.
 2. The test files must following the naming convention of cm_example_## (where `cm` indicates that it is the CommonMark Specification, `example` just means example, and the `##` should be replaced of the example number from the specification).

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Not too long ago we introduced our [AUTHORS](https://github.com/markedjs/marked/
 
 We're introducing a new, limited badge: Defibrilator.
 
-One of these will be given to anyone who submits a PR testing an example not already covered by other PRs or our test suite. It's pretty simple (maybe), just follow [this example](https://github.com/markedjs/marked/pull/1104).
+One of these will be given to anyone who submits a PR testing a single example not already covered by other PRs or our test suite. It's pretty simple (maybe), just follow [this example](https://github.com/markedjs/marked/pull/1104).
 
 1. Follow our [CONTRIBUTING](https://github.com/markedjs/marked/blob/master/CONTRIBUTING.md) guidelines.
 2. The test files must following the naming convention of cm_example_## (where `cm` indicates that it is the CommonMark Specification, `example` just means example, and the `##` should be replaced of the example number from the specification).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ There are four of us on the core team and we have one curious contributor helpin
 
 We've stirred the tanks a bit and, Houston, we have a problem. ([Apollo 13](https://youtu.be/Bti9_deF5gs). No? Where have y'all been!? Seriously, we haven't talked in a while, where have you been? Oh, right, better question, where has the *marked* community been? Again, mostly dead&hellip;)
 
-After careful analysis and consideration we have determined the marked test suite to be&hellip;ummmmm&hellip;incomplete. We run about 63 tests during our continuous integration cycle. We say we support the [CommonMark specification](http://spec.commonmark.org/0.28/). The CommonMark specification has roughly 625 testable scenarios. We're prioritizing spec comliance before going to a 1.0 release.
+After careful analysis and consideration we have determined the marked test suite to be&hellip;ummmmm&hellip;incomplete. We run about 63 tests during our continuous integration cycle. We say we support the [CommonMark specification](http://spec.commonmark.org/0.28/). The CommonMark specification has roughly 625 testable scenarios. We're prioritizing spec compliance before going to a 1.0 release.
 
 So, yeah, that's a thing.
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ We're introducing a new, limited badge: Defibrilator.
 One of these will be given to anyone who submits a PR testing a single example not already covered by other PRs or our test suite. It's pretty simple (maybe), just follow [this example](https://github.com/markedjs/marked/pull/1104).
 
 1. Follow our [CONTRIBUTING](https://github.com/markedjs/marked/blob/master/CONTRIBUTING.md) guidelines.
-2. The test files must follow the naming convention of cm_example_## (where `cm` indicates that it is the CommonMark Specification, `example` just means example, and the `##` should be replaced of the example number from the specification).
-3. Must include a both the Markdown and the HTML from the exammple.
-4. If the PR passes our continuous integration build, then we (and you) know that Marked can do the thing, and we can merge it in almost immediately; otherwise,
+2. The test files must follow the naming convention of cm_example_## (where `cm` indicates that it is the CommonMark Specification, `example` just means example, and the `##` should be replaced by the number of the example from the specification).
+3. Must include both the Markdown and the HTML from the example.
+4. If the PR passes our continuous integration build, then we (and you) know that Marked can do the thing, and we can merge it almost immediately; otherwise,
 5. if the PR fails our continuous integration build, then we (and you) know that Marked cannot do the thing, and you can either let it sit (you'll still get the badge); or, if you can fix it, great! update the PR and we'll review the solution before merging.
 
-Note: The failing PRs will take us longer to merge; so, it may take longer to get the badge and have your GitHub handle listed on the [AUTHORS](https://github.com/markedjs/marked/blob/master/AUTHORS.md) page; but those failing ones are bit more valuable to us in order to improve marked for our users.
+Note: The failing PRs will take us longer to merge; so, it may take longer to get the badge and have your GitHub handle listed on the [AUTHORS](https://github.com/markedjs/marked/blob/master/AUTHORS.md) page; but those failing tests are a bit more valuable to us in order to improve marked for you.
 
 ## Read me
 


### PR DESCRIPTION
**Marked version:** 0.3.17

## Description

We don't actually know how many users we really have. Our contributors have kinda bailed on us. This should help us gauge interest beyond the core team in keeping marked around. We're getting some feedback (new issue submissions and whatnot), but not a lot of help, which is unsustainable.

- We know we have 3,000+ dependents - don't know how many of those are actually active projects.
- We know we get about 1M downloads a month - don't know how many sites that equates to, whether they've been updated in the last few years (I built the [US Popclock page](https://www.census.gov/popclock/) a few years ago and it is still using a now dead SVG package, Raphael)
- We know we have 2000+ forks and no real contributions back to the mainline.

But, we don't know how many individual users we have and how interested they are in marked sticking around.

## The plan

Given the possible implications (getting overrun by PRs), a rolling wave approach is proposed:

  - Start with this PR, once full consent is given from the committers + @intcreator, I will tag a few folks I think might be interested in the badge (and give them a note on why I tagged them). (Might be good if we each submitted a PR as well, you know?)
  - Committers will then tag folks *they* think would be interested in the badge and helping out.
  - We merge to update the README on GitHub (smaller audience than NPM, I think). Leave it there for at least 30 days.
  - If we still need tests to cover the spec, and we're still driven to keep marked going, we push a release to (NPM) primarily to notify our users (kind of our only real communication channel to them).

Ps. For committers, can y'all please start actually putting all merged PRs in the draft release?? I'm guilty myself, to be fair. I think it will help me (and our users) when publishing releases to know what all went into that release and modify marketing and communication language accordingly without having to step through commit and PR history. (Users also get the opportunity to opt-in to the most esoteric details of the release, if they want to.)

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regresstion (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR