### PR TITLE
Make Steve publisher

### DIFF
--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -29,8 +29,8 @@ Marked takes an encompassing approach to its community. As such, you can think o
         </a>
         <br>
         <a href="https://www.ceriously.com">Steven</a>
-        <div>Admin</div>
-        <small>Open source, of course; GitHub Guru; Humaning Helper</small>
+        <div>Publisher</div>
+        <small>Release Wrangler; Dr. Docs; Open source, of course; GitHub Guru; Humaning Helper</small>
       </td>
     </tr>
   	<tr>
@@ -215,6 +215,8 @@ Badges? If you *want* 'em, we got 'em, and here's how you get 'em (and&hellip;dr
 			"The main characteristic of the DevOps movement is to strongly advocate automation and monitoring at all steps of software construction, from integration, testing, releasing to deployment and infrastructure management. DevOps aims at shorter development cycles, increased deployment frequency, more dependable releases, in close alignment with business objectives." ~ <a href="https://www.wikipedia.org/wiki/DevOps">Wikipedia</a>
 		</blockquote>
 	</dd>
+  <dt>Dr. Docs</dt>
+  <dd>Someone who has contributed a great deal to the creation and maintainance of the non-code areas of marked.</dd>
 	<dt>Eye for the CLI</dt>
 	<dd>At this point? Pretty much anyone who can update that `man` file to the current Marked version without regression in the CLI tool itself.</dd>
 	<dt>GitHub Guru</dt>


### PR DESCRIPTION
@styfle 

## Recommendation to:

- [ ] Change user group
- [x] Add a badge
- [ ] Remove a badge

1. The one separated the docs from the code.
2. Always able to read when the community is ready for something and willing to make requests and discuss with the "right" people.
3. Always adding little things to make a better experience for all.
4. The selfish bit: Given where I am with my latest "growth spurt", I might end up having to hustle a bit harder; therefore, having three of us seems like a good idea - in order of fallback - me, @styfle, @UziTech, @chjj (pretty sure he's still watching lol)

We've done great as a crew and I cannot adequately express my gratitude to all that you do and have done. When I came in to do the release two or three back I was amazed at how smooth and complete it was. Well done.

## As the one mentioned, I would like to:

- [ ] accept the recommendation; or,
- [ ] graciously decline; or,
- [ ] dispute the recommendation

within 30 days, if you have not indicated which option you are taking one of the following will happen:

1. If adding a badge, we will assume you are graciously declining.
2. If removing a badge, we will assume you do not want to dispute the recommendation; therefore, the badge will be removed.

<!--

	Why would someone not accept a badge? Loads of reasons depending on the circumstances.

	1. If you're a committer and someone puts a badge for you on having decision making authority in an area, do you really a) think you earned it and b) think you can do that *and* all the other stuff you got going as a committer, admin, or publisher (not to even mention your outside life)? Maybe not. And that's okay. Thank them for the recognition, explain you aren't able to take more on at the moment. It's cool to get recognized though.
	2. Maybe you don't feel you actually earned it yet. I remember being in an interview once. The interviewer asked me to give an example of going above and beyond the call of duty. I said, "That's hard. Because what you consider going above and beyond may be what I consider to be 'just rising to'. If we're in battle and you get wounded and I pull you out of the frey before heading back into it, I don't consider that going above and beyond; I consider that rising to."

	Why would someone remove their own badge? Loads of reasons...

	1. Maybe you got a lot going on right now and want to broadcast to the Marked community that, "Hey, I don't want to say I'm going to do this unless I can really commit to it right now in a way that serves the project well." That's awesome! That takes courage! Because a) saying "no" is hard for most humans ("people pleasers") and b) the alternative, well, for those of us here since about October of 2017 (and prior), we know what the alternative can look like.
	2. Maybe you just think you've done all you can to help and learned all you can from the experience. Again, very awesome and courageous. It takes courage to know when to walk away on your own accord.

	Why would you want to remove someone's badge? Loads of reasons...

	1. Maybe they have decision making authority on something. You asked for their advice. And, you ended up waiting almost a month before receiving a response.
	2. Maybe it was relevant at the time (Master of Marked, for example) but you think they've lost their former level of skill (fell out of practice, for example). They could always get it back.
	3. Maybe to signal to them that, "Hey, you seem to have forgotten about us. Are you still around (or alive)?"

	Anyway, you get the idea. This isn't about good or bad...it's just about giving the community a simple game mechanic by which to publicly say, "Thank you" or "Here's what my status is" in the community or "Hey, I think something's wrong here" in a civil manner.

-->

Note: All committers must approve via review before merging, the disapproving committer can simply close the PR.