### PR TITLE
Testing options and defaults

### DIFF
--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -29,8 +29,13 @@ describe('Test options', function() {
     expect(marked.options.headerIds).toBe(true);
   });
 
-  it('can change headerIds option to false', function() {
+  it('can change headerIds option to false via defaults', function() {
     marked.defaults.headerIds = false;
     expect(marked.defaults.headerIds).toBe(false);
+  });
+
+  it('can change headerIds option to false via setOptions', function() {
+    marked.setOptions({ headerIds: false });
+    expect(marked.options.headerIds).toBe(false);
   });
 });

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -7,15 +7,30 @@ it('should run the test', function () {
 });
 
 describe('Test heading ID functionality', function() {
-	it('should add id attribute by default', function() {
-		var renderer = new marked.Renderer(marked.defaults);
-		var header = renderer.heading('test', 1, 'test');
-		expect(header).toBe('<h1 id="test">test</h1>\n');
-	});
+  it('should add id attribute by default', function() {
+    var renderer = new marked.Renderer(marked.defaults);
+    var header = renderer.heading('test', 1, 'test');
+    expect(header).toBe('<h1 id="test">test</h1>\n');
+  });
 
-	it('should NOT add id attribute when options set false', function() {
-		var renderer = new marked.Renderer({ headerIds: false });
-		var header = renderer.heading('test', 1, 'test');
-		expect(header).toBe('<h1>test</h1>\n');
-	});
+  it('should NOT add id attribute when options set false', function() {
+    var renderer = new marked.Renderer({ headerIds: false });
+    var header = renderer.heading('test', 1, 'test');
+    expect(header).toBe('<h1>test</h1>\n');
+  });
+});
+
+describe('Test options', function() {
+  it('headerIds defaults should be true', function() {
+    expect(marked.defaults.headerIds).toBe(true);
+  });
+
+  it('headerIds options should be true', function() {
+    expect(marked.options.headerIds).toBe(true);
+  });
+
+  it('can change headerIds option to false', function() {
+    marked.defaults.headerIds = false;
+    expect(marked.defaults.headerIds).toBe(false);
+  });
 });


### PR DESCRIPTION
**Marked version:** 0.3.19

**Markdown flavor:** n/a

## Description

PR tests Marked configuration options. Related to #1160. 

## Expectation

- `marked.options` to be defined.

## Result

- `marked.options` is undefined. Can be set with `marked.defaults` or passing directly to the renderer (??).

## What was attempted

See tests.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
