### PR TITLE
fix gfm extended autolinking requiring multiple backpedals

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -655,7 +655,8 @@ InlineLexer.prototype.output = function(src) {
       text,
       href,
       title,
-      cap;
+      cap,
+      prevCapZero;
 
   while (src) {
     // escape
@@ -681,7 +682,10 @@ InlineLexer.prototype.output = function(src) {
 
     // url (gfm)
     if (!this.inLink && (cap = this.rules.url.exec(src))) {
-      cap[0] = this.rules._backpedal.exec(cap[0])[0];
+      do {
+        prevCapZero = cap[0];
+        cap[0] = this.rules._backpedal.exec(cap[0])[0];
+      } while (prevCapZero !== cap[0]);
       src = src.substring(cap[0].length);
       if (cap[2] === '@') {
         text = escape(cap[0]);

--- a/test/specs/marked/marked-spec.js
+++ b/test/specs/marked/marked-spec.js
@@ -35,7 +35,6 @@ var messenger = new Messenger();
 describe('Marked Autolinks', function() {
   var section = 'Autolinks';
 
-  // var shouldPassButFails = [];
   var shouldPassButFails = [];
 
   var willNotBeAttemptedByCoreTeam = [];
@@ -50,7 +49,6 @@ describe('Marked Autolinks', function() {
 describe('Marked Code spans', function() {
   var section = 'Code spans';
 
-  // var shouldPassButFails = [];
   var shouldPassButFails = [1];
 
   var willNotBeAttemptedByCoreTeam = [];
@@ -65,7 +63,6 @@ describe('Marked Code spans', function() {
 describe('Marked Table cells', function() {
   var section = 'Table cells';
 
-  // var shouldPassButFails = [];
   var shouldPassButFails = [];
 
   var willNotBeAttemptedByCoreTeam = [];

--- a/test/specs/marked/marked-spec.js
+++ b/test/specs/marked/marked-spec.js
@@ -32,6 +32,21 @@ Messenger.prototype.test = function(spec, section, ignore) {
 
 var messenger = new Messenger();
 
+describe('Marked Autolinks', function() {
+  var section = 'Autolinks';
+
+  // var shouldPassButFails = [];
+  var shouldPassButFails = [];
+
+  var willNotBeAttemptedByCoreTeam = [];
+
+  var ignore = shouldPassButFails.concat(willNotBeAttemptedByCoreTeam);
+
+  markedSpec.forEach(function(spec) {
+    messenger.test(spec, section, ignore);
+  });
+});
+
 describe('Marked Code spans', function() {
   var section = 'Code spans';
 

--- a/test/specs/marked/marked.json
+++ b/test/specs/marked/marked.json
@@ -6,6 +6,18 @@
     "example": 10
   },
   {
+    "section": "Autolinks",
+    "markdown": "((http://foo.com))",
+    "html": "<p>((<a href=\"http://foo.com\">http://foo.com</a>))</p>",
+    "example": 11
+  },
+  {
+    "section": "Autolinks",
+    "markdown": "((http://foo.com.))",
+    "html": "<p>((<a href=\"http://foo.com\">http://foo.com</a>.))</p>",
+    "example": 12
+  },
+  {
     "section": "Code spans",
     "markdown": "`someone@example.com`",
     "html": "<p><code>someone@example.com</code></p>",

--- a/test/specs/marked/marked.json
+++ b/test/specs/marked/marked.json
@@ -1,5 +1,11 @@
 [
   {
+    "section": "Autolinks",
+    "markdown": "(See https://www.example.com/fhqwhgads.)",
+    "html": "<p>(See <a href=\"https://www.example.com/fhqwhgads\">https://www.example.com/fhqwhgads</a>.)</p>",
+    "example": 10
+  },
+  {
     "section": "Code spans",
     "markdown": "`someone@example.com`",
     "html": "<p><code>someone@example.com</code></p>",


### PR DESCRIPTION
**Marked version:**

<!-- The NPM version or commit hash having the issue -->
0.4.0

**Markdown flavor:**

GitHub Flavored Markdown

## Description

Add a test and fix that trailing punctuation is omitted in link URLs for
markdown like this:

```markdown
(See https://www.example.com/fhqwhgads.)
```

The trailing period and closing parenthesis should not be part of the
link URL.

## Expectation

```html
<p>(See <a href="https://www.example.com/fhqwhgads">https://www.example.com/fhqwhgads</a>.)</p>
```

## Result

```html
<p>(See <a href="https://www.example.com/fhqwhgads.">https://www.example.com/fhqwhgads.</a>)</p>
```

Note that the trailing period is included as part of the URL. That's the bug.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
