### PR TITLE
use default options in Renderer by default

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -788,7 +788,7 @@ InlineLexer.prototype.mangle = function(text) {
  */
 
 function Renderer(options) {
-  this.options = options || {};
+  this.options = options || marked.defaults;
 }
 
 Renderer.prototype.code = function(code, lang, escaped) {


### PR DESCRIPTION

**Marked version:** 0.3.19

## Description

- Sets the Renderer options to the default options by default

I'm not sure if there is a reason the Renderer options were set to an empty object instead of the default options. The Parser and Lexers are set to the default options already

```js
function Renderer(options) {
  this.options = options || {};
  ...
```

```js
function Lexer(options) {
  this.options = options || marked.defaults;
  ...
```

```js
function InlineLexer(links, options) {
  this.options = options || marked.defaults;
  ...
```

```js
function Parser(options) {
  this.options = options || marked.defaults;
  ...
```

<!--

	If no issue exists that you're aware of. The maintainers should be able to figure out if it's a duplicate.

## Expectation

Describe the output you are expecting from marked

## Result

Describe the output you received from marked

## What was attempted

Describe what code combination got you there

-->

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
