### PR TITLE
Defib challenge badge

### DIFF
--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -37,7 +37,6 @@ A note on "decision making authority". This is related to submitting PRs and the
 |Name           |GiHub handle   |Decision making                          |Badges of honor (tag for questions) |
 |:--------------|:--------------|:----------------------------------------|------------------------------------|
 |Jamie Davis    |@davisjam      |Seeker of Security                       |                                    |
-|Steven         |@styfle        |Open source, of course and GitHub Guru   |                                    |
 |Tony Brix      |@UziTech       |Titan of the test harness and Dr. DevOps |                                    |
 
 **Should not exceed 5:** For larger PRs affecting more of the codebase and, most likely, review by more people, we try to keep this pool small and responsive and let those with decision making authority have final say without negative repercussions from the other committers.

--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -143,6 +143,8 @@ Badges? If you *want* 'em, we got 'em, and here's how you get 'em (and&hellip;dr
 ### Special badges that come with the job:
 
 <dl>
+	<dt>Defibrillator</dt>
+	<dd>A contributor who stepped to help bring Marked back to life by contriuting solutions to help Marked pass when compared against the CommonMark and GitHub Flavored Markdown specifications.</dd>
 	<dt>Maker of the Marked mark</dt>
 	<dd>This badge is given to the person or oganization credited with creating the logo (or logotype) used in Marked communications for a given period of time. **Maker of the Marked mark from 2017 to present**, for example.</dd>
 	<dt>Release Wrangler</dt>


### PR DESCRIPTION
**Marked version:** 0.3.19

**Markdown flavor:** CommonMark & GitHub Flavored Markdown

## Description

Adds limited badge related to the defibrillator challenge (#1216).

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
