### PR TITLE
Fix bold around autolink email address

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -694,43 +694,6 @@ InlineLexer.prototype.output = function(src) {
       continue;
     }
 
-    // autolink
-    if (cap = this.rules.autolink.exec(src)) {
-      src = src.substring(cap[0].length);
-      if (cap[2] === '@') {
-        text = escape(this.mangle(cap[1]));
-        href = 'mailto:' + text;
-      } else {
-        text = escape(cap[1]);
-        href = text;
-      }
-      out += this.renderer.link(href, null, text);
-      continue;
-    }
-
-    // url (gfm)
-    if (!this.inLink && (cap = this.rules.url.exec(src))) {
-      if (cap[2] === '@') {
-        text = escape(cap[0]);
-        href = 'mailto:' + text;
-      } else {
-        // do extended autolink path validation
-        do {
-          prevCapZero = cap[0];
-          cap[0] = this.rules._backpedal.exec(cap[0])[0];
-        } while (prevCapZero !== cap[0]);
-        text = escape(cap[0]);
-        if (cap[1] === 'www.') {
-          href = 'http://' + text;
-        } else {
-          href = text;
-        }
-      }
-      src = src.substring(cap[0].length);
-      out += this.renderer.link(href, null, text);
-      continue;
-    }
-
     // tag
     if (cap = this.rules.tag.exec(src)) {
       if (!this.inLink && /^<a /i.test(cap[0])) {
@@ -828,6 +791,43 @@ InlineLexer.prototype.output = function(src) {
     if (cap = this.rules.del.exec(src)) {
       src = src.substring(cap[0].length);
       out += this.renderer.del(this.output(cap[1]));
+      continue;
+    }
+
+    // autolink
+    if (cap = this.rules.autolink.exec(src)) {
+      src = src.substring(cap[0].length);
+      if (cap[2] === '@') {
+        text = escape(this.mangle(cap[1]));
+        href = 'mailto:' + text;
+      } else {
+        text = escape(cap[1]);
+        href = text;
+      }
+      out += this.renderer.link(href, null, text);
+      continue;
+    }
+
+    // url (gfm)
+    if (!this.inLink && (cap = this.rules.url.exec(src))) {
+      if (cap[2] === '@') {
+        text = escape(cap[0]);
+        href = 'mailto:' + text;
+      } else {
+        // do extended autolink path validation
+        do {
+          prevCapZero = cap[0];
+          cap[0] = this.rules._backpedal.exec(cap[0])[0];
+        } while (prevCapZero !== cap[0]);
+        text = escape(cap[0]);
+        if (cap[1] === 'www.') {
+          href = 'http://' + text;
+        } else {
+          href = text;
+        }
+      }
+      src = src.substring(cap[0].length);
+      out += this.renderer.link(href, null, text);
       continue;
     }
 

--- a/test/specs/marked/marked.json
+++ b/test/specs/marked/marked.json
@@ -95,6 +95,12 @@
     "html": "<p><strong><a href=\"mailto:me@example.com\">me@example.com</a></strong></p>",
     "example": 1327
   },
+  {
+    "section": "Autolinks",
+    "markdown": "__test@test.com__",
+    "html": "<p><strong><a href=\"mailto:test@test.com\">test@test.com</a></strong></p>",
+    "example": 1347
+  },
   {  
     "section": "Emphasis extra tests",
     "markdown": "_test_. _test_: _test_! _test_? _test_-",


### PR DESCRIPTION
**Marked version:** v0.5.2 (revision ed64407e3ddac290658ba042a691b11c40ba5f55)

**Markdown flavor:** n/a

## Description

- Fixes bold + autolink bug with input `__test@test.com__`

This PR fixes a bug of parsing order which can lead autolink to take over parsing of other elements (e.g. bolding). Please look **carefully** before merging this PR: I obviously ran tests and added a new one, but this is probably a **breaking change**. ~~Also, my test should probably not be there, so please feel free to edit (I allowed edit from maintainers)~~ (this has been fixed, c.f. my force push).

## Expectation

`<p><strong><a href="mailto:test@test.com">test@test.com</a></strong></p>`

## Result

`<p><a href="mailto:__test@test.co">__test@test.co</a>m__</p>`

## What was attempted

Reordering of parsing (autolink processing now just before text).

## Contributor

- [X] Test added to ensure functionality and minimize regression

## Committer

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
