### PR TITLE
Add dependency badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [![gzip size](https://badgen.net/badgesize/gzip/https://cdn.jsdelivr.net/npm/marked/marked.min.js)](https://cdn.jsdelivr.net/npm/marked/marked.min.js)
 [![install size](https://badgen.net/packagephobia/install/marked)](https://packagephobia.now.sh/result?p=marked)
 [![downloads](https://badgen.net/npm/dt/marked)](https://www.npmjs.com/package/marked)
-[![dep](https://badgen.net/david/dep/markedjs/marked)](https://david-dm.org/styfle/marked)
-[![dev dep](https://badgen.net/david/dev/markedjs/marked)](https://david-dm.org/styfle/marked?type=dev)
+[![dep](https://badgen.net/david/dep/markedjs/marked)](https://david-dm.org/markedjs/marked)
+[![dev dep](https://badgen.net/david/dev/markedjs/marked)](https://david-dm.org/markedjs/marked?type=dev)
 [![travis](https://badgen.net/travis/markedjs/marked)](https://travis-ci.org/markedjs/marked)
 
 - ⚡ built for speed

--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@
 # Marked
 
 [![npm](https://badgen.net/npm/v/marked)](https://www.npmjs.com/package/marked)
-[![gzip size](http://img.badgesize.io/https://cdn.jsdelivr.net/npm/marked/marked.min.js?compression=gzip)](https://cdn.jsdelivr.net/npm/marked/marked.min.js)
+[![gzip size](https://badgen.net/badgesize/gzip/https://cdn.jsdelivr.net/npm/marked/marked.min.js)](https://cdn.jsdelivr.net/npm/marked/marked.min.js)
 [![install size](https://badgen.net/packagephobia/install/marked)](https://packagephobia.now.sh/result?p=marked)
 [![downloads](https://badgen.net/npm/dt/marked)](https://www.npmjs.com/package/marked)
+[![dep](https://badgen.net/david/dep/markedjs/marked)](https://david-dm.org/styfle/marked)
+[![dev dep](https://badgen.net/david/dev/markedjs/marked)](https://david-dm.org/styfle/marked?type=dev)
 [![travis](https://badgen.net/travis/markedjs/marked)](https://travis-ci.org/markedjs/marked)
 
 - ⚡ built for speed


### PR DESCRIPTION
## Description

This PR adds a couple badges to show out of date dependencies (none) and dev dependencies.

I also updated the gzip size badge to use badgen.net for consistency.

Fixes #1330

![image](https://user-images.githubusercontent.com/229881/45775311-60dd7600-bc1d-11e8-920e-3abecd29372c.png)


## Contributor

- [x] no tests required for this PR.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
