### PR TITLE
Fix Heading ID for Unicode text

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -952,7 +952,7 @@ Renderer.prototype.heading = function(text, level, raw) {
       + level
       + ' id="'
       + this.options.headerPrefix
-      + raw.toLowerCase().replace(/[^\w]+/g, '-')
+      + raw.toLowerCase().replace(/[/\\()"':,.;<>~!@#$%^&*|+=[\]{}`?\-…_\s\t]+/g, '-')
       + '">'
       + text
       + '</h'

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -952,7 +952,7 @@ Renderer.prototype.heading = function(text, level, raw) {
       + level
       + ' id="'
       + this.options.headerPrefix
-      + raw.toLowerCase().replace(/[/\\()"':,.;<>~!@#$%^&*|+=[\]{}`?\-…_\s\t]+/g, '-')
+      + raw.toLowerCase().replace(/["\s]+/g, '-')
       + '">'
       + text
       + '</h'


### PR DESCRIPTION
I think defining `nonWordCharacters` will solve it.

Reference: [atom nonWordCharacters](https://github.com/atom/atom/blob/080d6ae1279c66e5f018d803186a0cde5c202c03/src/config-schema.js?fbclid=IwAR0BI3l0KgHls4gGlFw0HYQ_G_U7A84X0eTtmSvfEauo8NCnQxpRKuGJnQM#L450)


