### PR TITLE
Allow url protocol block/allow lists

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1361,7 +1361,7 @@ function urlProtocolMatch(href, protocols) {
     .replace(/[^\w:]/g, '')
     .toLowerCase();
 
-  return protocols.some(function(protocol) { return prot.startsWith(protocol + ':')});
+  return protocols.some(function(protocol) { return prot.startsWith(protocol + ':'); });
 }
 
 function resolveUrl(base, href) {

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1593,7 +1593,7 @@ marked.getDefaults = function () {
     tables: true,
     xhtml: false,
     blockedUrlProtocols: null,
-    allowedUrlProtocols: null,
+    allowedUrlProtocols: null
   };
 };
 

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1361,7 +1361,7 @@ function urlProtocolMatch(href, protocols) {
     .replace(/[^\w:]/g, '')
     .toLowerCase();
 
-  return protocols.some(function(protocol) { return prot.startsWith(protocol + ':'); });
+  return protocols.some(function(protocol) { return prot.indexOf(protocol + ':') === 0; });
 }
 
 function resolveUrl(base, href) {

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1329,21 +1329,24 @@ function edit(regex, opt) {
   };
 }
 
-function cleanUrl(sanitize, base, href) {
-  if (sanitize) {
-    try {
-      var prot = decodeURIComponent(unescape(href))
-        .replace(/[^\w:]/g, '')
-        .toLowerCase();
-    } catch (e) {
-      return null;
-    }
-    if (prot.indexOf('javascript:') === 0 || prot.indexOf('vbscript:') === 0 || prot.indexOf('data:') === 0) {
-      return null;
-    }
+function cleanUrl(href, options) {
+  if (options.sanitize && !options.blocked_url_protocols) {
+    options.blocked_url_protocols = ['javascript', 'vbscript', 'data'];
   }
-  if (base && !originIndependentUrl.test(href)) {
-    href = resolveUrl(base, href);
+
+  try {
+    if (options.allowed_url_protocols && !urlProtocolMatch(options.allowed_url_protocols)) {
+      return null;
+    }
+    if (options.blocked_url_protocols && urlProtocolMatch(options.blocked_url_protocols)) {
+      return null;
+    }
+  } catch (e) {
+    return null;
+  }
+
+  if (options.base && !originIndependentUrl.test(href)) {
+    href = resolveUrl(options.base, href);
   }
   try {
     href = encodeURI(href).replace(/%25/g, '%');
@@ -1351,6 +1354,14 @@ function cleanUrl(sanitize, base, href) {
     return null;
   }
   return href;
+}
+
+function urlProtocolMatch(href, protocols) {
+  var prot = decodeURIComponent(unescape(href))
+    .replace(/[^\w:]/g, '')
+    .toLowerCase();
+
+  return protocols.some(function(protocol) { return prot.startsWith(protocol + ':')});
 }
 
 function resolveUrl(base, href) {

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1034,7 +1034,7 @@ Renderer.prototype.del = function(text) {
 };
 
 Renderer.prototype.link = function(href, title, text) {
-  href = cleanUrl(this.options.sanitize, this.options.baseUrl, href);
+  href = cleanUrl(href, this.options);
   if (href === null) {
     return text;
   }
@@ -1047,7 +1047,7 @@ Renderer.prototype.link = function(href, title, text) {
 };
 
 Renderer.prototype.image = function(href, title, text) {
-  href = cleanUrl(this.options.sanitize, this.options.baseUrl, href);
+  href = cleanUrl(href, this.options);
   if (href === null) {
     return text;
   }
@@ -1335,10 +1335,10 @@ function cleanUrl(href, options) {
   }
 
   try {
-    if (options.allowed_url_protocols && !urlProtocolMatch(options.allowed_url_protocols)) {
+    if (options.allowed_url_protocols && !urlProtocolMatch(href, options.allowed_url_protocols)) {
       return null;
     }
-    if (options.blocked_url_protocols && urlProtocolMatch(options.blocked_url_protocols)) {
+    if (options.blocked_url_protocols && urlProtocolMatch(href, options.blocked_url_protocols)) {
       return null;
     }
   } catch (e) {

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1345,8 +1345,8 @@ function cleanUrl(href, options) {
     return null;
   }
 
-  if (options.base && !originIndependentUrl.test(href)) {
-    href = resolveUrl(options.base, href);
+  if (options.baseUrl && !originIndependentUrl.test(href)) {
+    href = resolveUrl(options.baseUrl, href);
   }
   try {
     href = encodeURI(href).replace(/%25/g, '%');

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1330,15 +1330,15 @@ function edit(regex, opt) {
 }
 
 function cleanUrl(href, options) {
-  if (options.sanitize && !options.blocked_url_protocols) {
-    options.blocked_url_protocols = ['javascript', 'vbscript', 'data'];
+  if (options.sanitize && !options.blockedUrlProtocols) {
+    options.blockedUrlProtocols = ['javascript', 'vbscript', 'data'];
   }
 
   try {
-    if (options.allowed_url_protocols && !urlProtocolMatch(href, options.allowed_url_protocols)) {
+    if (options.allowedUrlProtocols && !urlProtocolMatch(href, options.allowedUrlProtocols)) {
       return null;
     }
-    if (options.blocked_url_protocols && urlProtocolMatch(href, options.blocked_url_protocols)) {
+    if (options.blockedUrlProtocols && urlProtocolMatch(href, options.blockedUrlProtocols)) {
       return null;
     }
   } catch (e) {
@@ -1591,7 +1591,9 @@ marked.getDefaults = function () {
     smartLists: false,
     smartypants: false,
     tables: true,
-    xhtml: false
+    xhtml: false,
+    blockedUrlProtocols: null,
+    allowedUrlProtocols: null,
   };
 };
 

--- a/test/new/urls_allowed_protocols.html
+++ b/test/new/urls_allowed_protocols.html
@@ -1,0 +1,5 @@
+<p><a href="http://marked.js.org">Good Link</a></p>
+<p><a href="https://marked.js.org">Better Link</a></p>
+<p><a href="mailto:marked@example.com">Mail Link</a></p>
+<p>Bad Link</p>
+<p>Naughty Link</p>

--- a/test/new/urls_allowed_protocols.md
+++ b/test/new/urls_allowed_protocols.md
@@ -1,5 +1,5 @@
 ---
-allowed_url_protocols: ["http", "https", "ftp", "mailto"]
+allowedUrlProtocols: ["http", "https", "ftp", "mailto"]
 ---
 
 [Good Link](http://marked.js.org)

--- a/test/new/urls_allowed_protocols.md
+++ b/test/new/urls_allowed_protocols.md
@@ -4,7 +4,7 @@ allowed_url_protocols: ["http", "https", "ftp", "mailto"]
 
 [Good Link](http://marked.js.org)
 
-[Better Link](https://marked.js.org))
+[Better Link](https://marked.js.org)
 
 [Mail Link](mailto:marked@example.com)
 

--- a/test/new/urls_allowed_protocols.md
+++ b/test/new/urls_allowed_protocols.md
@@ -1,0 +1,13 @@
+---
+allowed_url_protocols: ["http", "https", "ftp", "mailto"]
+---
+
+[Good Link](http://marked.js.org)
+
+[Better Link](https://marked.js.org))
+
+[Mail Link](mailto:marked@example.com)
+
+[Bad Link](file:///etc/passwd)
+
+[Naughty Link](javascript:alert('xss'))

--- a/test/new/urls_blocked_protocols.html
+++ b/test/new/urls_blocked_protocols.html
@@ -1,0 +1,5 @@
+<p><a href="http://marked.js.org">Good Link</a></p>
+<p><a href="https://marked.js.org">Better Link</a></p>
+<p><a href="mailto:marked@example.com">Mail Link</a></p>
+<p>Bad Link</p>
+<p>Naughty Link</p>

--- a/test/new/urls_blocked_protocols.md
+++ b/test/new/urls_blocked_protocols.md
@@ -1,0 +1,13 @@
+---
+blocked_url_protocols: ["javascript", "file"]
+---
+
+[Good Link](http://marked.js.org)
+
+[Better Link](https://marked.js.org))
+
+[Mail Link](mailto:marked@example.com)
+
+[Bad Link](file:///etc/passwd)
+
+[Naughty Link](javascript:alert('xss'))

--- a/test/new/urls_blocked_protocols.md
+++ b/test/new/urls_blocked_protocols.md
@@ -1,5 +1,5 @@
 ---
-blocked_url_protocols: ["javascript", "file"]
+blockedUrlProtocols: ["javascript", "file"]
 ---
 
 [Good Link](http://marked.js.org)

--- a/test/new/urls_blocked_protocols.md
+++ b/test/new/urls_blocked_protocols.md
@@ -4,7 +4,7 @@ blocked_url_protocols: ["javascript", "file"]
 
 [Good Link](http://marked.js.org)
 
-[Better Link](https://marked.js.org))
+[Better Link](https://marked.js.org)
 
 [Mail Link](mailto:marked@example.com)
 


### PR DESCRIPTION
**Markdown flavor:** all

## Description

Add the ability to set lists of allowable or blocked url protocols. Replaces the current "sanitize" code for URLs with explicit controls. (Existing behavior for sanitize is retained, for compatibility, but if/when sanitize is removed generally, urls can still be restricted to only desired protocols.

The included tests have examples.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
