### PR TITLE
Fix table cells

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1340,6 +1340,8 @@ function merge(obj) {
 }
 
 function splitCells(tableRow, count) {
+  // ensure that every cell-delimiting pipe has a space
+  // before it to distinguish it from an escaped pipe
   var row = tableRow.replace(/\|/g, function (match, offset, str) {
         var escaped = false,
             curr = offset;
@@ -1363,6 +1365,7 @@ function splitCells(tableRow, count) {
   }
 
   for (; i < cells.length; i++) {
+    // leading or trailing whitespace is ignored per the gfm spec
     cells[i] = cells[i].trim().replace(/\\\|/g, '|');
   }
   return cells;

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1340,7 +1340,20 @@ function merge(obj) {
 }
 
 function splitCells(tableRow, count) {
-  var cells = tableRow.replace(/([^\\])\|/g, '$1 |').split(/ +\| */),
+  var row = tableRow.replace(/\|/g, function (match, offset, str) {
+        var escaped = false,
+            curr = offset;
+        while (--curr >= 0 && str[curr] === '\\') escaped = !escaped;
+        if (escaped) {
+          // odd number of slashes means | is escaped
+          // so we leave it alone
+          return '|';
+        } else {
+          // add space before unescaped |
+          return ' |';
+        }
+      }),
+      cells = row.split(/ \|/),
       i = 0;
 
   if (cells.length > count) {
@@ -1350,7 +1363,7 @@ function splitCells(tableRow, count) {
   }
 
   for (; i < cells.length; i++) {
-    cells[i] = cells[i].replace(/\\\|/g, '|');
+    cells[i] = cells[i].trim().replace(/\\\|/g, '|');
   }
   return cells;
 }

--- a/test/specs/marked/marked-spec.js
+++ b/test/specs/marked/marked-spec.js
@@ -46,3 +46,18 @@ describe('Marked Code spans', function() {
     messenger.test(spec, section, ignore);
   });
 });
+
+describe('Marked Table cells', function() {
+  var section = 'Table cells';
+
+  // var shouldPassButFails = [];
+  var shouldPassButFails = [];
+
+  var willNotBeAttemptedByCoreTeam = [];
+
+  var ignore = shouldPassButFails.concat(willNotBeAttemptedByCoreTeam);
+
+  markedSpec.forEach(function(spec) {
+    messenger.test(spec, section, ignore);
+  });
+});

--- a/test/specs/marked/marked.json
+++ b/test/specs/marked/marked.json
@@ -2,7 +2,7 @@
   {
     "section": "Code spans",
     "markdown": "`someone@example.com`",
-    "html": "<p><code>someone@exmaple.com</code></p>",
+    "html": "<p><code>someone@example.com</code></p>",
     "example": 1
   },
   {

--- a/test/specs/marked/marked.json
+++ b/test/specs/marked/marked.json
@@ -7,26 +7,44 @@
   },
   {
     "section": "Table cells",
+    "markdown": "|1|\n|-|\n|1|",
+    "html": "<table><thead><tr><th>1</th></tr></thead><tbody><tr><td>1</td></tr></tbody></table>",
+    "example": 2
+  },
+  {
+    "section": "Table cells",
+    "markdown": "|1|\n|-|\n|1\\||",
+    "html": "<table><thead><tr><th>1</th></tr></thead><tbody><tr><td>1|</td></tr></tbody></table>",
+    "example": 3
+  },
+  {
+    "section": "Table cells",
+    "markdown": "|1|\n|-|\n|1\\\\1|",
+    "html": "<table><thead><tr><th>1</th></tr></thead><tbody><tr><td>1\\1</td></tr></tbody></table>",
+    "example": 4
+  },
+  {
+    "section": "Table cells",
     "markdown": "|1|\n|-|\n|\\\\\\\\||",
     "html": "<table><thead><tr><th>1</th></tr></thead><tbody><tr><td>\\\\</td></tr></tbody></table>",
-    "example": 2
+    "example": 5
   },
   {
     "section": "Table cells",
     "markdown": "|1|\n|-|\n|\\\\\\\\\\||",
     "html": "<table><thead><tr><th>1</th></tr></thead><tbody><tr><td>\\\\|</td></tr></tbody></table>",
-    "example": 3
+    "example": 6
   },
   {
     "section": "Table cells",
     "markdown": "|1|2|\n|-|-|\n||2|",
     "html": "<table><thead><tr><th>1</th><th>2</th></tr></thead><tbody><tr><td></td><td>2</td></tr></tbody></table>",
-    "example": 4
+    "example": 7
   },
   {
     "section": "Table cells",
     "markdown": "|1|2|\n|-|-|\n|1\\|\\\\|2\\|\\\\|",
     "html": "<table><thead><tr><th>1</th><th>2</th></tr></thead><tbody><tr><td>1|\\</td><td>2|\\</td></tr></tbody></table>",
-    "example": 5
+    "example": 8
   }
 ]

--- a/test/specs/marked/marked.json
+++ b/test/specs/marked/marked.json
@@ -13,8 +13,8 @@
   },
   {
     "section": "Table cells",
-    "markdown": "|1|\n|-|\n|1\\||",
-    "html": "<table><thead><tr><th>1</th></tr></thead><tbody><tr><td>1|</td></tr></tbody></table>",
+    "markdown": "|1|\n|-|\n|\\||",
+    "html": "<table><thead><tr><th>1</th></tr></thead><tbody><tr><td>|</td></tr></tbody></table>",
     "example": 3
   },
   {

--- a/test/specs/marked/marked.json
+++ b/test/specs/marked/marked.json
@@ -22,5 +22,11 @@
     "markdown": "|1|2|\n|-|-|\n||2|",
     "html": "<table><thead><tr><th>1</th><th>2</th></tr></thead><tbody><tr><td></td><td>2</td></tr></tbody></table>",
     "example": 4
+  },
+  {
+    "section": "Table cells",
+    "markdown": "|1|2|\n|-|-|\n|1\\|\\\\|2\\|\\\\|",
+    "html": "<table><thead><tr><th>1</th><th>2</th></tr></thead><tbody><tr><td>1|\\</td><td>2|\\</td></tr></tbody></table>",
+    "example": 5
   }
 ]

--- a/test/specs/marked/marked.json
+++ b/test/specs/marked/marked.json
@@ -2,7 +2,25 @@
   {
     "section": "Code spans",
     "markdown": "`someone@example.com`",
-    "html": "<p><code>someone@exmaple.com</code></p>\n",
+    "html": "<p><code>someone@exmaple.com</code></p>",
     "example": 1
+  },
+  {
+    "section": "Table cells",
+    "markdown": "|1|\n|-|\n|\\\\\\\\||",
+    "html": "<table><thead><tr><th>1</th></tr></thead><tbody><tr><td>\\\\</td></tr></tbody></table>",
+    "example": 2
+  },
+  {
+    "section": "Table cells",
+    "markdown": "|1|\n|-|\n|\\\\\\\\\\||",
+    "html": "<table><thead><tr><th>1</th></tr></thead><tbody><tr><td>\\\\|</td></tr></tbody></table>",
+    "example": 3
+  },
+  {
+    "section": "Table cells",
+    "markdown": "|1|2|\n|-|-|\n||2|",
+    "html": "<table><thead><tr><th>1</th><th>2</th></tr></thead><tbody><tr><td></td><td>2</td></tr></tbody></table>",
+    "example": 4
   }
 ]

--- a/test/specs/marked/marked.json
+++ b/test/specs/marked/marked.json
@@ -46,5 +46,11 @@
     "markdown": "|1|2|\n|-|-|\n|1\\|\\\\|2\\|\\\\|",
     "html": "<table><thead><tr><th>1</th><th>2</th></tr></thead><tbody><tr><td>1|\\</td><td>2|\\</td></tr></tbody></table>",
     "example": 8
+  },
+  {
+    "section": "Table cells",
+    "markdown": "|1|2|\n|-|-|\n| |2|",
+    "html": "<table><thead><tr><th>1</th><th>2</th></tr></thead><tbody><tr><td></td><td>2</td></tr></tbody></table>",
+    "example": 9
   }
 ]


### PR DESCRIPTION

**Marked version:** master

<!-- The NPM version or commit hash having the issue -->

**Markdown flavor:** Markdown.pl|CommonMark|GitHub Flavored Markdown|n/a

## Description

- Fixes empty table cells and multiple slashes before `|`

fixes #1290

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
