### PR TITLE
Alphebatize block

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -8,35 +8,54 @@
 'use strict';
 
 /**
- * Block-Level Grammar
+ * Markdown block-level element rules
+ *
+ * QUESTION: What is the different between heading the lheading?
+ *
+ * TODO: Make object with properties that can call functions.
  */
-
 var block = {
-  newline: /^\n+/,
-  code: /^( {4}[^\n]+\n*)+/,
-  fences: noop,
-  hr: /^ {0,3}((?:- *){3,}|(?:_ *){3,}|(?:\* *){3,})(?:\n+|$)/,
-  heading: /^ *(#{1,6}) *([^\n]+?) *#* *(?:\n+|$)/,
-  nptable: noop,
   blockquote: /^( {0,3}> ?(paragraph|[^\n]*)(?:\n|$))+/,
-  list: /^( *)(bull) [\s\S]+?(?:hr|def|\n{2,}(?! )(?!\1bull )\n*|\s*$)/,
-  html: /^ *(?:comment *(?:\n|\s*$)|closed *(?:\n{2,}|\s*$)|closing *(?:\n{2,}|\s*$))/,
+  bullet: /(?:[*+-]|\d+\.)/, 
+  code: /^( {4}[^\n]+\n*)+/,
   def: /^ {0,3}\[(label)\]: *\n? *<?([^\s>]+)>?(?:(?: +\n? *| *\n *)(title))? *(?:\n+|$)/,
-  table: noop,
+  fences: noop,
+  heading: /^ *(#{1,6}) *([^\n]+?) *#* *(?:\n+|$)/,
+  hr: /^ {0,3}((?:- *){3,}|(?:_ *){3,}|(?:\* *){3,})(?:\n+|$)/,
+  html: /^ *(?:comment *(?:\n|\s*$)|closed *(?:\n{2,}|\s*$)|closing *(?:\n{2,}|\s*$))/,
+  item: /^( *)(bull) [^\n]*(?:\n(?!\1bull )[^\n]*)*/,
   lheading: /^([^\n]+)\n *(=|-){2,} *(?:\n+|$)/,
+  label: /(?:\\[\[\]]|[^\[\]])+/,
+  list: /^( *)(bull) [\s\S]+?(?:hr|def|\n{2,}(?! )(?!\1bull )\n*|\s*$)/,
+  newline: /^\n+/,
+  nptable: noop,
   paragraph: /^([^\n]+(?:\n?(?!hr|heading|lheading| {0,3}>|tag)[^\n]+)+)/,
-  text: /^[^\n]+/
+  table: noop,
+  tag: '(?!(?:'
+    + 'a|em|strong|small|s|cite|q|dfn|abbr|data|time|code'
+    + '|var|samp|kbd|sub|sup|i|b|u|mark|ruby|rt|rp|bdi|bdo'
+    + '|span|br|wbr|ins|del|img)\\b)\\w+(?!:|[^\\w\\s@]*@)\\b',
+  text: /^[^\n]+/,
+  title: /(?:"(?:\\"|[^"]|"[^"\n]*")*"|'\n?(?:[^'\n]+\n?)*'|\([^()]*\))/
 };
 
-block._label = /(?:\\[\[\]]|[^\[\]])+/;
-block._title = /(?:"(?:\\"|[^"]|"[^"\n]*")*"|'\n?(?:[^'\n]+\n?)*'|\([^()]*\))/;
+/** 
+ * QUESTION: This seems like a bad construction. We define block.def as the result
+ *           of a function call. The edit() function takes a parameter named the same
+ *           as what we are defining. Why?
+ */
 block.def = edit(block.def)
-  .replace('label', block._label)
-  .replace('title', block._title)
+  .replace('label', block.label)
+  .replace('title', block.title)
   .getRegex();
 
-block.bullet = /(?:[*+-]|\d+\.)/;
-block.item = /^( *)(bull) [^\n]*(?:\n(?!\1bull )[^\n]*)*/;
+block.html = edit(block.html)
+  .replace('comment', /<!--[\s\S]*?-->/)
+  .replace('closed', /<(tag)[\s\S]+?<\/\1>/)
+  .replace('closing', /<tag(?:"[^"]*"|'[^']*'|\s[^'"\/>\s]*)*?\/?>/)
+  .replace(/tag/g, block.tag)
+  .getRegex();
+
 block.item = edit(block.item, 'gm')
   .replace(/bull/g, block.bullet)
   .getRegex();
@@ -47,39 +66,32 @@ block.list = edit(block.list)
   .replace('def', '\\n+(?=' + block.def.source + ')')
   .getRegex();
 
-block._tag = '(?!(?:'
-  + 'a|em|strong|small|s|cite|q|dfn|abbr|data|time|code'
-  + '|var|samp|kbd|sub|sup|i|b|u|mark|ruby|rt|rp|bdi|bdo'
-  + '|span|br|wbr|ins|del|img)\\b)\\w+(?!:|[^\\w\\s@]*@)\\b';
-
-block.html = edit(block.html)
-  .replace('comment', /<!--[\s\S]*?-->/)
-  .replace('closed', /<(tag)[\s\S]+?<\/\1>/)
-  .replace('closing', /<tag(?:"[^"]*"|'[^']*'|\s[^'"\/>\s]*)*?\/?>/)
-  .replace(/tag/g, block._tag)
-  .getRegex();
-
 block.paragraph = edit(block.paragraph)
   .replace('hr', block.hr)
   .replace('heading', block.heading)
   .replace('lheading', block.lheading)
-  .replace('tag', '<' + block._tag)
+  .replace('tag', '<' + block.tag)
   .getRegex();
 
+/**
+ * QUESTION: Why do tests require this be last?
+ */
 block.blockquote = edit(block.blockquote)
   .replace('paragraph', block.paragraph)
   .getRegex();
 
 /**
- * Normal Block Grammar
+ * Make aggregate `block` object. 
  */
-
 block.normal = merge({}, block);
 
 /**
  * GFM Block Grammar
+ *
+ * GFM is an extension of the CommonMark.
+ * 
+ * TODO: Create CommonMark object. Create GFM object with extensions.
  */
-
 block.gfm = merge({}, block.normal, {
   fences: /^ *(`{3,}|~{3,})[ \.]*(\S+)? *\n([\s\S]*?)\n? *\1 *(?:\n+|$)/,
   paragraph: /^/,
@@ -94,8 +106,8 @@ block.gfm.paragraph = edit(block.paragraph)
 
 /**
  * GFM + Tables Block Grammar
+ *
  */
-
 block.tables = merge({}, block.gfm, {
   nptable: /^ *(\S.*\|.*)\n *([-:]+ *\|[-| :]*)\n((?:.*\|.*(?:\n|$))*)\n*/,
   table: /^ *\|(.+)\n *\|( *[-:]+[-| :]*)\n((?: *\|.*(?:\n|$))*)\n*/
@@ -104,7 +116,6 @@ block.tables = merge({}, block.gfm, {
 /**
  * Block Lexer
  */
-
 function Lexer(options) {
   this.tokens = [];
   this.tokens.links = {};


### PR DESCRIPTION
**Marked version:** 0.3.19

**Markdown flavor:** n/a

## Description

Pulls member declarations into block, standardizes naming convention, and alphabetizes the rules.  

All tests run during `node test` were checked.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regresstion (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
