### PR TITLE
Demo Page: Give user feedback when "options" is not valid JSON.

### DIFF
--- a/docs/demo/demo.css
+++ b/docs/demo/demo.css
@@ -65,3 +65,8 @@ header h1 {
 #preview iframe {
 	flex-grow: 1;
 }
+
+#options.badParse {
+	border-color: red;
+	background-color: #FEE
+}

--- a/docs/demo/demo.css
+++ b/docs/demo/demo.css
@@ -45,10 +45,6 @@ header h1 {
 	box-sizing: border-box;
 }
 
-#options {
-	resize: both;
-}
-
 .pane, .inputPane {
 	margin-top: 5px;
 	padding: 0.6em;

--- a/docs/demo/demo.js
+++ b/docs/demo/demo.js
@@ -181,7 +181,9 @@ function checkForChanges() {
       var optionsString = $optionsElem.value || '{}';
       var newOptions = JSON.parse(optionsString);
       options = newOptions;
+      $optionsElem.classList.remove('badParse');
     } catch (err) {
+      $optionsElem.classList.add('badParse');
     }
 
     var lexed = marked.lexer($markdownElem.value, options);


### PR DESCRIPTION
**Marked version:**

Commit: da9d155a1e54f058e876e4cd28c04ec4ab296303

**Markdown flavor:** all

## Description

When the "options" object provided by users doesn't parse, make the input field red to let them know:
<img width="420" alt="screen shot 2018-10-19 at 10 49 03 am" src="https://user-images.githubusercontent.com/1079775/47235047-b1ff9780-d38c-11e8-887d-c1695d89f46c.png">

And when it does parse, return to a regular old textarea.
<img width="417" alt="screen shot 2018-10-19 at 10 49 11 am" src="https://user-images.githubusercontent.com/1079775/47235099-d5c2dd80-d38c-11e8-9bf9-6ac90a0ac862.png">

## Expectation

Some kind of visual indication that the options entered into the text box aren't valid.

## Result

No such indication.

## What was attempted

https://marked.js.org/demo/?text=%23%23%23%20These%20options%20don%27t%20work.&options=a

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [x] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [x] Merge PR
