### PR TITLE
Add pictures to AUTHORS.md

### DIFF
--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -1,6 +1,6 @@
 # Authors
 
-Marked takes an encompassing approach to its community. As such, you can think of these as [concentric circles](https://medium.com/the-node-js-collection/healthy-open-source-967fa8be7951), where each subsequent group is enveloped by the previous one.
+Marked takes an encompassing approach to its community. As such, you can think of these as [concentric circles](https://medium.com/the-node-js-collection/healthy-open-source-967fa8be7951), where each group encompases the following groups.
 
 <table>
   <tbody>
@@ -111,30 +111,25 @@ Marked takes an encompassing approach to its community. As such, you can think o
   </tbody>
 </table>
 
-## Users
+## Publishers
 
-Users are anyone using Marked in some fashion, without them, there's no reason for us to exist.
+Publishers are admins who also have the responsibility, privilege, and burden of publishing the new releases to NPM and performing outreach and external stakeholder communications. Further, when things go pear-shaped, they're the ones taking most of the heat. Finally, when things go well, they're the primary ones praising the contributors who made it possible.
 
-|Individual or Organization |Website                 |Project                              |Submitted by                                        |
-|:--------------------------|:-----------------------|:------------------------------------|:---------------------------------------------------|
-|MarkedJS                   |https://marked.js.org   |https://github.com/markedjs/marked   |The marked committers                               |
+(In other words, while Admins are focused primarily on the internal workings of the project, Publishers are focused on internal *and* external concerns.)
 
-To be listed: All fields are optional. Contact any of the committers or, more timely, submit a pull request with the following (using the first row as an example):
+**Should not exceed 2:** Having more people with the authority to publish a release can quickly turn into a consensus seeking nightmare (design by committee). Having only one is preferred (Directly Responsible Individual); however, given the nature of the project and its history, having an immediate fallback, and a potential deep fallback (Original author) is probably a good idea.
 
-- **Individual or Organization:** The name you would like associated with the record.
-- **Website:** A URL to a standalone website for the project.
-- **Project:** A URL for the repository of the project using marked.
-- **Submitted by:** The name and optional honorifics for the person adding the listing.
+[Details on badges](#badges)
 
-To be removed: Same as above. Only instead of requesting addition request deletion or delete the row yourself.
+## Admins
 
-## Contributors
+Admins are committers who also have the responsibility, privilege, and burden of selecting committers and making sure the project itself runs smoothly, which includes community maintenance, governance, dispute resolution, and so on. (Letting the contributors easily enter into, and work within, the project to begin contributing, with as little friction as possible.)
 
-Contributors are users who submit a [PR](https://github.com/markedjs/marked/pulls), [Issue](https://github.com/markedjs/marked/issues), or collaborate in making Marked a better product and experience for all the users.
+**Should not exceed 3:** When there are too many people with the ability to reolves disputes, the dispute itself can quickly turn into a dispute amongst the admins themselves; therefore, we want this group to be small enough to commit to action and large enough to not put too much burden on one person. (Should ensure faster resolution and responsiveness.)
 
-To be listed: make a contribution and, if it has significant impact, the committers may be able to add you here.
+To be listed: Admins are usually selected from the pool of committers (or they volunteer, using the same process) who demonstrate good understanding of the marked culture, operations, and do their best to help new contributors get up to speed on how to contribute effectively to the project.
 
-To be removed: please let us know or submit a PR.
+To be removed: You can remove yourself through the [GitHub UI](https://help.github.com/articles/removing-yourself-from-a-collaborator-s-repository/).
 
 [Details on badges](#badges)
 
@@ -158,27 +153,32 @@ A note on volunteering:
 
 [Details on badges](#badges)
 
-## Admins
+## Contributors
 
-Admins are committers who also have the responsibility, privilege, and burden of selecting committers and making sure the project itself runs smoothly, which includes community maintenance, governance, dispute resolution, and so on. (Letting the contributors easily enter into, and work within, the project to begin contributing, with as little friction as possible.)
+Contributors are users who submit a [PR](https://github.com/markedjs/marked/pulls), [Issue](https://github.com/markedjs/marked/issues), or collaborate in making Marked a better product and experience for all the users.
 
-**Should not exceed 3:** When there are too many people with the ability to reolves disputes, the dispute itself can quickly turn into a dispute amongst the admins themselves; therefore, we want this group to be small enough to commit to action and large enough to not put too much burden on one person. (Should ensure faster resolution and responsiveness.)
+To be listed: make a contribution and, if it has significant impact, the committers may be able to add you here.
 
-To be listed: Admins are usually selected from the pool of committers (or they volunteer, using the same process) who demonstrate good understanding of the marked culture, operations, and do their best to help new contributors get up to speed on how to contribute effectively to the project.
-
-To be removed: You can remove yourself through the [GitHub UI](https://help.github.com/articles/removing-yourself-from-a-collaborator-s-repository/).
+To be removed: please let us know or submit a PR.
 
 [Details on badges](#badges)
 
-## Publishers
+## Users
 
-Publishers are admins who also have the responsibility, privilege, and burden of publishing the new releases to NPM and performing outreach and external stakeholder communications. Further, when things go pear-shaped, they're the ones taking most of the heat. Finally, when things go well, they're the primary ones praising the contributors who made it possible.
+Users are anyone using Marked in some fashion, without them, there's no reason for us to exist.
 
-(In other words, while Admins are focused primarily on the internal workings of the project, Publishers are focused on internal *and* external concerns.)
+|Individual or Organization |Website                 |Project                              |Submitted by                                        |
+|:--------------------------|:-----------------------|:------------------------------------|:---------------------------------------------------|
+|MarkedJS                   |https://marked.js.org   |https://github.com/markedjs/marked   |The marked committers                               |
 
-**Should not exceed 2:** Having more people with the authority to publish a release can quickly turn into a consensus seeking nightmare (design by committee). Having only one is preferred (Directly Responsible Individual); however, given the nature of the project and its history, having an immediate fallback, and a potential deep fallback (Original author) is probably a good idea.
+To be listed: All fields are optional. Contact any of the committers or, more timely, submit a pull request with the following (using the first row as an example):
 
-[Details on badges](#badges)
+- **Individual or Organization:** The name you would like associated with the record.
+- **Website:** A URL to a standalone website for the project.
+- **Project:** A URL for the repository of the project using marked.
+- **Submitted by:** The name and optional honorifics for the person adding the listing.
+
+To be removed: Same as above. Only instead of requesting addition request deletion or delete the row yourself.
 
 <h2 id="badges">Badges</h2>
 

--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -19,7 +19,7 @@ Marked takes an encompassing approach to its community. As such, you can think o
         <a href="https://github.com/joshbruce">Josh Bruce</a>
         <p>Publisher</p>
         <br>
-        <p>Release Wrangler</p>
+        <p>Release Wrangler; Humaning Helper; Heckler of Hypertext</p>
       </td>
       <td align="center" valign="top">
         <img width="150" height="150" src="https://github.com/styfle.png?s=150">
@@ -27,7 +27,7 @@ Marked takes an encompassing approach to its community. As such, you can think o
         <a href="https://github.com/styfle">Steven</a>
         <p>Admin</p>
         <br>
-        <p>Open source, of course and GitHub Guru</p>
+        <p>Open source, of course; GitHub Guru; Humaning Helper</p>
       </td>
     </tr>
   	<tr>
@@ -45,7 +45,7 @@ Marked takes an encompassing approach to its community. As such, you can think o
         <a href="https://github.com/UziTech">Tony Brix</a>
         <p>Committer</p>
         <br>
-        <p>Titan of the test harness and Dr. DevOps</p>
+        <p>Titan of the test harness; Dr. DevOps</p>
       </td>
       <td align="center" width="20%" valign="top">
         Placeholder
@@ -74,7 +74,7 @@ Marked takes an encompassing approach to its community. As such, you can think o
         <a href="https://github.com/Feder1co5oave">Federico Soave</a>
         <p>Contributor</p>
         <br>
-        <p>Regent of the Regex, Master of Marked</p>
+        <p>Regent of the Regex; Master of Marked</p>
       </td>
      </tr>
 	 <tr>

--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -53,13 +53,14 @@ Marked takes an encompassing approach to its community. As such, you can think o
         <small>Titan of the test harness; Dr. DevOps</small>
       </td>
       <td align="center" valign="top">
-        <img width="100" height="100" src="https://via.placeholder.com/150?text=This+could+be+you">
-        <br>
-        <a href="https://marked.js.org/#/CONTRIBUTING.md">This could be you!</a>
-        <div>Submit a Pull Request!</div>
-        <small>Become a committer</small>
+        &nbsp;
       </td>
     </tr>
+  </tbody>
+</table>
+
+<table>
+  <tbody>
     <tr>
       <td align="center" valign="top">
         <a href="https://github.com/intcreator">

--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -5,7 +5,7 @@ Marked takes an encompassing approach to its community. As such, you can think o
 <table>
   <tbody>
   	<tr>
-      <td align="center" valign="top">
+      <td align="center" valign="top" style="width:32%">
         <img width="150" height="150" src="https://github.com/chjj.png?s=150">
         <br>
         <a href="https://github.com/chjj">Christopher Jeffrey</a>
@@ -13,7 +13,7 @@ Marked takes an encompassing approach to its community. As such, you can think o
         <br>
         <small>Started the fire</small>
       </td>
-      <td align="center" valign="top">
+      <td align="center" valign="top" style="width:32%">
         <img width="150" height="150" src="https://github.com/joshbruce.png?s=150">
         <br>
         <a href="https://github.com/joshbruce">Josh Bruce</a>
@@ -21,7 +21,7 @@ Marked takes an encompassing approach to its community. As such, you can think o
         <br>
         <small>Release Wrangler; Humaning Helper; Heckler of Hypertext</small>
       </td>
-      <td align="center" valign="top">
+      <td align="center" valign="top" style="width:32%">
         <img width="150" height="150" src="https://github.com/styfle.png?s=150">
         <br>
         <a href="https://github.com/styfle">Steven</a>

--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -47,8 +47,13 @@ Marked takes an encompassing approach to its community. As such, you can think o
         <br>
         <p>Titan of the test harness; Dr. DevOps</p>
       </td>
-      <td align="center" width="20%" valign="top">
-        Placeholder
+      <td align="center" valign="top">
+        <img width="150" height="150" src="https://via.placeholder.com/150?text=This+could+be+you">
+        <br>
+        <a href="https://marked.js.org/#/CONTRIBUTING.md">This could be you!</a>
+        <p>Send a Pull Request</p>
+        <br>
+        <p>Become a committer</p>
       </td>
     </tr>
     <tr>

--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -7,126 +7,114 @@ Marked takes an encompassing approach to its community. As such, you can think o
   	<tr>
       <td align="center" valign="top" style="width:32%">
         <a href="https://github.com/chjj">
-          <img width="150" height="150" src="https://github.com/chjj.png?s=150">
+          <img width="100" height="100" src="https://github.com/chjj.png?s=150">
         </a>
         <br>
         <a href="https://github.com/chjj">Christopher Jeffrey</a>
-        <p>Original Author</p>
-        <br>
+        <div>Original Author</div>
         <small>Started the fire</small>
       </td>
       <td align="center" valign="top" style="width:32%">
         <a href="https://github.com/joshbruce">
-          <img width="150" height="150" src="https://github.com/joshbruce.png?s=150">
+          <img width="100" height="100" src="https://github.com/joshbruce.png?s=150">
         </a>
         <br>
         <a href="https://joshbruce.com">Josh Bruce</a>
-        <p>Publisher</p>
-        <br>
+        <div>Publisher</div>
         <small>Release Wrangler; Humaning Helper; Heckler of Hypertext</small>
       </td>
       <td align="center" valign="top" style="width:32%">
         <a href="https://github.com/styfle">
-          <img width="150" height="150" src="https://github.com/styfle.png?s=150">
+          <img width="100" height="100" src="https://github.com/styfle.png?s=150">
         </a>
         <br>
         <a href="https://www.ceriously.com">Steven</a>
-        <p>Admin</p>
-        <br>
+        <div>Admin</div>
         <small>Open source, of course; GitHub Guru; Humaning Helper</small>
       </td>
     </tr>
   	<tr>
       <td align="center" valign="top">
         <a href="https://github.com/davisjam">
-          <img width="150" height="150" src="https://github.com/davisjam.png?s=150">
+          <img width="100" height="100" src="https://github.com/davisjam.png?s=150">
         </a>
         <br>
         <a href="https://github.com/davisjam">Jamie Davis</a>
-        <p>Committer</p>
-        <br>
+        <div>Committer</div>
         <small>Seeker of Security</small>
       </td>
       <td align="center" valign="top">
         <a href="https://github.com/UziTech">
-          <img width="150" height="150" src="https://github.com/UziTech.png?s=150">
+          <img width="100" height="100" src="https://github.com/UziTech.png?s=150">
         </a>
         <br>
         <a href="https://tony.brix.ninja">Tony Brix</a>
-        <p>Committer</p>
-        <br>
+        <div>Committer</div>
         <small>Titan of the test harness; Dr. DevOps</small>
       </td>
       <td align="center" valign="top">
-        <img width="150" height="150" src="https://via.placeholder.com/150?text=This+could+be+you">
+        <img width="100" height="100" src="https://via.placeholder.com/150?text=This+could+be+you">
         <br>
         <a href="https://marked.js.org/#/CONTRIBUTING.md">This could be you!</a>
-        <p>Submit a Pull Request!</p>
-        <br>
+        <div>Submit a Pull Request!</div>
         <small>Become a committer</small>
       </td>
     </tr>
     <tr>
       <td align="center" valign="top">
         <a href="https://github.com/intcreator">
-          <img width="150" height="150" src="https://github.com/intcreator.png?s=150">
+          <img width="100" height="100" src="https://github.com/intcreator.png?s=150">
         </a>
         <br>
         <a href="https://github.com/intcreator">Brandon der Blätter</a>
-        <p>Contributor</p>
-        <br>
+        <div>Contributor</div>
         <small>Curious Contributor</small>
       </td>
       <td align="center" valign="top">
         <a href="https://github.com/carlosvalle">
-          <img width="150" height="150" src="https://github.com/carlosvalle.png?s=150">
+          <img width="100" height="100" src="https://github.com/carlosvalle.png?s=150">
         </a>
         <br>
         <a href="https://github.com/carlosvalle">Carlos Valle</a>
-        <p>Contributor</p>
-        <br>
+        <div>Contributor</div>
         <small>Maker of the Marked mark from 2018 to present</small>
       </td>
       <td align="center" width="20%" valign="top">
         <a href="https://github.com/Feder1co5oave">
-          <img width="150" height="150" src="https://github.com/Feder1co5oave.png?s=150">
+          <img width="100" height="100" src="https://github.com/Feder1co5oave.png?s=150">
         </a>
         <br>
         <a href="https://github.com/Feder1co5oave">Federico Soave</a>
-        <p>Contributor</p>
-        <br>
+        <div>Contributor</div>
         <small>Regent of the Regex; Master of Marked</small>
       </td>
      </tr>
 	 <tr>
       <td align="center" valign="top">
         <a href="https://github.com/karenyavine">
-          <img width="150" height="150" src="https://github.com/karenyavine.png?s=150">
+          <img width="100" height="100" src="https://github.com/karenyavine.png?s=150">
         </a>
         <br>
         <a href="https://github.com/karenyavine">Karen Yavine</a>
-        <p>Contributor</p>
-        <br>
+        <div>Contributor</div>
         <small>Snyk's Security Saint</small>
       </td>
       <td align="center" valign="top">
         <a href="https://github.com/KostyaTretyak">
-          <img width="150" height="150" src="https://github.com/KostyaTretyak.png?s=150">
+          <img width="100" height="100" src="https://github.com/KostyaTretyak.png?s=150">
         </a>
         <br>
         <a href="https://github.com/KostyaTretyak">Костя Третяк</a>
-        <p>Contributor</p>
-        <br>
+        <div>Contributor</div>
         <small></small>
       </td>
       <td align="center" width="20%" valign="top">
         <a href="https://github.com/tomtheisen">
-          <img width="150" height="150" src="https://github.com/tomtheisen.png?s=150">
+          <img width="100" height="100" src="https://github.com/tomtheisen.png?s=150">
         </a>
         <br>
         <a href="https://github.com/tomtheisen">Tom Theisen</a>
-        <p>Contributor</p>
-        <br>
+        <div>Contributor</div>
         <small>Defibrillator</small>
       </td>
      </tr>

--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -147,7 +147,7 @@ Publishers are admins who also have the responsibility, privilege, and burden of
 
 Admins are committers who also have the responsibility, privilege, and burden of selecting committers and making sure the project itself runs smoothly, which includes community maintenance, governance, dispute resolution, and so on. (Letting the contributors easily enter into, and work within, the project to begin contributing, with as little friction as possible.)
 
-**Should not exceed 3:** When there are too many people with the ability to reolves disputes, the dispute itself can quickly turn into a dispute amongst the admins themselves; therefore, we want this group to be small enough to commit to action and large enough to not put too much burden on one person. (Should ensure faster resolution and responsiveness.)
+**Should not exceed 3:** When there are too many people with the ability to resolve disputes, the dispute itself can quickly turn into a dispute amongst the admins themselves; therefore, we want this group to be small enough to commit to action and large enough to not put too much burden on one person. (Should ensure faster resolution and responsiveness.)
 
 To be listed: Admins are usually selected from the pool of committers (or they volunteer, using the same process) who demonstrate good understanding of the marked culture, operations, and do their best to help new contributors get up to speed on how to contribute effectively to the project.
 

--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -2,6 +2,110 @@
 
 Marked takes an encompassing approach to its community. As such, you can think of these as [concentric circles](https://medium.com/the-node-js-collection/healthy-open-source-967fa8be7951), where each subsequent group is enveloped by the previous one.
 
+<table>
+  <tbody>
+  	<tr>
+      <td align="center" valign="top">
+        <img width="150" height="150" src="https://github.com/chjj.png?s=150">
+        <br>
+        <a href="https://github.com/chjj">Christopher Jeffrey</a>
+        <p>Original Author</p>
+        <br>
+        <p>Started the fire</p>
+      </td>
+      <td align="center" valign="top">
+        <img width="150" height="150" src="https://github.com/joshbruce.png?s=150">
+        <br>
+        <a href="https://github.com/joshbruce">Josh Bruce</a>
+        <p>Publisher</p>
+        <br>
+        <p>Release Wrangler</p>
+      </td>
+      <td align="center" valign="top">
+        <img width="150" height="150" src="https://github.com/styfle.png?s=150">
+        <br>
+        <a href="https://github.com/styfle">Steven</a>
+        <p>Admin</p>
+        <br>
+        <p>Open source, of course and GitHub Guru</p>
+      </td>
+    </tr>
+  	<tr>
+      <td align="center" valign="top">
+        <img width="150" height="150" src="https://github.com/davisjam.png?s=150">
+        <br>
+        <a href="https://github.com/davisjam">Jamie Davis</a>
+        <p>Committer</p>
+        <br>
+        <p>Seeker of Security</p>
+      </td>
+      <td align="center" valign="top">
+        <img width="150" height="150" src="https://github.com/UziTech.png?s=150">
+        <br>
+        <a href="https://github.com/UziTech">Tony Brix</a>
+        <p>Committer</p>
+        <br>
+        <p>Titan of the test harness and Dr. DevOps</p>
+      </td>
+      <td align="center" width="20%" valign="top">
+        Placeholder
+      </td>
+    </tr>
+    <tr>
+      <td align="center" valign="top">
+        <img width="150" height="150" src="https://github.com/intcreator.png?s=150">
+        <br>
+        <a href="https://github.com/intcreator">Brandon der Blätter</a>
+        <p>Contributor</p>
+        <br>
+        <p>Curious Contributor</p>
+      </td>
+      <td align="center" valign="top">
+        <img width="150" height="150" src="https://github.com/carlosvalle.png?s=150">
+        <br>
+        <a href="https://github.com/carlosvalle">Carlos Valle</a>
+        <p>Contributor</p>
+        <br>
+        <p>Maker of the Marked mark from 2018 to present</p>
+      </td>
+      <td align="center" width="20%" valign="top">
+        <img width="150" height="150" src="https://github.com/Feder1co5oave.png?s=150">
+        <br>
+        <a href="https://github.com/Feder1co5oave">Federico Soave</a>
+        <p>Contributor</p>
+        <br>
+        <p>Regent of the Regex, Master of Marked</p>
+      </td>
+     </tr>
+	 <tr>
+      <td align="center" valign="top">
+        <img width="150" height="150" src="https://github.com/karenyavine.png?s=150">
+        <br>
+        <a href="https://github.com/karenyavine">Karen Yavine</a>
+        <p>Contributor</p>
+        <br>
+        <p>Snyk's Security Saint</p>
+      </td>
+      <td align="center" valign="top">
+        <img width="150" height="150" src="https://github.com/KostyaTretyak.png?s=150">
+        <br>
+        <a href="https://github.com/KostyaTretyak">Костя Третяк</a>
+        <p>Contributor</p>
+        <br>
+        <p></p>
+      </td>
+      <td align="center" width="20%" valign="top">
+        <img width="150" height="150" src="https://github.com/tomtheisen.png?s=150">
+        <br>
+        <a href="https://github.com/tomtheisen">Tom Theisen</a>
+        <p>Contributor</p>
+        <br>
+        <p>Defibrillator</p>
+      </td>
+     </tr>
+  </tbody>
+</table>
+
 ## Users
 
 Users are anyone using Marked in some fashion, without them, there's no reason for us to exist.
@@ -23,15 +127,6 @@ To be removed: Same as above. Only instead of requesting addition request deleti
 
 Contributors are users who submit a [PR](https://github.com/markedjs/marked/pulls), [Issue](https://github.com/markedjs/marked/issues), or collaborate in making Marked a better product and experience for all the users.
 
-|Name                |GitHub handle    |Badge of honor                                |
-|:-------------------|:----------------|:---------------------------------------------|
-|Brandon der Blätter |@intcreator      |Curious Contributor                           |
-|Carlos Valle        |@carlosvalle     |Maker of the Marked mark from 2018 to present |
-|Federico Soave      |@Feder1co5oave   |Regent of the Regex, Master of Marked         |
-|Karen Yavine        |@karenyavine     |Snyk's Security Saint                         |
-|Костя Третяк        |@KostyaTretyak   |--                                            |
-|Tom Theisen         |@tomtheisen      |Defibrillator                                 |
-
 To be listed: make a contribution and, if it has significant impact, the committers may be able to add you here.
 
 To be removed: please let us know or submit a PR.
@@ -43,11 +138,6 @@ To be removed: please let us know or submit a PR.
 Committers are contributors who also have the responsibility, privilege, some might even say burden of being able to review and merge contributions (just usually not their own).
 
 A note on "decision making authority". This is related to submitting PRs and the [advice process](http://www.reinventingorganizationswiki.com/Decision_Making). The person marked as having decision making authority over a certain area should be sought for advice in that area before committing to a course of action.
-
-|Name           |GitHub handle   |Decision making                          |Badges of honor (tag for questions)  |
-|:--------------|:---------------|:----------------------------------------|:------------------------------------|
-|Jamie Davis    |@davisjam       |Seeker of Security                       |                                     |
-|Tony Brix      |@UziTech        |Titan of the test harness and Dr. DevOps |                                     |
 
 **Should not exceed 5:** For larger PRs affecting more of the codebase and, most likely, review by more people, we try to keep this pool small and responsive and let those with decision making authority have final say without negative repercussions from the other committers.
 
@@ -67,10 +157,6 @@ A note on volunteering:
 
 Admins are committers who also have the responsibility, privilege, and burden of selecting committers and making sure the project itself runs smoothly, which includes community maintenance, governance, dispute resolution, and so on. (Letting the contributors easily enter into, and work within, the project to begin contributing, with as little friction as possible.)
 
-|Name           |GitHub handle   |Decision making                          |Badges of honor (tag for questions)  |
-|:--------------|:---------------|:----------------------------------------|:------------------------------------|
-|Steven         |@styfle         |Open source, of course and GitHub Guru   |Humaning Helper                      |
-
 **Should not exceed 3:** When there are too many people with the ability to reolves disputes, the dispute itself can quickly turn into a dispute amongst the admins themselves; therefore, we want this group to be small enough to commit to action and large enough to not put too much burden on one person. (Should ensure faster resolution and responsiveness.)
 
 To be listed: Admins are usually selected from the pool of committers (or they volunteer, using the same process) who demonstrate good understanding of the marked culture, operations, and do their best to help new contributors get up to speed on how to contribute effectively to the project.
@@ -85,19 +171,9 @@ Publishers are admins who also have the responsibility, privilege, and burden of
 
 (In other words, while Admins are focused primarily on the internal workings of the project, Publishers are focused on internal *and* external concerns.)
 
-|Name       |GitHub handle  |Decision making          |Badges of honor (tag for questions)   |
-|:----------|:--------------|:------------------------|:-------------------------------------|
-|Josh Bruce |@joshbruce     |Release Wrangler         |Humaning Helper, Heckler of Hypertext |
-
 **Should not exceed 2:** Having more people with the authority to publish a release can quickly turn into a consensus seeking nightmare (design by committee). Having only one is preferred (Directly Responsible Individual); however, given the nature of the project and its history, having an immediate fallback, and a potential deep fallback (Original author) is probably a good idea.
 
 [Details on badges](#badges)
-
-## Original author
-
-The original author is the publisher who started it all.
-
-Christopher Jeffrey @chjj
 
 <h2 id="badges">Badges</h2>
 

--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -6,7 +6,9 @@ Marked takes an encompassing approach to its community. As such, you can think o
   <tbody>
   	<tr>
       <td align="center" valign="top" style="width:32%">
-        <img width="150" height="150" src="https://github.com/chjj.png?s=150">
+        <a href="https://github.com/chjj">
+          <img width="150" height="150" src="https://github.com/chjj.png?s=150">
+        </a>
         <br>
         <a href="https://github.com/chjj">Christopher Jeffrey</a>
         <p>Original Author</p>
@@ -14,17 +16,21 @@ Marked takes an encompassing approach to its community. As such, you can think o
         <small>Started the fire</small>
       </td>
       <td align="center" valign="top" style="width:32%">
-        <img width="150" height="150" src="https://github.com/joshbruce.png?s=150">
+        <a href="https://github.com/joshbruce">
+          <img width="150" height="150" src="https://github.com/joshbruce.png?s=150">
+        </a>
         <br>
-        <a href="https://github.com/joshbruce">Josh Bruce</a>
+        <a href="https://joshbruce.com">Josh Bruce</a>
         <p>Publisher</p>
         <br>
         <small>Release Wrangler; Humaning Helper; Heckler of Hypertext</small>
       </td>
       <td align="center" valign="top" style="width:32%">
-        <img width="150" height="150" src="https://github.com/styfle.png?s=150">
+        <a href="https://github.com/styfle">
+          <img width="150" height="150" src="https://github.com/styfle.png?s=150">
+        </a>
         <br>
-        <a href="https://github.com/styfle">Steven</a>
+        <a href="https://www.ceriously.com">Steven</a>
         <p>Admin</p>
         <br>
         <small>Open source, of course; GitHub Guru; Humaning Helper</small>
@@ -32,7 +38,9 @@ Marked takes an encompassing approach to its community. As such, you can think o
     </tr>
   	<tr>
       <td align="center" valign="top">
-        <img width="150" height="150" src="https://github.com/davisjam.png?s=150">
+        <a href="https://github.com/davisjam">
+          <img width="150" height="150" src="https://github.com/davisjam.png?s=150">
+        </a>
         <br>
         <a href="https://github.com/davisjam">Jamie Davis</a>
         <p>Committer</p>
@@ -40,9 +48,11 @@ Marked takes an encompassing approach to its community. As such, you can think o
         <small>Seeker of Security</small>
       </td>
       <td align="center" valign="top">
-        <img width="150" height="150" src="https://github.com/UziTech.png?s=150">
+        <a href="https://github.com/UziTech">
+          <img width="150" height="150" src="https://github.com/UziTech.png?s=150">
+        </a>
         <br>
-        <a href="https://github.com/UziTech">Tony Brix</a>
+        <a href="https://tony.brix.ninja">Tony Brix</a>
         <p>Committer</p>
         <br>
         <small>Titan of the test harness; Dr. DevOps</small>
@@ -58,7 +68,9 @@ Marked takes an encompassing approach to its community. As such, you can think o
     </tr>
     <tr>
       <td align="center" valign="top">
-        <img width="150" height="150" src="https://github.com/intcreator.png?s=150">
+        <a href="https://github.com/intcreator">
+          <img width="150" height="150" src="https://github.com/intcreator.png?s=150">
+        </a>
         <br>
         <a href="https://github.com/intcreator">Brandon der Blätter</a>
         <p>Contributor</p>
@@ -66,7 +78,9 @@ Marked takes an encompassing approach to its community. As such, you can think o
         <small>Curious Contributor</small>
       </td>
       <td align="center" valign="top">
-        <img width="150" height="150" src="https://github.com/carlosvalle.png?s=150">
+        <a href="https://github.com/carlosvalle">
+          <img width="150" height="150" src="https://github.com/carlosvalle.png?s=150">
+        </a>
         <br>
         <a href="https://github.com/carlosvalle">Carlos Valle</a>
         <p>Contributor</p>
@@ -74,7 +88,9 @@ Marked takes an encompassing approach to its community. As such, you can think o
         <small>Maker of the Marked mark from 2018 to present</small>
       </td>
       <td align="center" width="20%" valign="top">
-        <img width="150" height="150" src="https://github.com/Feder1co5oave.png?s=150">
+        <a href="https://github.com/Feder1co5oave">
+          <img width="150" height="150" src="https://github.com/Feder1co5oave.png?s=150">
+        </a>
         <br>
         <a href="https://github.com/Feder1co5oave">Federico Soave</a>
         <p>Contributor</p>
@@ -84,7 +100,9 @@ Marked takes an encompassing approach to its community. As such, you can think o
      </tr>
 	 <tr>
       <td align="center" valign="top">
-        <img width="150" height="150" src="https://github.com/karenyavine.png?s=150">
+        <a href="https://github.com/karenyavine">
+          <img width="150" height="150" src="https://github.com/karenyavine.png?s=150">
+        </a>
         <br>
         <a href="https://github.com/karenyavine">Karen Yavine</a>
         <p>Contributor</p>
@@ -92,7 +110,9 @@ Marked takes an encompassing approach to its community. As such, you can think o
         <small>Snyk's Security Saint</small>
       </td>
       <td align="center" valign="top">
-        <img width="150" height="150" src="https://github.com/KostyaTretyak.png?s=150">
+        <a href="https://github.com/KostyaTretyak">
+          <img width="150" height="150" src="https://github.com/KostyaTretyak.png?s=150">
+        </a>
         <br>
         <a href="https://github.com/KostyaTretyak">Костя Третяк</a>
         <p>Contributor</p>
@@ -100,7 +120,9 @@ Marked takes an encompassing approach to its community. As such, you can think o
         <small></small>
       </td>
       <td align="center" width="20%" valign="top">
-        <img width="150" height="150" src="https://github.com/tomtheisen.png?s=150">
+        <a href="https://github.com/tomtheisen">
+          <img width="150" height="150" src="https://github.com/tomtheisen.png?s=150">
+        </a>
         <br>
         <a href="https://github.com/tomtheisen">Tom Theisen</a>
         <p>Contributor</p>

--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -11,7 +11,7 @@ Marked takes an encompassing approach to its community. As such, you can think o
         <a href="https://github.com/chjj">Christopher Jeffrey</a>
         <p>Original Author</p>
         <br>
-        <p>Started the fire</p>
+        <small>Started the fire</small>
       </td>
       <td align="center" valign="top">
         <img width="150" height="150" src="https://github.com/joshbruce.png?s=150">
@@ -19,7 +19,7 @@ Marked takes an encompassing approach to its community. As such, you can think o
         <a href="https://github.com/joshbruce">Josh Bruce</a>
         <p>Publisher</p>
         <br>
-        <p>Release Wrangler; Humaning Helper; Heckler of Hypertext</p>
+        <small>Release Wrangler; Humaning Helper; Heckler of Hypertext</small>
       </td>
       <td align="center" valign="top">
         <img width="150" height="150" src="https://github.com/styfle.png?s=150">
@@ -27,7 +27,7 @@ Marked takes an encompassing approach to its community. As such, you can think o
         <a href="https://github.com/styfle">Steven</a>
         <p>Admin</p>
         <br>
-        <p>Open source, of course; GitHub Guru; Humaning Helper</p>
+        <small>Open source, of course; GitHub Guru; Humaning Helper</small>
       </td>
     </tr>
   	<tr>
@@ -37,7 +37,7 @@ Marked takes an encompassing approach to its community. As such, you can think o
         <a href="https://github.com/davisjam">Jamie Davis</a>
         <p>Committer</p>
         <br>
-        <p>Seeker of Security</p>
+        <small>Seeker of Security</small>
       </td>
       <td align="center" valign="top">
         <img width="150" height="150" src="https://github.com/UziTech.png?s=150">
@@ -45,15 +45,15 @@ Marked takes an encompassing approach to its community. As such, you can think o
         <a href="https://github.com/UziTech">Tony Brix</a>
         <p>Committer</p>
         <br>
-        <p>Titan of the test harness; Dr. DevOps</p>
+        <small>Titan of the test harness; Dr. DevOps</small>
       </td>
       <td align="center" valign="top">
         <img width="150" height="150" src="https://via.placeholder.com/150?text=This+could+be+you">
         <br>
         <a href="https://marked.js.org/#/CONTRIBUTING.md">This could be you!</a>
-        <p>Send a Pull Request</p>
+        <p>Submit a Pull Request!</p>
         <br>
-        <p>Become a committer</p>
+        <small>Become a committer</small>
       </td>
     </tr>
     <tr>
@@ -63,7 +63,7 @@ Marked takes an encompassing approach to its community. As such, you can think o
         <a href="https://github.com/intcreator">Brandon der Blätter</a>
         <p>Contributor</p>
         <br>
-        <p>Curious Contributor</p>
+        <small>Curious Contributor</small>
       </td>
       <td align="center" valign="top">
         <img width="150" height="150" src="https://github.com/carlosvalle.png?s=150">
@@ -71,7 +71,7 @@ Marked takes an encompassing approach to its community. As such, you can think o
         <a href="https://github.com/carlosvalle">Carlos Valle</a>
         <p>Contributor</p>
         <br>
-        <p>Maker of the Marked mark from 2018 to present</p>
+        <small>Maker of the Marked mark from 2018 to present</small>
       </td>
       <td align="center" width="20%" valign="top">
         <img width="150" height="150" src="https://github.com/Feder1co5oave.png?s=150">
@@ -79,7 +79,7 @@ Marked takes an encompassing approach to its community. As such, you can think o
         <a href="https://github.com/Feder1co5oave">Federico Soave</a>
         <p>Contributor</p>
         <br>
-        <p>Regent of the Regex; Master of Marked</p>
+        <small>Regent of the Regex; Master of Marked</small>
       </td>
      </tr>
 	 <tr>
@@ -89,7 +89,7 @@ Marked takes an encompassing approach to its community. As such, you can think o
         <a href="https://github.com/karenyavine">Karen Yavine</a>
         <p>Contributor</p>
         <br>
-        <p>Snyk's Security Saint</p>
+        <small>Snyk's Security Saint</small>
       </td>
       <td align="center" valign="top">
         <img width="150" height="150" src="https://github.com/KostyaTretyak.png?s=150">
@@ -97,7 +97,7 @@ Marked takes an encompassing approach to its community. As such, you can think o
         <a href="https://github.com/KostyaTretyak">Костя Третяк</a>
         <p>Contributor</p>
         <br>
-        <p></p>
+        <small></small>
       </td>
       <td align="center" width="20%" valign="top">
         <img width="150" height="150" src="https://github.com/tomtheisen.png?s=150">
@@ -105,7 +105,7 @@ Marked takes an encompassing approach to its community. As such, you can think o
         <a href="https://github.com/tomtheisen">Tom Theisen</a>
         <p>Contributor</p>
         <br>
-        <p>Defibrillator</p>
+        <small>Defibrillator</small>
       </td>
      </tr>
   </tbody>


### PR DESCRIPTION
## Description

This changes `AUTHORS.md` file so that contributor profile images are visible and also changes the order listed from most privileged to least privileged. Also the table format is a little different so that there are no columns.

This follows the format of other large open source projects such as:

- [Webpack](https://github.com/webpack/webpack/blob/master/README.md#core-team) Core Team
- [Ava](https://github.com/avajs/ava/blob/master/readme.md#team) Team
- [XO](https://github.com/xojs/xo/blob/master/readme.md#team) Team

## Screenshot

![image](https://user-images.githubusercontent.com/229881/40026282-bb97a49c-57a2-11e8-9118-cd4515dba6c3.png)


## Contributor

- [x] no tests required for this PR.

## Committer

In most cases, this should be a different person than the contributor.

- [x] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [x] Merge PR
