### PR TITLE
Add snyk badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@
 [![gzip size](https://badgen.net/badgesize/gzip/https://cdn.jsdelivr.net/npm/marked/marked.min.js)](https://cdn.jsdelivr.net/npm/marked/marked.min.js)
 [![install size](https://badgen.net/packagephobia/install/marked)](https://packagephobia.now.sh/result?p=marked)
 [![downloads](https://badgen.net/npm/dt/marked)](https://www.npmjs.com/package/marked)
-[![dep](https://badgen.net/david/dep/markedjs/marked)](https://david-dm.org/markedjs/marked)
-[![dev dep](https://badgen.net/david/dev/markedjs/marked)](https://david-dm.org/markedjs/marked?type=dev)
+[![dep](https://badgen.net/david/dep/markedjs/marked?label=deps)](https://david-dm.org/markedjs/marked)
+[![dev dep](https://badgen.net/david/dev/markedjs/marked?label=devDeps)](https://david-dm.org/markedjs/marked?type=dev)
 [![travis](https://badgen.net/travis/markedjs/marked)](https://travis-ci.org/markedjs/marked)
+[![snyk](https://snyk.io/test/npm/marked/badge.svg)](https://snyk.io/test/npm/marked)
 
 - ⚡ built for speed
 - ⬇️ low-level compiler for parsing markdown without caching or blocking for long periods of time


### PR DESCRIPTION
**Marked version:** Latest

**Markdown flavor:** All

## Description

The Snyk integration never actually checked specific PRs but instead checked the latest version published to npm.

So I removed the integration and added this new badge to the readme called `vulnerabilities` linking to snyk's website.

I also made the other badges a bit smaller so everything fits on one line.

## Contributor

- [x] no tests required for this PR

## Committer

In most cases, this should be a different person than the contributor.

- [x] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [x] Merge PR
