### PR TITLE
security: use rtrim, not unsafe /X+$/

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1355,36 +1355,36 @@ function splitCells(tableRow, count) {
   return cells;
 }
 
-// Return str with all trailing {c | all but c} removed
-// allButC: Default false
-function rtrim(str, c, allButC) {
-  if (typeof allButC === 'undefined') {
-    allButC = false;
+// Remove trailing 'c's. Equivalent to str.replace(/c*$/, '').
+// /c*$/ is vulnerable to REDOS.
+// invert: Remove suffix of non-c chars instead. Default false.
+function rtrim(str, c, invert) {
+  if (typeof invert === 'undefined' || !invert) {
+    invert = false;
   } else {
-    allButC = true;
+    invert = true;
   }
-  var mustMatchC = !allButC;
 
   if (str.length === 0) {
     return '';
   }
 
-  // ix+1 of leftmost that fits description
-  // i.e. the length of the string we should return
-  var curr = str.length;
+  // Length of suffix matching the invert condition.
+  var suffLen = 0;
 
-  while (curr > 0) {
-    var currChar = str.charAt(curr - 1);
-    if (mustMatchC && currChar === c) {
-      curr--;
-    } else if (!mustMatchC && currChar !== c) {
-      curr--;
+  // Step left until we fail to match the invert condition.
+  while (suffLen < str.length) {
+    var currChar = str.charAt(str.length - suffLen - 1);
+    if (currChar === c && !invert) {
+      suffLen++;
+    } else if (currChar !== c && invert) {
+      suffLen++;
     } else {
       break;
     }
   }
 
-  return str.substr(0, curr);
+  return str.substr(0, str.length - suffLen);
 }
 
 /**

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -217,7 +217,7 @@ Lexer.prototype.token = function(src, top) {
       this.tokens.push({
         type: 'code',
         text: !this.options.pedantic
-          ? cap.replace(/\n+$/, '')
+          ? rtrim(cap, '\n')
           : cap
       });
       continue;
@@ -1303,7 +1303,7 @@ function resolveUrl(base, href) {
     if (/^[^:]+:\/*[^/]*$/.test(base)) {
       baseUrls[' ' + base] = base + '/';
     } else {
-      baseUrls[' ' + base] = base.replace(/[^/]*$/, '');
+      baseUrls[' ' + base] = rtrim(base, '/', true);
     }
   }
   base = baseUrls[' ' + base];
@@ -1353,6 +1353,38 @@ function splitCells(tableRow, count) {
     cells[i] = cells[i].replace(/\\\|/g, '|');
   }
   return cells;
+}
+
+// Return str with all trailing {c | all but c} removed
+// allButC: Default false
+function rtrim(str, c, allButC) {
+  if (typeof allButC === 'undefined') {
+    allButC = false;
+  } else {
+    allButC = true;
+  }
+  var mustMatchC = !allButC;
+
+  if (str.length === 0) {
+    return '';
+  }
+
+  // ix+1 of leftmost that fits description
+  // i.e. the length of the string we should return
+  var curr = str.length;
+
+  while (curr > 0) {
+    var currChar = str.charAt(curr - 1);
+    if (mustMatchC && currChar === c) {
+      curr--;
+    } else if (!mustMatchC && currChar !== c) {
+      curr--;
+    } else {
+      break;
+    }
+  }
+
+  return str.substr(0, curr);
 }
 
 /**

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1357,14 +1357,8 @@ function splitCells(tableRow, count) {
 
 // Remove trailing 'c's. Equivalent to str.replace(/c*$/, '').
 // /c*$/ is vulnerable to REDOS.
-// invert: Remove suffix of non-c chars instead. Default false.
+// invert: Remove suffix of non-c chars instead. Default falsey.
 function rtrim(str, c, invert) {
-  if (typeof invert === 'undefined' || !invert) {
-    invert = false;
-  } else {
-    invert = true;
-  }
-
   if (str.length === 0) {
     return '';
   }


### PR DESCRIPTION
Problem:
`replace(/X+$/, '')` is vulnerable to REDOS

Solution:
Replace these instances with a custom rtrim.