### PR TITLE
Release 0.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "marked",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marked",
   "description": "A markdown parser built for speed",
   "author": "Christopher Jeffrey",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "main": "./lib/marked.js",
   "bin": "./bin/marked",
   "man": "./man/marked.1",


### PR DESCRIPTION
## Publisher

- [x] `$ npm version` has been run.
- [x] Release notes in [draft GitHub release](https://github.com/markedjs/marked/releases) are up to date
- [x] Release notes include which flavors and versions of Markdown are supported by this release
- [x] Committer checklist is complete.
- [ ] Merge PR.
- [ ] Publish GitHub release using `master` with correct version number.
- [ ] `$ npm publish` has been run.
- [ ] Create draft GitHub release to prepare next release.

Note: If merges to `master` occur after submitting this PR and before running `$ npm pubish` you should be able to

1. pull from `upstream/master` (`git pull upstream master`) into the branch holding this version,
2. run `$ npm run build` to regenerate the `min` file, and
3. commit and push the updated changes.

## Committer

In most cases, this should be someone different than the publisher.

- [x] Version in `package.json` has been updated (see [PUBLISHING.md](https://github.com/markedjs/marked/blob/master/docs/PUBLISHING.md)).
- [x] The `marked.min.js` has been updated; or,
- [x] release does not change library.
- [x] CI is green (no forced merge required).

# Release Notes

## Fixes

- Fix parenthesis url redos #1414

## Docs

- Update demo site to use a worker #1418 
- Update devDependencies to last stable #1409
- Update documentation about extending Renderer #1417
