### PR TITLE
Export URL handler to allow for easier overriding.

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1034,7 +1034,7 @@ Renderer.prototype.del = function(text) {
 };
 
 Renderer.prototype.link = function(href, title, text) {
-  href = cleanUrl(this.options.sanitize, this.options.baseUrl, href);
+  href = this.cleanUrl(href);
   if (href === null) {
     return text;
   }
@@ -1047,7 +1047,7 @@ Renderer.prototype.link = function(href, title, text) {
 };
 
 Renderer.prototype.image = function(href, title, text) {
-  href = cleanUrl(this.options.sanitize, this.options.baseUrl, href);
+  href = this.cleanUrl(href);
   if (href === null) {
     return text;
   }
@@ -1063,6 +1063,32 @@ Renderer.prototype.image = function(href, title, text) {
 Renderer.prototype.text = function(text) {
   return text;
 };
+
+Renderer.prototype.cleanUrl = function(href) {
+  if (this.options.sanitize) {
+    try {
+      var prot = decodeURIComponent(unescape(href))
+        .replace(/[^\w:]/g, '')
+        .toLowerCase();
+    } catch (e) {
+      return null;
+    }
+    if (prot.indexOf('javascript:') === 0 || prot.indexOf('vbscript:') === 0 || prot.indexOf('data:') === 0) {
+      return null;
+    }
+  }
+  if (this.options.baseUrl && !originIndependentUrl.test(href)) {
+    href = resolveUrl(this.options.baseUrl, href);
+  }
+  try {
+    href = encodeURI(href).replace(/%25/g, '%');
+  } catch (e) {
+    return null;
+  }
+  return href;
+}
+
+
 
 /**
  * TextRenderer
@@ -1327,30 +1353,6 @@ function edit(regex, opt) {
       return new RegExp(regex, opt);
     }
   };
-}
-
-function cleanUrl(sanitize, base, href) {
-  if (sanitize) {
-    try {
-      var prot = decodeURIComponent(unescape(href))
-        .replace(/[^\w:]/g, '')
-        .toLowerCase();
-    } catch (e) {
-      return null;
-    }
-    if (prot.indexOf('javascript:') === 0 || prot.indexOf('vbscript:') === 0 || prot.indexOf('data:') === 0) {
-      return null;
-    }
-  }
-  if (base && !originIndependentUrl.test(href)) {
-    href = resolveUrl(base, href);
-  }
-  try {
-    href = encodeURI(href).replace(/%25/g, '%');
-  } catch (e) {
-    return null;
-  }
-  return href;
 }
 
 function resolveUrl(base, href) {

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1086,9 +1086,7 @@ Renderer.prototype.cleanUrl = function(href) {
     return null;
   }
   return href;
-}
-
-
+};
 
 /**
  * TextRenderer


### PR DESCRIPTION
## Description

Alternative to #1361, allowing users to replace Renderer's url cleaner themselves.

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
