### PR TITLE
Improve worst-case performance of inline.text regex

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -546,7 +546,7 @@ var inline = {
   code: /^(`+)([^`]|[^`][\s\S]*?[^`])\1(?!`)/,
   br: /^( {2,}|\\)\n(?!\s*$)/,
   del: noop,
-  text: /^(`+|[^`])[\s\S]*?(?=[\\<!\[`*]|\b_| {2,}\n|$)/
+  text: /^(`+|[^`])(?:[\s\S]*?(?:(?=[\\<!\[`*]|\b_|$)|[^ ](?= {2,}\n))|(?= {2,}\n))/
 };
 
 // list of punctuation marks from common mark spec
@@ -615,10 +615,7 @@ inline.gfm = merge({}, inline.normal, {
   url: /^((?:ftp|https?):\/\/|www\.)(?:[a-zA-Z0-9\-]+\.?)+[^\s<]*|^email/,
   _backpedal: /(?:[^?!.,:;*_~()&]+|\([^)]*\)|&(?![a-zA-Z0-9]+;$)|[?!.,:;*_~)]+(?!$))+/,
   del: /^~+(?=\S)([\s\S]*?\S)~+/,
-  text: edit(inline.text)
-    .replace(']|', '~]|')
-    .replace('|$', '|https?://|ftp://|www\\.|[a-zA-Z0-9.!#$%&\'*+/=?^_`{\\|}~-]+@|$')
-    .getRegex()
+  text: /^(`+|[^`])(?:[\s\S]*?(?:(?=[\\<!\[`*~]|\b_|https?:\/\/|ftp:\/\/|www\.|$)|[^ ](?= {2,}\n)|[^a-zA-Z0-9.!#$%&'*+\/=?_`{\|}~-](?=[a-zA-Z0-9.!#$%&'*+\/=?_`{\|}~-]+@))|(?= {2,}\n|[a-zA-Z0-9.!#$%&'*+\/=?_`{\|}~-]+@))/
 });
 
 inline.gfm.url = edit(inline.gfm.url, 'i')
@@ -630,7 +627,7 @@ inline.gfm.url = edit(inline.gfm.url, 'i')
 
 inline.breaks = merge({}, inline.gfm, {
   br: edit(inline.br).replace('{2,}', '*').getRegex(),
-  text: edit(inline.gfm.text).replace('{2,}', '*').getRegex()
+  text: edit(inline.gfm.text).replace(/\{2,\}/g, '*').getRegex()
 });
 
 /**

--- a/test/redos/quadratic_br.js
+++ b/test/redos/quadratic_br.js
@@ -1,0 +1,4 @@
+module.exports = {
+  markdown: `a${' '.repeat(50000)}`,
+  html: `<p>a${' '.repeat(50000)}</p>`
+};

--- a/test/redos/quadratic_email.js
+++ b/test/redos/quadratic_email.js
@@ -1,0 +1,4 @@
+module.exports = {
+  markdown: 'a'.repeat(50000),
+  html: `<p>${'a'.repeat(50000)}</p>`
+};

--- a/test/specs/gfm/gfm.0.28.json
+++ b/test/specs/gfm/gfm.0.28.json
@@ -141,8 +141,7 @@
     "section": "Autolinks",
     "html": "<p><a href=\"mailto:a.b-c_d@a.b\">a.b-c_d@a.b</a></p>\n<p><a href=\"mailto:a.b-c_d@a.b\">a.b-c_d@a.b</a>.</p>\n<p>a.b-c_d@a.b-</p>\n<p>a.b-c_d@a.b_</p>",
     "markdown": "a.b-c_d@a.b\n\na.b-c_d@a.b.\n\na.b-c_d@a.b-\n\na.b-c_d@a.b_",
-    "example": 607,
-    "shouldFail": true
+    "example": 607
   },
   {
     "section": "Disallowed Raw HTML",

--- a/test/specs/redos-spec.js
+++ b/test/specs/redos-spec.js
@@ -1,0 +1,24 @@
+const path = require('path');
+const fs = require('fs');
+
+const redosDir = path.resolve(__dirname, '../redos');
+
+describe('ReDOS tests', () => {
+  const files = fs.readdirSync(redosDir);
+  files.forEach(file => {
+    if (!file.match(/\.js$/)) {
+      return;
+    }
+
+    it(file, () => {
+      const spec = require(path.resolve(redosDir, file));
+      const before = process.hrtime();
+      expect(spec).toRender(spec.html);
+      const elapsed = process.hrtime(before);
+      if (elapsed[0] > 0) {
+        const s = (elapsed[0] + elapsed[1] * 1e-9).toFixed(3);
+        fail(`took too long: ${s}s`);
+      }
+    });
+  });
+});


### PR DESCRIPTION
The old regex may take quadratic time to scan for potential email addresses starting at every point.  Fix it to avoid scanning from points that would have been in the middle of a previous scan.

**Marked version:**

0.1.3 and later (problem introduced by commit 00f1f7a)

**Markdown flavor:** GitHub Flavored Markdown

## Description

- Fixes DoS issue reported privately.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
