### PR TITLE
ESLint ignore node_modules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,7 @@
+# /node_modules/* and /bower_components/* ignored by default
+/node_modules/*
+/bower_components/*
+
+# Ignore built files except build/index.js
+build/*
+!build/index.js


### PR DESCRIPTION
**Marked version:** 0.3.17

## Description

Our builds keep failing because of lint...??

From what I understand chatting with @UziTech, the linter is running against `node_modules` as well. 

The ESLint docs discuss an `.eslintignore` file. However, the sample has a comment that says `node_modules` is ignored by default. Confused.

This PR makes the ignore explicit but I'm not sure that will actually solve the issue and is necessary.

Leaving the "build" ignores in just for completeness with the example.

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regresstion (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR