### PR TITLE
Change travis clone depth to 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,4 +44,4 @@ cache:
     - node_modules
 
 git:
-  depth: 5
+  depth: 3

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,3 +42,6 @@ jobs:
 cache:
   directories:
     - node_modules
+
+git:
+  depth: 5


### PR DESCRIPTION
## Description

By default Travis CI clones the last 50 commits. Cloning less means faster checkout and clone times which results in slightly faster builds.

See [the docs](https://docs.travis-ci.com/user/customizing-the-build#Git-Clone-Depth) for more information.

## Contributor

- [x] no tests required for this PR.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
