### PR TITLE
GFM compliance for tasks lists

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -366,11 +366,11 @@ Lexer.prototype.token = function(src, top) {
         }
 
         // Check for task list items
-        istask = /^\[[ xX]\]/.test(item);
+        istask = /^\[[ xX]\] /.test(item);
         ischecked = undefined;
         if (istask) {
           ischecked = item[1] !== ' ';
-          item = item.replace(/^\[[ xX]\] */, '');
+          item = item.replace(/^\[[ xX]\] +/, '');
         }
 
         this.tokens.push({

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -195,7 +195,9 @@ Lexer.prototype.token = function(src, top) {
       i,
       tag,
       l,
-      isordered;
+      isordered,
+      istask,
+      ischecked;
 
   while (src) {
     // newline
@@ -363,10 +365,20 @@ Lexer.prototype.token = function(src, top) {
           if (!loose) loose = next;
         }
 
+        // Check for task list items
+        istask = /^\[[ xX]\]/.test(item);
+        ischecked = undefined;
+        if (istask) {
+          ischecked = item[1] !== ' ';
+          item = item.replace(/^\[[ xX]\] */, '');
+        }
+
         this.tokens.push({
           type: loose
             ? 'loose_item_start'
-            : 'list_item_start'
+            : 'list_item_start',
+          task: istask,
+          checked: ischecked
         });
 
         // Recurse.
@@ -927,6 +939,14 @@ Renderer.prototype.listitem = function(text) {
   return '<li>' + text + '</li>\n';
 };
 
+Renderer.prototype.checkbox = function(checked) {
+  return '<input '
+    + (checked ? 'checked="" ' : '')
+    + 'disabled="" type="checkbox"'
+    + (this.options.xhtml ? ' /' : '')
+    + '>';
+}
+
 Renderer.prototype.paragraph = function(text) {
   return '<p>' + text + '</p>\n';
 };
@@ -1197,6 +1217,10 @@ Parser.prototype.tok = function() {
     }
     case 'list_item_start': {
       body = '';
+
+      if (this.token.task) {
+        body += this.renderer.checkbox(this.token.checked);
+      }
 
       while (this.next().type !== 'list_item_end') {
         body += this.token.type === 'text'

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -944,7 +944,7 @@ Renderer.prototype.checkbox = function(checked) {
     + (checked ? 'checked="" ' : '')
     + 'disabled="" type="checkbox"'
     + (this.options.xhtml ? ' /' : '')
-    + '>';
+    + '> ';
 }
 
 Renderer.prototype.paragraph = function(text) {

--- a/test/specs/gfm/gfm-spec.js
+++ b/test/specs/gfm/gfm-spec.js
@@ -15,7 +15,8 @@ Messenger.prototype.test = function(spec, section, ignore) {
     var shouldFail = ~ignore.indexOf(spec.example);
     it('should ' + (shouldFail ? 'fail' : 'pass') + ' example ' + spec.example, function() {
       var expected = spec.html;
-      var actual = marked(spec.markdown, { headerIds: false, xhtml: true });
+      var usexhtml = typeof spec.xhtml === 'boolean' ? spec.xhtml : true;
+      var actual = marked(spec.markdown, { headerIds: false, xhtml: usexhtml });
       since(messenger.message(spec, expected, actual)).expect(
         htmlDiffer.isEqual(expected, actual)
       ).toEqual(!shouldFail);
@@ -42,7 +43,7 @@ describe('GFM 0.28 Tables', function() {
 describe('GFM 0.28 Task list items', function() {
   var section = 'Task list items';
 
-  var shouldPassButFails = [272, 273];
+  var shouldPassButFails = [];
 
   var willNotBeAttemptedByCoreTeam = [];
 

--- a/test/specs/gfm/gfm-spec.js
+++ b/test/specs/gfm/gfm-spec.js
@@ -15,8 +15,7 @@ Messenger.prototype.test = function(spec, section, ignore) {
     var shouldFail = ~ignore.indexOf(spec.example);
     it('should ' + (shouldFail ? 'fail' : 'pass') + ' example ' + spec.example, function() {
       var expected = spec.html;
-      var usexhtml = typeof spec.xhtml === 'boolean' ? spec.xhtml : true;
-      var actual = marked(spec.markdown, { headerIds: false, xhtml: usexhtml });
+      var actual = marked(spec.markdown, { headerIds: false, xhtml: false });
       since(messenger.message(spec, expected, actual)).expect(
         htmlDiffer.isEqual(expected, actual)
       ).toEqual(!shouldFail);

--- a/test/specs/gfm/gfm.0.28.json
+++ b/test/specs/gfm/gfm.0.28.json
@@ -51,15 +51,13 @@
     "section": "Task list items",
     "html": "<ul>\n<li><input disabled=\"\" type=\"checkbox\"> foo</li>\n<li><input checked=\"\" disabled=\"\" type=\"checkbox\"> bar</li>\n</ul>",
     "markdown": "- [ ] foo\n- [x] bar",
-    "example": 272,
-    "xhtml": false
+    "example": 272
   },
   {
     "section": "Task list items",
     "html": "<ul>\n<li><input checked=\"\" disabled=\"\" type=\"checkbox\"> foo\n<ul>\n<li><input disabled=\"\" type=\"checkbox\"> bar</li>\n<li><input checked=\"\" disabled=\"\" type=\"checkbox\"> baz</li>\n</ul>\n</li>\n<li><input disabled=\"\" type=\"checkbox\"> bim</li>\n</ul>",
     "markdown": "- [x] foo\n  - [ ] bar\n  - [x] baz\n- [ ] bim",
-    "example": 273,
-    "xhtml": false
+    "example": 273
   },
   {
     "section": "Strikethrough",

--- a/test/specs/gfm/gfm.0.28.json
+++ b/test/specs/gfm/gfm.0.28.json
@@ -51,13 +51,15 @@
     "section": "Task list items",
     "html": "<ul>\n<li><input disabled=\"\" type=\"checkbox\"> foo</li>\n<li><input checked=\"\" disabled=\"\" type=\"checkbox\"> bar</li>\n</ul>",
     "markdown": "- [ ] foo\n- [x] bar",
-    "example": 272
+    "example": 272,
+    "xhtml": false
   },
   {
     "section": "Task list items",
     "html": "<ul>\n<li><input checked=\"\" disabled=\"\" type=\"checkbox\"> foo\n<ul>\n<li><input disabled=\"\" type=\"checkbox\"> bar</li>\n<li><input checked=\"\" disabled=\"\" type=\"checkbox\"> baz</li>\n</ul>\n</li>\n<li><input disabled=\"\" type=\"checkbox\"> bim</li>\n</ul>",
     "markdown": "- [x] foo\n  - [ ] bar\n  - [x] baz\n- [ ] bim",
-    "example": 273
+    "example": 273,
+    "xhtml": false
   },
   {
     "section": "Strikethrough",


### PR DESCRIPTION
**Marked version:**  0.3.19

**Markdown flavor:**  GitHub Flavored Markdown

Fixes #107
Fixes #419
Fixes #170
Fixes #689
Fixes #587

## Description

This adds [task list items](https://github.github.com/gfm/#task-list-items-extension-) support as specified in GFM.  These are the checkboxes you can make in bulleted lists.

I did do some funny stuff in the gfm test runner.  In particular all the other gfm tests use the xhtml rendering option.  But for some reason, (probably not a good one) the checkbox rendering in the gfm spec is *not* xhtml.  So, I added a an `xhtml` attribute to the test spec json for those tests.  It seems pretty janky.  Maybe someone can think of a better way of handling it.

## Contributor

- [X] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [x] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [x] Merge PR
