### PR TITLE
Fix: TextRenerer.paragraph is not a function

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -967,6 +967,10 @@ TextRenderer.prototype.br = function() {
   return '';
 }
 
+TextRenderer.prototype.paragraph = function(text) {
+  return text;
+}
+
 /**
  * Parsing & Compiling
  */


### PR DESCRIPTION
## Description

The method `paragraph` is missing in the TextRenderer.

## Result

```
TypeError: this.renderer.paragraph is not a function
```

## What was attempted

```
marked('Test', {
    renderer: new marked.TextRenderer()
})
```

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
