### PR TITLE
fix issues link references and prototypes

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -135,7 +135,7 @@ block.pedantic = merge({}, block.normal, {
 
 function Lexer(options) {
   this.tokens = [];
-  this.tokens.links = {};
+  this.tokens.links = Object.create(null);
   this.options = options || marked.defaults;
   this.rules = block.normal;
 

--- a/test/specs/marked/marked-spec.js
+++ b/test/specs/marked/marked-spec.js
@@ -47,6 +47,20 @@ describe('Marked Code spans', function() {
   });
 });
 
+describe('Marked Links', function() {
+  var section = 'Links';
+
+  var shouldPassButFails = [];
+
+  var willNotBeAttemptedByCoreTeam = [];
+
+  var ignore = shouldPassButFails.concat(willNotBeAttemptedByCoreTeam);
+
+  markedSpec.forEach(function(spec) {
+    messenger.test(spec, section, ignore);
+  });
+});
+
 describe('Marked Table cells', function() {
   var section = 'Table cells';
 

--- a/test/specs/marked/marked.json
+++ b/test/specs/marked/marked.json
@@ -52,5 +52,11 @@
     "markdown": "|1|2|\n|-|-|\n| |2|",
     "html": "<table><thead><tr><th>1</th><th>2</th></tr></thead><tbody><tr><td></td><td>2</td></tr></tbody></table>",
     "example": 9
+  },
+  {
+    "section": "Links",
+    "markdown": "Link: [constructor][].\n\n[constructor]: https://example.org/",
+    "html": "<p>Link: <a href=\"https://example.org/\">constructor</a>.</p>",
+    "example": 10
   }
 ]


### PR DESCRIPTION
<!--

	If release PR, add ?template=release.md to the PR url to use the release PR template.

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->

**Marked version:** 0.4.0

<!-- The NPM version or commit hash having the issue -->

**Markdown flavor:** Markdown.pl

## Description

Link with names that clashed with properties inherited from the
Object prototype (such as "constructor") were not expanding. This fixes
this issue.

Before this change, markdown of this form...:

    Link: [constructor][].

    [constructor]: https://example.org/

...resulted in HTML output of this form:

    <p>Link: [constructor][].</p>

With this change, it now renders as expected:

    <p>Link: <a href="https://example.org/">constructor</a>.</p>


## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
