### PR TITLE
Add the ability to specify options on the demo page as JSON

### DIFF
--- a/docs/demo/demo.css
+++ b/docs/demo/demo.css
@@ -49,7 +49,7 @@ header h1 {
 	resize: both;
 }
 
-.pane, #input {
+.pane, .inputPane {
 	margin-top: 5px;
 	padding: 0.6em;
 	border: 1px solid #ccc;

--- a/docs/demo/demo.css
+++ b/docs/demo/demo.css
@@ -45,6 +45,10 @@ header h1 {
 	box-sizing: border-box;
 }
 
+#options {
+	resize: both;
+}
+
 .pane, #input {
 	margin-top: 5px;
 	padding: 0.6em;

--- a/docs/demo/demo.js
+++ b/docs/demo/demo.js
@@ -49,7 +49,14 @@ if ('text' in search) {
 if ('options' in search) {
   $optionsElem.value = search.options;
 } else {
-  $optionsElem.value = JSON.stringify(marked.getDefaults(), null, ' ');
+  $optionsElem.value = JSON.stringify(
+    marked.getDefaults(),
+    function (key, value) {
+      if (value && typeof(value) === "object" && Object.getPrototypeOf(value) !== Object.prototype){
+        return undefined;
+      }
+      return value;
+    }, ' ');
 }
 
 if (search.outputType) {

--- a/docs/demo/demo.js
+++ b/docs/demo/demo.js
@@ -166,10 +166,7 @@ function checkForChanges() {
       var newOptions = JSON.parse(optionsString);
       options = newOptions;
     } catch (err) {
-      console.log('Unable to parse JSON: "%s"', optionsString);
     }
-
-    console.log(options);
 
     var lexed = marked.lexer($inputElem.value, options);
 

--- a/docs/demo/demo.js
+++ b/docs/demo/demo.js
@@ -72,7 +72,7 @@ function handleOutputChange() {
 function handleChange(panes, visiblePane) {
   var active = null;
   for (var i = 0; i < panes.length; i++) {
-    if (panes[i].id == visiblePane) {
+    if (panes[i].id === visiblePane) {
       panes[i].style.display = '';
       active = panes[i];
     } else {

--- a/docs/demo/demo.js
+++ b/docs/demo/demo.js
@@ -48,6 +48,8 @@ if ('text' in search) {
 
 if ('options' in search) {
   $optionsElem.value = search.options;
+} else {
+  $optionsElem.value = JSON.stringify(marked.getDefaults(), null, ' ');
 }
 
 if (search.outputType) {

--- a/docs/demo/demo.js
+++ b/docs/demo/demo.js
@@ -144,8 +144,8 @@ function updateLink() {
     outputType = 'outputType=' + $outputTypeElem.value + '&';
   }
 
-  $permalinkElem.href = '?' + outputType + 'text=' + encodeURIComponent($inputElem.value) +
-      '&options=' + encodeURIComponent($optionsElem.value) ;
+  $permalinkElem.href = '?' + outputType + 'text=' + encodeURIComponent($inputElem.value)
+      + '&options=' + encodeURIComponent($optionsElem.value);
   history.replaceState('', document.title, $permalinkElem.href);
 }
 
@@ -162,10 +162,10 @@ function checkForChanges() {
     var scrollPercent = getScrollPercent();
 
     try {
-      var optionsString = $optionsElem.value || '{}'
-      var new_options = JSON.parse(optionsString);
-      options = new_options;
-    } catch(err) {
+      var optionsString = $optionsElem.value || '{}';
+      var newOptions = JSON.parse(optionsString);
+      options = newOptions;
+    } catch (err) {
       console.log('Unable to parse JSON: "%s"', optionsString);
     }
 

--- a/docs/demo/demo.js
+++ b/docs/demo/demo.js
@@ -52,7 +52,7 @@ if ('options' in search) {
   $optionsElem.value = JSON.stringify(
     marked.getDefaults(),
     function (key, value) {
-      if (value && typeof(value) === "object" && Object.getPrototypeOf(value) !== Object.prototype){
+      if (value && typeof value === 'object' && Object.getPrototypeOf(value) !== Object.prototype) {
         return undefined;
       }
       return value;

--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -24,12 +24,13 @@
           <span>Input</span> ·
           <a id="permalink">Permalink</a> ·
           <button id="clear">Clear</button>
+          <select id="inputType">
+            <option value="markdown">Markdown</option>
+            <option value="options">Options</option>
+          </select>
         </div>
-        <details>
-          <summary>Options</summary>
-          <textarea id="options" placeholder="Options (as JSON)"></textarea>
-        </details>
-        <textarea id="input"></textarea>
+        <textarea id="markdown" class="inputPane"></textarea>
+        <textarea id="options" class="inputPane" placeholder="Options (as JSON)"></textarea>
       </div>
 
       <div class="container">

--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -25,6 +25,10 @@
           <a id="permalink">Permalink</a> ·
           <button id="clear">Clear</button>
         </div>
+        <details>
+          <summary>Options</summary>
+          <textarea id="options" placeholder="Options (as JSON)"></textarea>
+        </details>
         <textarea id="input"></textarea>
       </div>
 


### PR DESCRIPTION
## Description

Create a details toggle that hides a textarea into which a user can type a JSON-formatted options object.

(For some reason, I can't seem to get the textarea inside a details tag to match the width of the other textareas. After staring at the CSS and banging my head against it, I figured I'd let other people look at it, decide if it was important, and if it was, how to fix it.)

 
![screenshot from 2018-10-17 01-27-32](https://user-images.githubusercontent.com/1079775/47072890-e5cf9700-d1ab-11e8-884c-7921435e7de7.png)

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
