### PR TITLE
 Add size constraints and ability to volunteer to AUTHORS

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -39,7 +39,9 @@ A note on "decision making authority". This is related to submitting PRs and the
 |Steven         |@styfle        |Open source, of course and GitHub Guru   |                                    |
 |Jamie Davis    |@davisjam      |Seeker of Security                       |                                    |
 
-To be listed: Committers are usually selected from contributors who enter the discussions regarding the future direction of Marked (maybe even doing informal reviews of contributions despite not being able to merge them yourself).
+**Should not exceed 5:** For larger PRs affecting more of the codebase and, most likely, review by more people, we try to keep this pool small and responsive and let those with decision making authority have final say without negative repercussions from the other committers.
+
+To be listed: Committers are usually selected (or they volunteer, using the same process) from contributors who enter the discussions regarding the future direction of Marked (maybe even doing informal reviews of contributions despite not being able to merge them yourself).
 
 To be removed: You can remove yourself through the [GitHub UI](https://help.github.com/articles/removing-yourself-from-a-collaborator-s-repository/).
 
@@ -49,7 +51,9 @@ To be removed: You can remove yourself through the [GitHub UI](https://help.gith
 
 Admins are committers who also have the responsibility, privilege, and burden of selecting committers and making sure the project itself runs smoothly, which includes community maintenance, governance, dispute resolution, and so on. (Letting the contributors easily enter into, and work within, the project to begin contributing, with as little friction as possible.)
 
-To be listed: Admins are usually selected from the pool of committers who demonstrate good understanding of the marked culture, operations, and do their best to help new contributors get up to speed on how to contribute effectively to the project.
+**Should not exceed 3:** When there are too many people with the ability to reolves disputes, the dispute itself can quickly turn into a dispute amongst the admins themselves; therefore, we want this group to be small enough to commit to action and large enough to not put too much burden on one person. (Should ensure faster resolution and responsiveness.)
+
+To be listed: Admins are usually selected from the pool of committers (or they volunteer, using the same process) who demonstrate good understanding of the marked culture, operations, and do their best to help new contributors get up to speed on how to contribute effectively to the project.
 
 To be removed: You can remove yourself through the [GitHub UI](https://help.github.com/articles/removing-yourself-from-a-collaborator-s-repository/).
 
@@ -59,11 +63,13 @@ To be removed: You can remove yourself through the [GitHub UI](https://help.gith
 
 Publishers are admins who also have the responsibility, privilege, and burden of publishing the new releases to NPM and performing outreach and external stakeholder communications. Further, when things go pear-shaped, they're the ones taking most of the heat. Finally, when things go well, they're the primary ones praising the contributors who made it possible.
 
-(In other words, while Admins are focused primarily on the internal workings of the project, Publishers are focused on internal *and* external concerns.) 
+(In other words, while Admins are focused primarily on the internal workings of the project, Publishers are focused on internal *and* external concerns.)
 
 |Name       |GitHub handle  |Decision making          |Badges of honor (tag for questions)   |
 |:----------|:--------------|:------------------------|:-------------------------------------|
 |Josh Bruce |@joshbruce     |Release Wrangler         |Humaning Helper, Heckler of Hypertext |
+
+**Should not exceed 2:** Having more people with the authority to publish a release can quickly turn into a consensus seeking nightmare (design by committee). Having only one is preferred (Directly Responsible Individual); however, given the nature of the project and its history, having an immediate fallback, and a potential deep fallback (Original author) is probably a good idea.
 
 [Details on badges](#badges)
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -45,6 +45,12 @@ To be listed: Committers are usually selected (or they volunteer, using the same
 
 To be removed: You can remove yourself through the [GitHub UI](https://help.github.com/articles/removing-yourself-from-a-collaborator-s-repository/).
 
+A note on volunteering:
+
+1. Please do not volunteer unless you believe you can demonstrate to your peers you can do the work required.
+2. Please do not overcommit yourself; we count on those committed to the project to be responsive. Really consider, with all you have going on, wehther you able to really commit to it.
+3. Don't let the previous frighten you away, it can always be changed later by you or your peers.
+
 [Details on badges](#badges)
 
 ## Admins


### PR DESCRIPTION
**Marked version:** 0.3.17

## Description

This PR:

- Adds limits to each contributor type size starting with committer.
- Makes explicit the concept of volunteering for a change in status to become more engaged.

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regresstion (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
