### PR TITLE
Fix duplicate heading id

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -953,13 +953,13 @@ Renderer.prototype.html = function(html) {
   return html;
 };
 
-Renderer.prototype.heading = function(text, level, raw) {
+Renderer.prototype.heading = function(text, level, raw, slugger) {
   if (this.options.headerIds) {
     return '<h'
       + level
       + ' id="'
       + this.options.headerPrefix
-      + raw.toLowerCase().replace(/[^\w]+/g, '-')
+      + slugger.slug(raw)
       + '">'
       + text
       + '</h'
@@ -1108,6 +1108,7 @@ function Parser(options) {
   this.options.renderer = this.options.renderer || new Renderer();
   this.renderer = this.options.renderer;
   this.renderer.options = this.options;
+  this.slugger = new Slugger();
 }
 
 /**
@@ -1186,7 +1187,8 @@ Parser.prototype.tok = function() {
       return this.renderer.heading(
         this.inline.output(this.token.text),
         this.token.depth,
-        unescape(this.inlineText.output(this.token.text)));
+        unescape(this.inlineText.output(this.token.text)),
+        this.slugger);
     }
     case 'code': {
       return this.renderer.code(this.token.text,
@@ -1281,6 +1283,35 @@ Parser.prototype.tok = function() {
       }
     }
   }
+};
+
+/**
+ * Slugger generates header id
+ */
+
+function Slugger () {	
+  this.seen = {};	
+}	
+
+/**
+ * Convert string to unique id
+ */
+
+Slugger.prototype.slug = function (value) {	
+  var slug = value	
+    .toLowerCase()
+    .trim()
+    .replace(/[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,./:;<=>?@[\]^`{|}~]/g, '')
+    .replace(/\s/g, '-');
+  
+  var count = this.seen.hasOwnProperty(slug) ? this.seen[slug] + 1 : 0;
+  this.seen[slug] = count;
+
+  if (count > 0) {	
+    slug = slug + '-' + count;	
+  }
+  
+  return slug;	
 };
 
 /**

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1289,29 +1289,31 @@ Parser.prototype.tok = function() {
  * Slugger generates header id
  */
 
-function Slugger () {	
-  this.seen = {};	
-}	
+function Slugger () {
+  this.seen = {};
+}
 
 /**
  * Convert string to unique id
  */
 
-Slugger.prototype.slug = function (value) {	
-  var slug = value	
+Slugger.prototype.slug = function (value) {
+  var slug = value
     .toLowerCase()
     .trim()
     .replace(/[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,./:;<=>?@[\]^`{|}~]/g, '')
     .replace(/\s/g, '-');
-  
-  var count = this.seen.hasOwnProperty(slug) ? this.seen[slug] + 1 : 0;
-  this.seen[slug] = count;
 
-  if (count > 0) {	
-    slug = slug + '-' + count;	
+  if (this.seen.hasOwnProperty(slug)) {
+    var originalSlug = slug;
+    do {
+      this.seen[originalSlug]++;
+      slug = originalSlug + '-' + this.seen[originalSlug];
+    } while (this.seen.hasOwnProperty(slug));
   }
-  
-  return slug;	
+  this.seen[slug] = 0;
+
+  return slug;
 };
 
 /**
@@ -1647,6 +1649,8 @@ marked.lexer = Lexer.lex;
 
 marked.InlineLexer = InlineLexer;
 marked.inlineLexer = InlineLexer.output;
+
+marked.Slugger = Slugger;
 
 marked.parse = marked;
 

--- a/test/new/cm_blockquotes.html
+++ b/test/new/cm_blockquotes.html
@@ -11,7 +11,7 @@ baz</p>
 <p>The spaces after the <code>&gt;</code> characters can be omitted:</p>
 
 <blockquote>
-<h1 id="foo">Foo</h1>
+<h1 id="bar">Bar</h1>
 <p>bar
 baz</p>
 </blockquote>
@@ -21,7 +21,7 @@ baz</p>
 <p>The <code>&gt;</code> characters can be indented 1-3 spaces:</p>
 
 <blockquote>
-<h1 id="foo">Foo</h1>
+<h1 id="baz">Baz</h1>
 <p>bar
 baz</p>
 </blockquote>
@@ -30,7 +30,7 @@ baz</p>
 
 <p>Four spaces gives us a code block:</p>
 
-<pre><code>&gt; # Foo
+<pre><code>&gt; # Qux
 &gt; bar
 &gt; baz</code></pre>
 
@@ -39,7 +39,7 @@ baz</p>
 <p>The Laziness clause allows us to omit the <code>&gt;</code> before paragraph continuation text:</p>
 
 <blockquote>
-<h1 id="foo">Foo</h1>
+<h1 id="quux">Quux</h1>
 <p>bar
 baz</p>
 </blockquote>

--- a/test/new/cm_blockquotes.md
+++ b/test/new/cm_blockquotes.md
@@ -8,7 +8,7 @@
 
 The spaces after the `>` characters can be omitted:
 
-># Foo
+># Bar
 >bar
 > baz
 
@@ -16,7 +16,7 @@ The spaces after the `>` characters can be omitted:
 
 The `>` characters can be indented 1-3 spaces:
 
-   > # Foo
+   > # Baz
    > bar
  > baz
 
@@ -24,7 +24,7 @@ The `>` characters can be indented 1-3 spaces:
 
 Four spaces gives us a code block:
 
-    > # Foo
+    > # Qux
     > bar
     > baz
 
@@ -32,7 +32,7 @@ Four spaces gives us a code block:
 
 The Laziness clause allows us to omit the `>` before paragraph continuation text:
 
-> # Foo
+> # Quux
 > bar
 baz
 

--- a/test/new/toplevel_paragraphs.html
+++ b/test/new/toplevel_paragraphs.html
@@ -12,7 +12,7 @@
 <h1 id="how-are-you">how are you</h1>
 
 <p>paragraph before head with equals</p>
-<h1 id="how-are-you">how are you</h1>
+<h1 id="how-are-you-again">how are you again</h1>
 
 <p>paragraph before blockquote</p>
 <blockquote><p>text for blockquote</p></blockquote>

--- a/test/new/toplevel_paragraphs.md
+++ b/test/new/toplevel_paragraphs.md
@@ -17,7 +17,7 @@ paragraph before head with hash
 # how are you
 
 paragraph before head with equals
-how are you
+how are you again
 ===========
 
 paragraph before blockquote

--- a/test/original/markdown_documentation_basics.html
+++ b/test/original/markdown_documentation_basics.html
@@ -1,4 +1,4 @@
-<h1>Markdown: Basics</h1>
+<h1 id="markdown-basics">Markdown: Basics</h1>
 
 <ul id="ProjectSubmenu">
     <li><a href="/projects/markdown/" title="Markdown Project Page">Main</a></li>
@@ -8,7 +8,7 @@
     <li><a href="/projects/markdown/dingus" title="Online Markdown Web Form">Dingus</a></li>
 </ul>
 
-<h2>Getting the Gist of Markdown's Formatting Syntax</h2>
+<h2 id="getting-the-gist-of-markdowns-formatting-syntax">Getting the Gist of Markdown's Formatting Syntax</h2>
 
 <p>This page offers a brief overview of what it's like to use Markdown.
 The <a href="/projects/markdown/syntax" title="Markdown Syntax">syntax page</a> provides complete, detailed documentation for
@@ -24,7 +24,7 @@ and translate it to XHTML.</p>
 <p><strong>Note:</strong> This document is itself written using Markdown; you
 can <a href="/projects/markdown/basics.text">see the source for it by adding '.text' to the URL</a>.</p>
 
-<h2>Paragraphs, Headers, Blockquotes</h2>
+<h2 id="paragraphs-headers-blockquotes">Paragraphs, Headers, Blockquotes</h2>
 
 <p>A paragraph is simply one or more consecutive lines of text, separated
 by one or more blank lines. (A blank line is any line that looks like a
@@ -88,7 +88,7 @@ dog's back.&lt;/p&gt;
 &lt;/blockquote&gt;
 </code></pre>
 
-<h3>Phrase Emphasis</h3>
+<h3 id="phrase-emphasis">Phrase Emphasis</h3>
 
 <p>Markdown uses asterisks and underscores to indicate spans of emphasis.</p>
 
@@ -110,7 +110,7 @@ Some of these words &lt;em&gt;are emphasized also&lt;/em&gt;.&lt;/p&gt;
 Or, if you prefer, &lt;strong&gt;use two underscores instead&lt;/strong&gt;.&lt;/p&gt;
 </code></pre>
 
-<h2>Lists</h2>
+<h2 id="lists">Lists</h2>
 
 <p>Unordered (bulleted) lists use asterisks, pluses, and hyphens (<code>*</code>,
 <code>+</code>, and <code>-</code>) as list markers. These three markers are
@@ -181,7 +181,7 @@ the paragraphs by 4 spaces or 1 tab:</p>
 &lt;/ul&gt;
 </code></pre>
 
-<h3>Links</h3>
+<h3 id="links">Links</h3>
 
 <p>Markdown supports two styles for creating links: <em>inline</em> and
 <em>reference</em>. With both styles, you use square brackets to delimit the
@@ -244,7 +244,7 @@ numbers and spaces, but are <em>not</em> case sensitive:</p>
 &lt;a href="http://www.nytimes.com/"&gt;The New York Times&lt;/a&gt;.&lt;/p&gt;
 </code></pre>
 
-<h3>Images</h3>
+<h3 id="images">Images</h3>
 
 <p>Image syntax is very much like link syntax.</p>
 
@@ -265,7 +265,7 @@ numbers and spaces, but are <em>not</em> case sensitive:</p>
 <pre><code>&lt;img src="/path/to/img.jpg" alt="alt text" title="Title" /&gt;
 </code></pre>
 
-<h3>Code</h3>
+<h3 id="code">Code</h3>
 
 <p>In a regular paragraph, you can create code span by wrapping text in
 backtick quotes. Any ampersands (<code>&amp;</code>) and angle brackets (<code>&lt;</code> or

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -2,15 +2,29 @@ var marked = require('../../lib/marked.js');
 
 describe('Test heading ID functionality', function() {
   it('should add id attribute by default', function() {
-    var renderer = new marked.Renderer(marked.defaults);
-    var header = renderer.heading('test', 1, 'test');
-    expect(header).toBe('<h1 id="test">test</h1>\n');
+    var html = marked('# test');
+    expect(html).toBe('<h1 id="test">test</h1>\n');
+  });
+
+  it('should add unique id for repeating heading 1280', function() {
+    var html = marked('# test\n# test\n# test');
+    expect(html).toBe('<h1 id="test">test</h1>\n<h1 id="test-1">test</h1>\n<h1 id="test-2">test</h1>\n');
+  });
+
+  it('should add id with non-latin chars', function() {
+    var html = marked('# привет');
+    expect(html).toBe('<h1 id="привет">привет</h1>\n');
+  });
+
+  it('should add id without ampersands 857', function() {
+    var html = marked('# This & That Section');
+    expect(html).toBe('<h1 id="this--that-section">This &amp; That Section</h1>\n');
   });
 
   it('should NOT add id attribute when options set false', function() {
-    var renderer = new marked.Renderer({ headerIds: false });
-    var header = renderer.heading('test', 1, 'test');
-    expect(header).toBe('<h1>test</h1>\n');
+    var options = { headerIds: false };
+    var html = marked('# test', options);
+    expect(html).toBe('<h1>test</h1>\n');
   });
 });
 

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -28,7 +28,14 @@ describe('Test slugger functionality', function() {
     expect(slugger.slug('test')).toBe('test-2');
   });
 
-  it('should be unique to avoid collisions 1401', function() {
+  it('should be unique when slug ends with number', function() {
+    var slugger = new marked.Slugger();
+    expect(slugger.slug('test 1')).toBe('test-1');
+    expect(slugger.slug('test')).toBe('test');
+    expect(slugger.slug('test')).toBe('test-2');
+  });
+
+  it('should be unique when slug ends with hyphen number', function() {
     var slugger = new marked.Slugger();
     expect(slugger.slug('foo')).toBe('foo');
     expect(slugger.slug('foo')).toBe('foo-1');

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -2,29 +2,54 @@ var marked = require('../../lib/marked.js');
 
 describe('Test heading ID functionality', function() {
   it('should add id attribute by default', function() {
-    var html = marked('# test');
-    expect(html).toBe('<h1 id="test">test</h1>\n');
-  });
-
-  it('should add unique id for repeating heading 1280', function() {
-    var html = marked('# test\n# test\n# test');
-    expect(html).toBe('<h1 id="test">test</h1>\n<h1 id="test-1">test</h1>\n<h1 id="test-2">test</h1>\n');
-  });
-
-  it('should add id with non-latin chars', function() {
-    var html = marked('# привет');
-    expect(html).toBe('<h1 id="привет">привет</h1>\n');
-  });
-
-  it('should add id without ampersands 857', function() {
-    var html = marked('# This & That Section');
-    expect(html).toBe('<h1 id="this--that-section">This &amp; That Section</h1>\n');
+    var renderer = new marked.Renderer();
+    var slugger = new marked.Slugger();
+    var header = renderer.heading('test', 1, 'test', slugger);
+    expect(header).toBe('<h1 id="test">test</h1>\n');
   });
 
   it('should NOT add id attribute when options set false', function() {
-    var options = { headerIds: false };
-    var html = marked('# test', options);
-    expect(html).toBe('<h1>test</h1>\n');
+    var renderer = new marked.Renderer({ headerIds: false });
+    var header = renderer.heading('test', 1, 'test');
+    expect(header).toBe('<h1>test</h1>\n');
+  });
+});
+
+describe('Test slugger functionality', function() {
+  it('should use lowercase slug', function() {
+    var slugger = new marked.Slugger();
+    expect(slugger.slug('Test')).toBe('test');
+  });
+
+  it('should be unique to avoid collisions 1280', function() {
+    var slugger = new marked.Slugger();
+    expect(slugger.slug('test')).toBe('test');
+    expect(slugger.slug('test')).toBe('test-1');
+    expect(slugger.slug('test')).toBe('test-2');
+  });
+
+  it('should be unique to avoid collisions 1401', function() {
+    var slugger = new marked.Slugger();
+    expect(slugger.slug('foo')).toBe('foo');
+    expect(slugger.slug('foo')).toBe('foo-1');
+    expect(slugger.slug('foo 1')).toBe('foo-1-1');
+    expect(slugger.slug('foo-1')).toBe('foo-1-2');
+    expect(slugger.slug('foo')).toBe('foo-2');
+  });
+
+  it('should allow non-latin chars', function() {
+    var slugger = new marked.Slugger();
+    expect(slugger.slug('привет')).toBe('привет');
+  });
+
+  it('should remove ampersands 857', function() {
+    var slugger = new marked.Slugger();
+    expect(slugger.slug('This & That Section')).toBe('this--that-section');
+  });
+
+  it('should remove periods', function() {
+    var slugger = new marked.Slugger();
+    expect(slugger.slug('file.txt')).toBe('filetxt');
   });
 });
 


### PR DESCRIPTION
**Marked version:** 0.5.2

<!-- The NPM version or commit hash having the issue -->

**Markdown flavor:** All

## Description

This fixes several bugs involving `headerIds: true`.

- Fixes #857
- Fixes #1280 
- Fixes #1354
- Fixes #1374

This adds a new export `marked.Slugger`.

I added several more tests to cover duplicates as well as ampersands.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression
## Committer

In most cases, this should be a different person than the contributor.

- [x] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [x] Merge PR
