### PR TITLE
Fix builds: remove node v0.10 from travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
 
     - stage: spec tests 👩🏽‍💻
       script: npm run test:specs
-    - node_js: v4
+      node_js: v4
     - node_js: lts/*
     - node_js: node
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ jobs:
 
     - stage: spec tests 👩🏽‍💻
       script: npm run test:specs
-      node_js: v0.10
     - node_js: v4
     - node_js: lts/*
     - node_js: node


### PR DESCRIPTION
## Description

Fixes our failing builds.

Node v0.10 went End-of-Life two years ago which is why jasmine (our test framework) won't work anymore (looks like they dropped support awhile ago and just introduced breaking changes recently.

Related: https://github.com/jasmine/jasmine-npm/pull/144

## Contributor

- [x] no new tests required for this PR.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
