### PR TITLE
Fix nits in code example in USING_PRO.md

### DIFF
--- a/docs/USING_PRO.md
+++ b/docs/USING_PRO.md
@@ -25,8 +25,9 @@ var renderer = new myMarked.Renderer();
 renderer.heading = function (text, level) {
   var escapedText = text.toLowerCase().replace(/[^\w]+/g, '-');
 
-  return `<h${level}>
-            <a name="'${escapedText}'" class="anchor" href="#${escapedText}">
+  return `
+          <h${level}>
+            <a name="${escapedText}" class="anchor" href="#${escapedText}">
               <span class="header-link"></span>
             </a>
             ${text}
@@ -34,7 +35,7 @@ renderer.heading = function (text, level) {
 };
 
 // Run marked
-console.log(marked('# heading+', { renderer: renderer }));
+console.log(myMarked('# heading+', { renderer: renderer }));
 ```
 
 **Output:**


### PR DESCRIPTION
## Description

* Rename undefined variable.
* Delete unneeded quotes.
* Fix alignment in the actual output from the code example and make it more close to the "Output:" example (otherwise, the indentation of the "<h1>" line will be out of order).

## Contributor

- [x] no tests required for this PR.

## Committer

- [ ] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [x] Merge PR
