### PR TITLE
[WIP] add options to demo page

### DIFF
--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -15,15 +15,30 @@
       <a href="../">
       <img src="../img/logo-black.svg" height="64px" width="64px" />
     </a>
-      <h1>Marked Demo</h1>
+      <h1>Marked Demo <span id="version"></span></h1>
     </header>
 
     <div class="containers">
       <div class="container">
         <div class="label">
-          <span>Input</span> ·
-          <a id="permalink">Permalink</a> ·
+          <span>Input:</span>
+          <a id="permalink">Permalink</a>
+          ·
           <button id="clear">Clear</button>
+          ·
+          <select id="spec" title="Specification">
+            <option value="cm">CommonMark</option>
+            <option value="gfm">GFM</option>
+            <option value="pedantic">Pedantic</option>
+          </select>
+          <a href="https://spec.commonmark.org/0.28/" id="cm-spec-url" class="spec-url" title="CommonMark Specs">?</a>
+          <a href="https://github.github.com/gfm/" id="gfm-spec-url" class="spec-url" title="GitHub Flavored Markdown Specs">?</a>
+          <a href="https://daringfireball.net/projects/markdown/syntax" id="pedantic-spec-url" class="spec-url" title="Original Specs">?</a>
+          ·
+          <label>
+            <input type="checkbox" id="smartypants" title="SmartyPants" />SmartyPants
+            <a href="https://daringfireball.net/projects/smartypants/" title="What is SmartyPants?">?</a>
+          </label>
         </div>
         <textarea id="input"></textarea>
       </div>


### PR DESCRIPTION
## Description

Adds options to the demo page so users can set the `gfm`, `pedantic`, or `smartypants` options

![image](https://user-images.githubusercontent.com/97994/39261907-84c94912-4883-11e8-8210-ffe70bb929d2.png)

The question mark next to the spec links to the spec they selected.

The question mark next to smartypants links to the smartypants docs

Also adds the marked version to the title

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
