### PR TITLE
Make autolinks case insensitive

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -615,7 +615,7 @@ inline.gfm = merge({}, inline.normal, {
     .getRegex()
 });
 
-inline.gfm.url = edit(inline.gfm.url)
+inline.gfm.url = edit(inline.gfm.url, 'i')
   .replace('email', inline.gfm._extended_email)
   .getRegex();
 /**

--- a/test/specs/marked/marked.json
+++ b/test/specs/marked/marked.json
@@ -85,6 +85,18 @@
   },
   {
     "section": "Autolinks",
+    "markdown": "HTTP://FOO.COM",
+    "html": "<p><a href=\"HTTP://FOO.COM\">HTTP://FOO.COM</a></p>",
+    "example": 15
+  },
+  {
+    "section": "Autolinks",
+    "markdown": "hTtP://fOo.CoM",
+    "html": "<p><a href=\"hTtP://fOo.CoM\">hTtP://fOo.CoM</a></p>",
+    "example": 16
+  },
+  {
+    "section": "Autolinks",
     "markdown": "~~hello@email.com~~",
     "html": "<p><del><a href=\"mailto:hello@email.com\">hello@email.com</a></del></p>",
     "example": 1307

--- a/test/specs/marked/marked.json
+++ b/test/specs/marked/marked.json
@@ -93,7 +93,7 @@
     "section": "Autolinks",
     "markdown": "hTtP://fOo.CoM",
     "html": "<p><a href=\"hTtP://fOo.CoM\">hTtP://fOo.CoM</a></p>",
-    "example": 16
+    "example": 18
   },
   {
     "section": "Autolinks",

--- a/test/specs/marked/marked.json
+++ b/test/specs/marked/marked.json
@@ -87,7 +87,7 @@
     "section": "Autolinks",
     "markdown": "HTTP://FOO.COM",
     "html": "<p><a href=\"HTTP://FOO.COM\">HTTP://FOO.COM</a></p>",
-    "example": 15
+    "example": 17
   },
   {
     "section": "Autolinks",


### PR DESCRIPTION
**Marked version:** master

<!-- The NPM version or commit hash having the issue -->

**Markdown flavor:** Markdown.pl|CommonMark|GitHub Flavored Markdown|n/a

## Description

Make urls case insensitive

implements https://github.com/markedjs/marked/pull/1350#issuecomment-427164249

```js
marked("hTtP://fOo.CoM");
// <p><a href=\"hTtP://fOo.CoM\">hTtP://fOo.CoM</a></p>
```

- closes #1350

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression

## Committer

In most cases, this should be a different person than the contributor.

- [x] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [x] Merge PR
