### PR TITLE
Fix typographic substitution in (pre|code|kbd|script) blocks when smartypants=true

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -730,6 +730,14 @@ InlineLexer.prototype.output = function(src) {
       } else if (this.inLink && /^<\/a>/i.test(cap[0])) {
         this.inLink = false;
       }
+      if (!this.inRawBlock
+          && /^<pre|^<code|^<kbd|^<script/i.test(cap[0])) {
+        this.inRawBlock = true;
+      } else if (this.inRawBlock
+          && /^<\/pre>|^<\/code>|^<\/kbd>|^<\/script>/i.test(cap[0])) {
+        this.inRawBlock = false;
+      }
+
       src = src.substring(cap[0].length);
       out += this.options.sanitize
         ? this.options.sanitizer
@@ -820,7 +828,11 @@ InlineLexer.prototype.output = function(src) {
     // text
     if (cap = this.rules.text.exec(src)) {
       src = src.substring(cap[0].length);
-      out += this.renderer.text(escape(this.smartypants(cap[0])));
+      if (this.inRawBlock) {
+        out += this.renderer.text(cap[0]);
+      } else {
+        out += this.renderer.text(escape(this.smartypants(cap[0])));
+      }
       continue;
     }
 

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -731,10 +731,10 @@ InlineLexer.prototype.output = function(src) {
         this.inLink = false;
       }
       if (!this.inRawBlock
-          && /^<pre|^<code|^<kbd|^<script/i.test(cap[0])) {
+          && /^<(pre|code|kbd|script)/i.test(cap[0])) {
         this.inRawBlock = true;
       } else if (this.inRawBlock
-          && /^<\/pre>|^<\/code>|^<\/kbd>|^<\/script>/i.test(cap[0])) {
+          && /^<\/(pre|code|kbd|script)>/i.test(cap[0])) {
         this.inRawBlock = false;
       }
 

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -730,11 +730,9 @@ InlineLexer.prototype.output = function(src) {
       } else if (this.inLink && /^<\/a>/i.test(cap[0])) {
         this.inLink = false;
       }
-      if (!this.inRawBlock
-          && /^<(pre|code|kbd|script)/i.test(cap[0])) {
+      if (!this.inRawBlock && /^<(pre|code|kbd|script)(\s|>)/i.test(cap[0])) {
         this.inRawBlock = true;
-      } else if (this.inRawBlock
-          && /^<\/(pre|code|kbd|script)>/i.test(cap[0])) {
+      } else if (this.inRawBlock && /^<\/(pre|code|kbd|script)(\s|>)/i.test(cap[0])) {
         this.inRawBlock = false;
       }
 

--- a/test/new/smartypants_code.html
+++ b/test/new/smartypants_code.html
@@ -1,0 +1,4 @@
+<pre>&amp;</pre>
+<p><code>--foo</code>
+<kbd>---foo</kbd></p>
+<script>--foo</script>

--- a/test/new/smartypants_code.html
+++ b/test/new/smartypants_code.html
@@ -2,3 +2,10 @@
 <p><code>--foo</code>
 <kbd>---foo</kbd></p>
 <script>--foo</script>
+
+<p>Ensure that text such as custom tags that happen to
+begin with the same letters as the above tags don’t
+match and thus benefit from Smartypants-ing.</p>
+
+<p><script-custom>–foo</script-custom>
+<code>--foo</code> &lt;codebar –foo codebar&gt;</p>

--- a/test/new/smartypants_code.md
+++ b/test/new/smartypants_code.md
@@ -7,3 +7,9 @@ spec: https://daringfireball.net/projects/smartypants/
 <code>--foo</code>
 <kbd>---foo</kbd>
 <script>--foo</script>
+
+Ensure that text such as custom tags that happen to
+begin with the same letters as the above tags don't
+match and thus benefit from Smartypants-ing.
+<script-custom>--foo</script-custom>
+`--foo` <codebar --foo codebar>

--- a/test/new/smartypants_code.md
+++ b/test/new/smartypants_code.md
@@ -1,0 +1,9 @@
+---
+smartypants: true
+description: SmartyPants does not modify characters within <pre>, <code>, <kbd>, or <script> tag blocks.
+spec: https://daringfireball.net/projects/smartypants/
+---
+<pre>&amp;</pre>
+<code>--foo</code>
+<kbd>---foo</kbd>
+<script>--foo</script>


### PR DESCRIPTION
**Marked version:**

`0.5.0` (latest)

**Markdown flavor:** all

## Description

- Fixes #1334 

## Contributor

- [X] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [x] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [x] Merge PR
