### PR TITLE
Link parenthesis

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -728,7 +728,7 @@ InlineLexer.prototype.output = function(src) {
     if (cap = this.rules.link.exec(src)) {
       var lastParenIndex = findClosingBracket(cap[2], '()');
       if (lastParenIndex > -1) {
-        var linkLen = cap[0].length - (cap[2].length - lastParenIndex) - (cap[3] || '').length;
+        var linkLen = 4 + cap[1].length + lastParenIndex;
         cap[2] = cap[2].substring(0, lastParenIndex);
         cap[0] = cap[0].substring(0, linkLen).trim();
         cap[3] = '';

--- a/test/specs/new/links_paren.html
+++ b/test/specs/new/links_paren.html
@@ -1,0 +1,5 @@
+<p>(<a href="http://example.com/1">one</a>) (<a href="http://example.com/2">two</a>)</p>
+
+<p>(<a href="http://example.com/1">one</a>) (<a href="http://example.com/2">two</a>)</p>
+
+<p>(<a href="http://example.com/1" title="a">one</a>) (<a href="http://example.com/2" title="b">two</a>)</p>

--- a/test/specs/new/links_paren.md
+++ b/test/specs/new/links_paren.md
@@ -1,0 +1,5 @@
+([one](http://example.com/1)) ([two](http://example.com/2))
+
+([one](http://example.com/1))  ([two](http://example.com/2))
+
+([one](http://example.com/1 "a")) ([two](http://example.com/2 "b"))


### PR DESCRIPTION
**Marked version:** master

## Description

Fix multiple inline links with parenthesis around them

### Markdown

```markdown
([one](http://example.com/1)) ([two](http://example.com/2))
```

### Expected

([one](http://example.com/1)) ([two](http://example.com/2))

### Actual

([one](http://example.com/1) ([two](http://example.com/2))

- Fixes https://github.com/markedjs/marked/issues/1459#issuecomment-507046542

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
