### PR TITLE
CommonMark code block class names

### DIFF
--- a/docs/USING_ADVANCED.md
+++ b/docs/USING_ADVANCED.md
@@ -47,7 +47,7 @@ console.log(myMarked('I am using __markdown__.'));
 |headerIds   |`boolean` |`true`   |v0.4.0   |If true, include an `id` attribute when emitting headings (h1, h2, h3, etc).|
 |headerPrefix|`string`  |`''`     |???      |A string to prefix the `id` attribute when emitting headings (h1, h2, h3, etc).|
 |highlight   |`function`|`null`   |???      |A function to highlight code blocks, see <a href="#highlight">Asynchronous highlighting</a>.|
-|langPrefix  |`string`  |`'lang-'`|???      |A string to prefix the className in a `<code>` block. Useful for syntax highlighting.|
+|langPrefix  |`string`  |`'language-'`|???      |A string to prefix the className in a `<code>` block. Useful for syntax highlighting.|
 |mangle      |`boolean` |`true`   |???      |???     |
 |pedantic    |`boolean` |`false`  |???      |If true, conform to the original `markdown.pl` as much as possible. Don't fix original markdown bugs or behavior. Turns off and overrides `gfm`.|
 |renderer    |`object`  |`new Renderer()`|???|An object containing functions to render tokens to HTML. See [extensibility](USING_PRO.md) for more details.|

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1470,7 +1470,7 @@ marked.getDefaults = function () {
     headerIds: true,
     headerPrefix: '',
     highlight: null,
-    langPrefix: 'lang-',
+    langPrefix: 'language-',
     mangle: true,
     pedantic: false,
     renderer: new Renderer(),

--- a/test/new/gfm_code.html
+++ b/test/new/gfm_code.html
@@ -1,12 +1,12 @@
-<pre><code class="lang-js">var a = &#39;hello&#39;;
+<pre><code class="language-js">var a = &#39;hello&#39;;
 console.log(a + &#39; world&#39;);</code></pre>
-<pre><code class="lang-bash">echo &quot;hello, ${WORLD}&quot;</code></pre>
-<pre><code class="lang-longfence">Q: What do you call a tall person who sells stolen goods?</code></pre>
-<pre><code class="lang-ManyTildes">A longfence!</code></pre>
+<pre><code class="language-bash">echo &quot;hello, ${WORLD}&quot;</code></pre>
+<pre><code class="language-longfence">Q: What do you call a tall person who sells stolen goods?</code></pre>
+<pre><code class="language-ManyTildes">A longfence!</code></pre>
 <p>How about an empty code block?</p>
-<pre><code class="lang-js"></code></pre>
+<pre><code class="language-js"></code></pre>
 <p>How about a code block with only an empty line?</p>
-<pre><code class="lang-js">
+<pre><code class="language-js">
 </code></pre>
 
 <p>With some trailing empty lines:</p>

--- a/test/new/gfm_code_hr_list.html
+++ b/test/new/gfm_code_hr_list.html
@@ -22,11 +22,11 @@
 <li><p>foo:</p>
 <ol>
 <li><p>foo <code>bar</code> bar:</p>
-<pre><code class="lang-erb"> some code here
+<pre><code class="language-erb"> some code here
 </code></pre>
 </li>
 <li><p>foo <code>bar</code> bar:</p>
-<pre><code class="lang-erb"> foo
+<pre><code class="language-erb"> foo
  ---
  bar
  ---
@@ -34,7 +34,7 @@
  bar</code></pre>
 </li>
 <li><p>foo <code>bar</code> bar:</p>
-<pre><code class="lang-html"> ---
+<pre><code class="language-html"> ---
  foo
  foo
  ---

--- a/test/specs/commonmark/commonmark-spec.js
+++ b/test/specs/commonmark/commonmark-spec.js
@@ -155,7 +155,7 @@ describe('CommonMark 0.28 Fenced code blocks', function() {
   var section = 'Fenced code blocks';
 
   // var shouldPassButFails = [];
-  var shouldPassButFails = [93, 95, 96, 97, 101, 102, 106, 108, 111, 112, 113];
+  var shouldPassButFails = [93, 95, 96, 97, 101, 102, 106, 108, 112];
 
   var willNotBeAttemptedByCoreTeam = [];
 


### PR DESCRIPTION
This is a very simple fix to follow the CommonMark spec for code blocks:
https://spec.commonmark.org/0.27/ Example: https://spec.commonmark.org/0.27/#example-109

Right now Marked defaults to `lang-` for fenced code blocks, which as far I understand it, is legacy from Highlight.js. By enforcing the CommonMark standard developers will be able to leverage other CommonMark tools when using output from Marked.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
