### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,10 @@
+# Security Policy
+
+The only completely secure system is the one that doesn't exist in the first place.
+Having said that, we take the security of Marked very seriously.
+
+## Reporting a Vulnerability
+
+Please disclose potential security issues by email to the project committers as well as the listed owners within NPM.
+We will provide an initial assessment of security reports within 48 hours and should apply patches within 2 weeks
+(also, feel free to contribute a fix for the issue).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,6 +5,6 @@ Having said that, we take the security of Marked very seriously.
 
 ## Reporting a Vulnerability
 
-Please disclose potential security issues by email to the project committers as well as the listed owners within NPM.
+Please disclose potential security issues by email to the project [committers](https://marked.js.org/#/AUTHORS.md) as well as the [listed owners within NPM](https://docs.npmjs.com/cli/owner).
 We will provide an initial assessment of security reports within 48 hours and should apply patches within 2 weeks
 (also, feel free to contribute a fix for the issue).


### PR DESCRIPTION
## Description

- Move security policy to SECURITY.md for the new GitHub Security Policy

https://help.github.com/en/articles/adding-a-security-policy-to-your-repository

![image](https://user-images.githubusercontent.com/97994/58283505-0e38f880-7d6e-11e9-8192-9a93b646499d.png)


## Contributor

- [x] no tests required for this PR.

## Committer

In most cases, this should be a different person than the contributor.

- [x] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [x] Merge PR
