### PR TITLE
[editorconfig]: All md files except in test use tab

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,5 +13,5 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 translate_tabs_to_spaces = true
-indent_style = space
+indent_style = tab
 indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,5 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
-translate_tabs_to_spaces = true
 indent_style = tab
 indent_size = 4


### PR DESCRIPTION
**Marked version:** 0.3.17

## Description

tl;dr: PR changes editorconfig to use tabs not spaces while still ignoring MD files in test directory.

Looking at the CommonMark specification and considering the future regarding #1104 and https://github.com/markedjs/marked/issues/1103#issuecomment-369957173 a lot of the examples use honest tabs...not spaces in Markdown...makes sense given the nature of plain text editors (this was why @davisjam's initial contributions didn't pass lint - he uses VIM, which doesn't do spaced tabs).

So, not too sure what to do here regarding ignoring that `/test` folder. Or maybe ignoring markdown files all together like Federico had mentioned in the initial PR #1082 - think I forgot to put it back into WIP status or something and we hadn't really talked more about the GH Pages thing yet.

Plus, that's why we call it software and not hardware - can be easy to change in the future, if we do it right.

Thoughts?

Tagging @intcreator as well, as it's something to consider as we move toward creating all the tests ever.

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regresstion (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR