### PR TITLE
Add ZEIT Now deployments to docs

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,5 +1,5 @@
 {
-  "name": "markedjs",
+  "name": "web",
   "scope": "markedjs",
   "alias": "markedjs.now.sh",
   "version": 2,

--- a/now.json
+++ b/now.json
@@ -9,6 +9,7 @@
   ],
   "routes": [ 
     { "src": "/repo", "status": 302, "headers": { "Location": "https://github.com/markedjs/marked" } },
+    { "src": "/old", "status": 302, "headers": { "Location": "https://marked.js.org" } },
     { "src": "/(.*)", "dest": "/docs/$1" }
   ]
 }

--- a/now.json
+++ b/now.json
@@ -1,0 +1,13 @@
+{
+  "name": "markedjs",
+  "scope": "markedjs",
+  "alias": "markedjs.now.sh",
+  "version": 2,
+  "regions": ["all"],
+  "builds": [
+    { "src": "docs/**", "use": "@now/static" }
+  ],
+  "routes": [ 
+    { "src": "/(.*)", "dest": "/docs/$1" }
+  ]
+}

--- a/now.json
+++ b/now.json
@@ -8,6 +8,7 @@
     { "src": "docs/**", "use": "@now/static" }
   ],
   "routes": [ 
+    { "src": "/repo", "status": 302, "headers": { "Location": "https://github.com/markedjs/marked" } },
     { "src": "/(.*)", "dest": "/docs/$1" }
   ]
 }

--- a/now.json
+++ b/now.json
@@ -1,5 +1,5 @@
 {
-  "name": "docs",
+  "name": "markedjs",
   "scope": "markedjs",
   "alias": "markedjs.now.sh",
   "version": 2,

--- a/now.json
+++ b/now.json
@@ -1,5 +1,5 @@
 {
-  "name": "markedjs",
+  "name": "docs",
   "scope": "markedjs",
   "alias": "markedjs.now.sh",
   "version": 2,

--- a/now.json
+++ b/now.json
@@ -1,5 +1,5 @@
 {
-  "name": "web",
+  "name": "markedjs",
   "scope": "markedjs",
   "alias": "markedjs.now.sh",
   "version": 2,


### PR DESCRIPTION
## Description

Adds [ZEIT Now](https://zeit.co/now) deployments for `/docs` to https://markedjs.now.sh

## Contributor

- [x] no tests required for this PR

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR