### PR TITLE
Update editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,13 +1,13 @@
 root = true
 
-[*, *.json, *.js]
+[*{json,js}]
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 indent_style = space
 indent_size = 2
 
-[*.md, !test/*md]
+[*.md, !test/*.md]
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 root = true
 
-[*{json,js}]
+[*.{json,js}]
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true


### PR DESCRIPTION
**Marked version:** 0.3.19

**Markdown flavor:** n/a

## Expectation

While using a text editor that recognizes `.editorconfig` the rules are honored.

## Result

Rules were not honored resulting in me having to run `npm run lint` multiple times to apply proper tabbing and spacing.

## What was attempted

Standard use of text editor. Minor changes to `.editorconfig` seems to do the trick.
## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [x] Merge PR
