### PR TITLE
revert #1464

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -200,9 +200,7 @@ Lexer.prototype.token = function(src, top) {
       l,
       isordered,
       istask,
-      ischecked,
-      blockquote,
-      count;
+      ischecked;
 
   while (src) {
     // newline
@@ -308,26 +306,16 @@ Lexer.prototype.token = function(src, top) {
         type: 'blockquote_start'
       });
 
-      blockquote = cap[0].replace(/^ *> ?/gm, '');
-      count = 1;
-      while (blockquote.match(/^ {0,3}>/)) {
-        count++;
-        this.tokens.push({
-          type: 'blockquote_start'
-        });
-        blockquote = blockquote.replace(/^ *> ?/gm, '');
-      }
+      cap = cap[0].replace(/^ *> ?/gm, '');
 
       // Pass `top` to keep the current
       // "toplevel" state. This is exactly
       // how markdown.pl works.
-      this.token(blockquote, top);
+      this.token(cap, top);
 
-      for (i = 0; i < count; i++) {
-        this.tokens.push({
-          type: 'blockquote_end'
-        });
-      }
+      this.tokens.push({
+        type: 'blockquote_end'
+      });
 
       continue;
     }
@@ -1253,27 +1241,13 @@ Parser.prototype.tok = function() {
       return this.renderer.table(header, body);
     }
     case 'blockquote_start': {
-      var count = 1;
-      while (this.peek() && this.peek().type === 'blockquote_start') {
-        this.next();
-        count++;
-      }
-
       body = '';
 
       while (this.next().type !== 'blockquote_end') {
         body += this.tok();
       }
 
-      while (this.peek() && this.peek().type === 'blockquote_end') {
-        this.next();
-      }
-
-      for (i = 0; i < count; i++) {
-        body = this.renderer.blockquote(body);
-      }
-
-      return body;
+      return this.renderer.blockquote(body);
     }
     case 'list_start': {
       body = '';

--- a/test/specs/redos/nested_blockquote.js
+++ b/test/specs/redos/nested_blockquote.js
@@ -1,4 +1,0 @@
-module.exports = {
-  markdown: '>'.repeat(5000),
-  html: '<blockquote>'.repeat(5000) + '</blockquote>'.repeat(5000)
-};


### PR DESCRIPTION
**Marked version:** master

<!-- The NPM version or commit hash having the issue -->

**Markdown flavor:** Markdown.pl|CommonMark|GitHub Flavored Markdown|n/a

## Description

Revert #1464 
Fixes #1494 

#1464 fixes recursion limit for fully nested blockquotes

```
>> a
>> b
```

but it doesn't solve recursion for partially nested blockquotes
```
> a
>> b
```

I'm not sure that we should have a special case for fully nested blockquotes.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression

## Committer

In most cases, this should be a different person than the contributor.

- [x] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [x] Merge PR
