### PR TITLE
Change badges from shields.io to badgen.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 # Marked
 
-[![npm](https://img.shields.io/npm/v/marked.svg)](https://www.npmjs.com/package/marked)
+[![npm](https://badgen.net/npm/v/marked)](https://www.npmjs.com/package/marked)
 [![gzip size](http://img.badgesize.io/https://cdn.jsdelivr.net/npm/marked/marked.min.js?compression=gzip)](https://cdn.jsdelivr.net/npm/marked/marked.min.js)
 [![install size](https://packagephobia.now.sh/badge?p=marked)](https://packagephobia.now.sh/result?p=marked)
-[![downloads](https://img.shields.io/npm/dt/marked.svg)](https://www.npmjs.com/package/marked)
-[![travis](https://travis-ci.org/markedjs/marked.svg?branch=master)](https://travis-ci.org/markedjs/marked)
+[![downloads](https://badgen.net/npm/dt/marked)](https://www.npmjs.com/package/marked)
+[![travis](https://badgen.net/travis/markedjs/marked)](https://travis-ci.org/markedjs/marked)
 
 - ⚡ built for speed
 - ⬇️ low-level compiler for parsing markdown without caching or blocking for long periods of time

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![npm](https://badgen.net/npm/v/marked)](https://www.npmjs.com/package/marked)
 [![gzip size](http://img.badgesize.io/https://cdn.jsdelivr.net/npm/marked/marked.min.js?compression=gzip)](https://cdn.jsdelivr.net/npm/marked/marked.min.js)
-[![install size](https://packagephobia.now.sh/badge?p=marked)](https://packagephobia.now.sh/result?p=marked)
+[![install size](https://badgen.net/packagephobia/install/marked)](https://packagephobia.now.sh/result?p=marked)
 [![downloads](https://badgen.net/npm/dt/marked)](https://www.npmjs.com/package/marked)
 [![travis](https://badgen.net/travis/markedjs/marked)](https://travis-ci.org/markedjs/marked)
 


### PR DESCRIPTION
## Description

Sometimes, shields is overloaded and the images don't load.
This switches the badges to render with badgen so that the badges will be more reliable.

There is no visible change here, just speed/reliability.

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [x] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [x] Merge PR
