### PR TITLE
Remove node v4 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ jobs:
   include:
     - stage: spec tests 👩🏽‍💻
       node_js: v0.10
-    - node_js: v4
     - node_js: lts/*
     - node_js: node
 


### PR DESCRIPTION
## Description

Node v4.x is just about to reach [end-of-life](https://github.com/nodejs/Release#release-schedule) so we really don't need to be running tests against it.

This should speed up CI just a little bit.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR);

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
