### PR TITLE
fix commonmark example 353

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -173,7 +173,6 @@ Lexer.prototype.lex = function(src) {
   src = src
     .replace(/\r\n|\r/g, '\n')
     .replace(/\t/g, '    ')
-    .replace(/\u00a0/g, ' ')
     .replace(/\u2424/g, '\n');
 
   return this.token(src, true);

--- a/test/specs/commonmark/commonmark.0.29.json
+++ b/test/specs/commonmark/commonmark.0.29.json
@@ -2871,8 +2871,7 @@
     "example": 353,
     "start_line": 6322,
     "end_line": 6326,
-    "section": "Emphasis and strong emphasis",
-    "shouldFail": true
+    "section": "Emphasis and strong emphasis"
   },
   {
     "markdown": "foo*bar*\n",


### PR DESCRIPTION
**Marked version: 0.6.2**

<!-- The NPM version or commit hash having the issue -->

**Markdown flavor:** CommonMark

related issue #1474 and [PR in Mark Text](https://github.com/marktext/marktext/pull/957)

## Description

Fixed commonMark [example 353](https://spec.commonmark.org/0.29/#example-353), in this example, there is a non-break whitespace after `*`, it should not create a list if a non-break whitespace after `*`, so I remove this `.replace(/\u00a0/g, ' ')`.

**Why not add the replacement to inline lexer?**

Because of [example 503](https://spec.commonmark.org/0.29/#example-503).

>Titles must be separated from the link using a whitespace. Other Unicode whitespace like non-breaking space doesn’t work.


## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
