### PR TITLE
Reset defaults before tests

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1346,7 +1346,7 @@ marked.setOptions = function(opt) {
 };
 
 marked.getDefaults = function () {
-  var defaults = {
+  return {
     baseUrl: null,
     breaks: false,
     gfm: true,
@@ -1365,13 +1365,6 @@ marked.getDefaults = function () {
     tables: true,
     xhtml: false
   };
-
-  var clone = {};
-  for (var opt in defaults) {
-    clone[opt] = defaults[opt];
-  }
-
-  return clone;
 }
 
 marked.defaults = marked.getDefaults();

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1345,30 +1345,36 @@ marked.setOptions = function(opt) {
   return marked;
 };
 
-marked.defaults = {
-  baseUrl: null,
-  breaks: false,
-  gfm: true,
-  headerIds: true,
-  headerPrefix: '',
-  highlight: null,
-  langPrefix: 'lang-',
-  mangle: true,
-  pedantic: false,
-  renderer: new Renderer(),
-  sanitize: false,
-  sanitizer: null,
-  silent: false,
-  smartLists: false,
-  smartypants: false,
-  tables: true,
-  xhtml: false
-};
+marked.getDefaults = function () {
+  var defaults = {
+    baseUrl: null,
+    breaks: false,
+    gfm: true,
+    headerIds: true,
+    headerPrefix: '',
+    highlight: null,
+    langPrefix: 'lang-',
+    mangle: true,
+    pedantic: false,
+    renderer: new Renderer(),
+    sanitize: false,
+    sanitizer: null,
+    silent: false,
+    smartLists: false,
+    smartypants: false,
+    tables: true,
+    xhtml: false
+  };
 
-marked.origDefaults = {};
-for (var opt in marked.defaults) {
-  marked.origDefaults[opt] = marked.defaults[opt];
+  var clone = {};
+  for (var opt in defaults) {
+    clone[opt] = defaults[opt];
+  }
+
+  return clone;
 }
+
+marked.defaults = marked.getDefaults();
 
 /**
  * Expose

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1365,6 +1365,11 @@ marked.defaults = {
   xhtml: false
 };
 
+marked.origDefaults = {};
+for (var opt in marked.defaults) {
+  marked.origDefaults[opt] = marked.defaults[opt];
+}
+
 /**
  * Expose
  */

--- a/test/helpers/helpers.js
+++ b/test/helpers/helpers.js
@@ -1,5 +1,5 @@
 var marked = require('../../lib/marked.js');
 
 beforeEach(function () {
-  marked.setOptions(marked.origDefaults);
+  marked.setOptions(marked.getDefaults());
 });

--- a/test/helpers/helpers.js
+++ b/test/helpers/helpers.js
@@ -1,0 +1,5 @@
+var marked = require('../../lib/marked.js');
+
+beforeEach(function () {
+  marked.setOptions(marked.origDefaults);
+});


### PR DESCRIPTION
**Marked version:** 0.3.19


## Description

- add function `marked.getDefaults()` that gets assigned to `marked.defaults`
- resets the defaults before each test

<!--

	If no issue exists that you're aware of. The maintainers should be able to figure out if it's a duplicate.

## Expectation

Describe the output you are expecting from marked

## Result

Describe the output you received from marked

## What was attempted

Describe what code combination got you there

-->

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
