### PR TITLE
allow string arg from command line

### DIFF
--- a/bin/marked
+++ b/bin/marked
@@ -41,6 +41,7 @@ function main(argv, callback) {
       options = {},
       input,
       output,
+      string,
       arg,
       tokens,
       opt;

--- a/bin/marked
+++ b/bin/marked
@@ -86,6 +86,10 @@ function main(argv, callback) {
       case '--input':
         input = argv.shift();
         break;
+      case '-s':
+      case '--string':
+        string = argv.shift();
+        break;
       case '-t':
       case '--tokens':
         tokens = true;
@@ -116,6 +120,9 @@ function main(argv, callback) {
   }
 
   function getData(callback) {
+    if (string) {
+      return callback(null, string);
+    }
     if (!input) {
       if (files.length <= 2) {
         return getStdin(callback);

--- a/bin/marked
+++ b/bin/marked
@@ -120,11 +120,11 @@ function main(argv, callback) {
   }
 
   function getData(callback) {
-    if (string) {
-      return callback(null, string);
-    }
     if (!input) {
       if (files.length <= 2) {
+        if (string) {
+          return callback(null, string);
+        }
         return getStdin(callback);
       }
       input = files.pop();

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,11 @@ $ cat hello.html
 <p>hello world</p>
 ```
 
+``` bash
+$ marked -s "*hello world*"
+<p><em>hello world</em></p>
+```
+
 **Browser**
 
 ```html

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -7,15 +7,15 @@ it('should run the test', function () {
 });
 
 describe('Test heading ID functionality', function() {
-	it('should add id attribute by default', function() {
-		var renderer = new marked.Renderer(marked.defaults);
-		var header = renderer.heading('test', 1, 'test');
-		expect(header).toBe('<h1 id="test">test</h1>\n');
-	});
+  it('should add id attribute by default', function() {
+    var renderer = new marked.Renderer(marked.defaults);
+    var header = renderer.heading('test', 1, 'test');
+    expect(header).toBe('<h1 id="test">test</h1>\n');
+  });
 
-	it('should NOT add id attribute when options set false', function() {
-		var renderer = new marked.Renderer({ headerIds: false });
-		var header = renderer.heading('test', 1, 'test');
-		expect(header).toBe('<h1>test</h1>\n');
-	});
+  it('should NOT add id attribute when options set false', function() {
+    var renderer = new marked.Renderer({ headerIds: false });
+    var header = renderer.heading('test', 1, 'test');
+    expect(header).toBe('<h1>test</h1>\n');
+  });
 });


### PR DESCRIPTION


**Marked version:** 84894118873d616c085f216a2d818c761f0592be

## Description

Allow marked to use a string argument as input.

```sh
$ marked --string "*test*"
<p><em>test</em></p>

$ marked -s "*test*"
<p><em>test</em></p>
```
## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [x] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [x] Merge PR
