### PR TITLE
Get second marked descriptor to fit one line

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Marked is 
 
 1. built for speed.
-2. a low-level markdown compiler that allows frequent parsing of large chunks of markdown without caching or blocking for long periods of time.
+2. a low-level markdown compiler for parsing markdown without caching or blocking for long periods of time.
 3. light-weight while implementing all markdown features from the supported flavors & specifications.
 4. available as a command line interface (CLI) and running in client- or server-side JavaScript projects.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@
 Marked is
 
 1. built for speed.<sup>*</sup>
-2. a low-level markdown compiler that allows frequent parsing of large chunks of markdown without caching or blocking for long periods of time.<sup>**</sup>
+2. a low-level markdown compiler for parsing markdown without caching or blocking for long periods of time.<sup>**</sup>
 3. light-weight while implementing all markdown features from the supported flavors & specifications.<sup>***</sup>
 4. available as a command line interface (CLI) and running in client- or server-side JavaScript projects.
 

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -7,15 +7,15 @@ it('should run the test', function () {
 });
 
 describe('Test heading ID functionality', function() {
-	it('should add id attribute by default', function() {
-		var renderer = new marked.Renderer(marked.defaults);
-		var header = renderer.heading('test', 1, 'test');
-		expect(header).toBe('<h1 id="test">test</h1>\n');
-	});
+  it('should add id attribute by default', function() {
+    var renderer = new marked.Renderer(marked.defaults);
+    var header = renderer.heading('test', 1, 'test');
+    expect(header).toBe('<h1 id="test">test</h1>\n');
+  });
 
-	it('should NOT add id attribute when options set false', function() {
-		var renderer = new marked.Renderer({ headerIds: false });
-		var header = renderer.heading('test', 1, 'test');
-		expect(header).toBe('<h1>test</h1>\n');
-	});
+  it('should NOT add id attribute when options set false', function() {
+    var renderer = new marked.Renderer({ headerIds: false });
+    var header = renderer.heading('test', 1, 'test');
+    expect(header).toBe('<h1>test</h1>\n');
+  });
 });


### PR DESCRIPTION
**Marked version:** 0.3.19

**Markdown flavor:** n/a

## Description

The second bullet was just long to read, think we can get the point across while maintaining the spirit.

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [ ] Merge PR
