### PR TITLE
Fix auto-linking email

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -705,15 +705,15 @@ InlineLexer.prototype.output = function(src) {
 
     // url (gfm)
     if (!this.inLink && (cap = this.rules.url.exec(src))) {
-      do {
-        prevCapZero = cap[0];
-        cap[0] = this.rules._backpedal.exec(cap[0])[0];
-      } while (prevCapZero !== cap[0]);
-      src = src.substring(cap[0].length);
       if (cap[2] === '@') {
         text = escape(cap[0]);
         href = 'mailto:' + text;
       } else {
+        // do extended autolink path validation
+        do {
+          prevCapZero = cap[0];
+          cap[0] = this.rules._backpedal.exec(cap[0])[0];
+        } while (prevCapZero !== cap[0]);
         text = escape(cap[0]);
         if (cap[1] === 'www.') {
           href = 'http://' + text;
@@ -721,6 +721,7 @@ InlineLexer.prototype.output = function(src) {
           href = text;
         }
       }
+      src = src.substring(cap[0].length);
       out += this.renderer.link(href, null, text);
       continue;
     }

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -605,9 +605,8 @@ inline.pedantic = merge({}, inline.normal, {
 
 inline.gfm = merge({}, inline.normal, {
   escape: edit(inline.escape).replace('])', '~|])').getRegex(),
-  url: edit(/^((?:ftp|https?):\/\/|www\.)(?:[a-zA-Z0-9\-]+\.?)+[^\s<]*|^email/)
-    .replace('email', inline._email)
-    .getRegex(),
+  _extended_email: /[A-Za-z0-9._+-]+(@)[a-zA-Z0-9-_]+(?:\.[a-zA-Z0-9-_]*[a-zA-Z0-9])+(?![-_])/,
+  url: /^((?:ftp|https?):\/\/|www\.)(?:[a-zA-Z0-9\-]+\.?)+[^\s<]*|^email/,
   _backpedal: /(?:[^?!.,:;*_~()&]+|\([^)]*\)|&(?![a-zA-Z0-9]+;$)|[?!.,:;*_~)]+(?!$))+/,
   del: /^~+(?=\S)([\s\S]*?\S)~+/,
   text: edit(inline.text)
@@ -616,6 +615,9 @@ inline.gfm = merge({}, inline.normal, {
     .getRegex()
 });
 
+inline.gfm.url = edit(inline.gfm.url)
+  .replace('email', inline.gfm._extended_email)
+  .getRegex();
 /**
  * GFM + Line Breaks Inline Grammar
  */

--- a/test/specs/marked/marked-spec.js
+++ b/test/specs/marked/marked-spec.js
@@ -49,7 +49,7 @@ describe('Marked Autolinks', function() {
 describe('Marked Code spans', function() {
   var section = 'Code spans';
 
-  var shouldPassButFails = [1];
+  var shouldPassButFails = [];
 
   var willNotBeAttemptedByCoreTeam = [];
 

--- a/test/specs/marked/marked.json
+++ b/test/specs/marked/marked.json
@@ -1,23 +1,5 @@
 [
   {
-    "section": "Autolinks",
-    "markdown": "(See https://www.example.com/fhqwhgads.)",
-    "html": "<p>(See <a href=\"https://www.example.com/fhqwhgads\">https://www.example.com/fhqwhgads</a>.)</p>",
-    "example": 10
-  },
-  {
-    "section": "Autolinks",
-    "markdown": "((http://foo.com))",
-    "html": "<p>((<a href=\"http://foo.com\">http://foo.com</a>))</p>",
-    "example": 11
-  },
-  {
-    "section": "Autolinks",
-    "markdown": "((http://foo.com.))",
-    "html": "<p>((<a href=\"http://foo.com\">http://foo.com</a>.))</p>",
-    "example": 12
-  },
-  {
     "section": "Code spans",
     "markdown": "`someone@example.com`",
     "html": "<p><code>someone@example.com</code></p>",
@@ -76,5 +58,35 @@
     "markdown": "Link: [constructor][].\n\n[constructor]: https://example.org/",
     "html": "<p>Link: <a href=\"https://example.org/\">constructor</a>.</p>",
     "example": 10
+  },
+  {
+    "section": "Autolinks",
+    "markdown": "(See https://www.example.com/fhqwhgads.)",
+    "html": "<p>(See <a href=\"https://www.example.com/fhqwhgads\">https://www.example.com/fhqwhgads</a>.)</p>",
+    "example": 11
+  },
+  {
+    "section": "Autolinks",
+    "markdown": "((http://foo.com))",
+    "html": "<p>((<a href=\"http://foo.com\">http://foo.com</a>))</p>",
+    "example": 12
+  },
+  {
+    "section": "Autolinks",
+    "markdown": "((http://foo.com.))",
+    "html": "<p>((<a href=\"http://foo.com\">http://foo.com</a>.))</p>",
+    "example": 13
+  },
+  {
+    "section": "Autolinks",
+    "markdown": "~~hello@email.com~~",
+    "html": "<p><del><a href=\"mailto:hello@email.com\">hello@email.com</a></del></p>",
+    "example": 1307
+  },
+  {
+    "section": "Autolinks",
+    "markdown": "**me@example.com**",
+    "html": "<p><strong><a href=\"mailto:me@example.com\">me@example.com</a></strong></p>",
+    "example": 1327
   }
 ]


### PR DESCRIPTION
**Markdown flavor:** GitHub Flavored

## Description

Fixes #1218 (see [comment](https://github.com/markedjs/marked/issues/1218#issuecomment-422518372))
Fixes #1307
Fixes #1327

I believe this complies better with the gfm spec.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR)