### PR TITLE
Fix unrendered links in docs/CODE_OF_CONDUCT.md

### DIFF
--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -68,4 +68,7 @@ members of the project's leadership.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+version [1.4][version].
+
+[homepage]: https://www.contributor-covenant.org/
+[version]: https://www.contributor-covenant.org/version/1/4/code-of-conduct.html


### PR DESCRIPTION
I've also tried to shorten the text part of the second link to not be a bit tautological.

## Contributor

- [x] no tests required for this PR.

## Committer

- [ ] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [x] Merge PR
