### PR TITLE
Allow travis to pass when redos check fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 
 jobs:
+  fast_finish: true
   allow_failures:
     - stage: security scan 🔐
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 
 jobs:
+  allow_failures:
+    - stage: security scan 🔐
+
   include:
     - stage: unit tests 👩🏽‍💻
       script: npm run test:unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,6 @@ jobs:
     - node_js: lts/*
     - node_js: node
 
-    - stage: security scan 🔐
-      script: npm run test:redos
-      node_js: lts/*
-
     - stage: lint ✨
       script: npm run test:lint
       node_js: lts/*
@@ -38,6 +34,10 @@ jobs:
         fi
       node_js: lts/*
       if: branch = master AND type = push
+
+    - stage: security scan 🔐
+      script: npm run test:redos
+      node_js: lts/*
 
 cache:
   directories:


### PR DESCRIPTION
**Markdown flavor:** 7a9e35eb7d5afc729cf73a6a7c5d9bfbe7a833c1

## Description

- Allows travis to pass even when `npm run test:redos` fails

![image](https://user-images.githubusercontent.com/97994/39724919-c148f0dc-520f-11e8-81a1-f47b549b5c05.png)

closes #1254

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
