### PR TITLE
Withdraw permission for Branding usage

### DIFF
--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -8,7 +8,6 @@ Users are anyone using Marked in some fashion, without them, there's no reason f
 
 |Individual or Organization |Website                |GitHub project                                                 |Submitted by                                        |
 |:--------------------------|:----------------------|:--------------------------------------------------------------|:---------------------------------------------------|
-|OpenUserJS                 |https://openuserjs.org |[OpenUserJS.org](https://github.com/OpenUserJS/OpenUserJS.org) | Marti Martz (@Martii) Co-Owner / Active Maintainer |
 
 To be listed: please let us know or submit a PR.
 


### PR DESCRIPTION
* Unfortunately @joshbruce lost some credibility by a post edit with an edit misusing the OpenUserJS brand so respectfully removing listing.

NOTE:
* This is probably why no-one else has done this

Ref:
* #1233

with

> LGTM!

... apparently it wasn't and shouldn't have been merged without all parties consent.
