### PR TITLE
relative baseUrl

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1426,11 +1426,18 @@ function resolveUrl(base, href) {
     }
   }
   base = baseUrls[' ' + base];
+  var relativeBase = base.indexOf(':') === -1;
 
   if (href.slice(0, 2) === '//') {
-    return base.replace(/:[\s\S]*/, ':') + href;
+    if (relativeBase) {
+      return href;
+    }
+    return base.replace(/^([^:]+:)[\s\S]*$/, '$1') + href;
   } else if (href.charAt(0) === '/') {
-    return base.replace(/(:\/*[^/]*)[\s\S]*/, '$1') + href;
+    if (relativeBase) {
+      return href;
+    }
+    return base.replace(/^([^:]+:\/*[^/]*)[\s\S]*$/, '$1') + href;
   } else {
     return base + href;
   }

--- a/test/specs/new/relative_base_urls.html
+++ b/test/specs/new/relative_base_urls.html
@@ -1,0 +1,35 @@
+<h1 id="absolutization-of-rfc-3986-uris">Absolutization of RFC 3986 URIs</h1>
+
+<h2 id="absolute-uri">Absolute URI</h2>
+
+<p><a href="http://example.com/"><img src="http://example.com/logo" alt="section 4.3"></a></p>
+
+<h2 id="network-path-reference">Network-path reference</h2>
+
+<p><a href="//example.com/"><img src="//example.com/logo" alt="section 4.2"></a></p>
+
+<h2 id="absolute-path">Absolute path</h2>
+
+<p><a href="/path/to/content"><img src="/path/to/img" alt="section 4.2"></a></p>
+
+<h2 id="relative-path">Relative path</h2>
+
+<p><a href="/base/content"><img src="/base/img" alt="section 4.2"></a></p>
+
+<h2 id="dot-relative-path">Dot-relative path</h2>
+
+<p><a href="/base/./content"><img src="/base/./img" alt="section 3.3"></a></p>
+
+<p><a href="/base/../content"><img src="/base/../img" alt="section 3.3"></a></p>
+
+<h2 id="same-document-query">Same-document query</h2>
+
+<p><a href="?"><img src="?type=image" alt="section 4.4"></a></p>
+
+<h2 id="same-document-fragment">Same-document fragment</h2>
+
+<p><a href="#"><img src="#img" alt="section 4.4"></a></p>
+
+<h2 id="empty">Empty</h2>
+
+<p><a href="">section 4.2</a></p>

--- a/test/specs/new/relative_base_urls.md
+++ b/test/specs/new/relative_base_urls.md
@@ -1,0 +1,30 @@
+---
+baseUrl: "/base/"
+---
+# Absolutization of RFC 3986 URIs
+
+## Absolute URI
+[![section 4.3](http://example.com/logo)](http://example.com/)
+
+## Network-path reference
+[![section 4.2](//example.com/logo)](//example.com/)
+
+## Absolute path
+[![section 4.2](/path/to/img)](/path/to/content)
+
+## Relative path
+[![section 4.2](img)](content)
+
+## Dot-relative path
+[![section 3.3](./img)](./content)
+
+[![section 3.3](../img)](../content)
+
+## Same-document query
+[![section 4.4](?type=image)](?)
+
+## Same-document fragment
+[![section 4.4](#img)](#)
+
+## Empty
+[section 4.2]()


### PR DESCRIPTION
**Marked version:** master

## Description

Allow `baseUrl` option to be a relative url.

- Closes #1513 
- Fixes #1466 

## Expectation

```html
<p><img src="/favicon.ico" alt="alt text" title="relative"></p>
```

## Result

```html
<p><img src="/derp//favicon.ico" alt="alt text" title="relative"></p>
```

## What was attempted

```js
marked('![alt text](/favicon.ico "relative")', {baseUrl: "/derp/"});
```

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression.
- [x] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
