### PR TITLE
Change badge to latest version of marked

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # Marked
 
 [![npm](https://img.shields.io/npm/v/marked.svg)](https://www.npmjs.com/package/marked)
-[![gzip size](http://img.badgesize.io/https://cdn.jsdelivr.net/npm/marked@0.3.19/marked.min.js?compression=gzip)](https://cdn.jsdelivr.net/npm/marked@0.3.19/marked.min.js)
+[![gzip size](http://img.badgesize.io/https://cdn.jsdelivr.net/npm/marked/marked.min.js?compression=gzip)](https://cdn.jsdelivr.net/npm/marked/marked.min.js)
 [![install size](https://packagephobia.now.sh/badge?p=marked)](https://packagephobia.now.sh/result?p=marked)
 [![downloads](https://img.shields.io/npm/dt/marked.svg)](https://www.npmjs.com/package/marked)
 [![travis](https://travis-ci.org/markedjs/marked.svg?branch=master)](https://travis-ci.org/markedjs/marked)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![npm](https://img.shields.io/npm/v/marked.svg)](https://www.npmjs.com/package/marked)
 [![gzip size](http://img.badgesize.io/https://cdn.jsdelivr.net/npm/marked@0.3.19/marked.min.js?compression=gzip)](https://cdn.jsdelivr.net/npm/marked@0.3.19/marked.min.js)
-[![install size](https://packagephobia.now.sh/badge?p=marked@0.3.19)](https://packagephobia.now.sh/result?p=marked@0.3.19)
+[![install size](https://packagephobia.now.sh/badge?p=marked)](https://packagephobia.now.sh/result?p=marked)
 [![downloads](https://img.shields.io/npm/dt/marked.svg)](https://www.npmjs.com/package/marked)
 [![travis](https://travis-ci.org/markedjs/marked.svg?branch=master)](https://travis-ci.org/markedjs/marked)
 


### PR DESCRIPTION
## Description

This changes the "install size" badge so it's always pointing to the latest version of marked.

## Contributor

- [x] no tests required for this PR.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
