### PR TITLE
Update supported spec versions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -72,8 +72,8 @@ We actively support the features of the following [Markdown flavors](https://git
 |Flavor                                                     |Version    |
 |:----------------------------------------------------------|:----------|
 |The original markdown.pl                                   |--         |
-|[CommonMark](http://spec.commonmark.org/0.28/)             |0.28       |
-|[GitHub Flavored Markdown](https://github.github.com/gfm/) |0.28       |
+|[CommonMark](http://spec.commonmark.org/0.29/)             |0.29       |
+|[GitHub Flavored Markdown](https://github.github.com/gfm/) |0.29       |
 
 By supporting the above Markdown flavors, it's possible that Marked can help you use other flavors as well; however, these are not actively supported by the community.
 


### PR DESCRIPTION
**Marked version:** master

<!-- The NPM version or commit hash having the issue -->

## Description

- Updates the docs to show 0.29 as the commonmark and gfm version

## Contributor

- [x] no tests required for this PR.

## Committer

In most cases, this should be a different person than the contributor.

- [x] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [x] Merge PR
