### PR TITLE
Allow links to be multiline

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -573,7 +573,7 @@ inline.tag = edit(inline.tag)
   .getRegex();
 
 inline._label = /(?:\[[^\[\]]*\]|\\.|`[^`]*`|[^\[\]\\`])*?/;
-inline._href = /<(?:\\[<>]?|[^\s<>\\])*>|[^\s\x00-\x1f]*/;
+inline._href = /<(?:\\[<>]?|[^\s<>\\])*>|[^\x00-\x09\x0b-\x20]*/;
 inline._title = /"(?:\\"?|[^"\\])*"|'(?:\\'?|[^'\\])*'|\((?:\\\)?|[^)\\])*\)/;
 
 inline.link = edit(inline.link)


### PR DESCRIPTION

<!--

	If release PR, add ?template=release.md to the PR url to use the release PR template.

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->

**Marked version:**

0.4.0

**Markdown flavor:** Markdown.pl|CommonMark|GitHub Flavored Markdown|n/a

## Description

Since raven.js updated marked in their package form 0.3.19 to 0.6.0, changes in 0.4.0 also was included.
I notice, that since 0.4.0 multiline links not allowed: [demo](https://marked.js.org/demo/?text=%23%20yUML%0A%0A!%5B%5D(http%3A%2F%2Fyuml.me%2Fdiagram%2Fplain%2Fclass%2F%0A%2F%2F%20%7Btype%3Aclass%7D%2C%0A%2F%2F%20%7Bdirection%3AleftToRight%7D%2C%0A%2F%2F%20Cool%20Class%20Diagram%2C%0A%5BCustomer%5D-orders*%3E%5BOrder%5D%2C%0A%5BOrder%5D%2B%2B-0..*%3E%5BLineItem%5D%2C%0A%5BOrder%5D-%5BAggregate%20root%5D%2C%0A)&options=%7B%0A%20%22baseUrl%22%3A%20null%2C%0A%20%22breaks%22%3A%20false%2C%0A%20%22gfm%22%3A%20true%2C%0A%20%22headerIds%22%3A%20true%2C%0A%20%22headerPrefix%22%3A%20%22%22%2C%0A%20%22highlight%22%3A%20null%2C%0A%20%22langPrefix%22%3A%20%22language-%22%2C%0A%20%22mangle%22%3A%20true%2C%0A%20%22pedantic%22%3A%20false%2C%0A%20%22sanitize%22%3A%20false%2C%0A%20%22sanitizer%22%3A%20null%2C%0A%20%22silent%22%3A%20false%2C%0A%20%22smartLists%22%3A%20false%2C%0A%20%22smartypants%22%3A%20false%2C%0A%20%22xhtml%22%3A%20false%0A%7D&version=0.3.19)

I assume, that inline text should not contain line breaks, but MD is for humans, so maybe we want to split link into multiple lines for readability.
I assume, that links should not contain spaces

Please check - is it still vulnerable? (#1223)

```
# YUML

![](http://yuml.me/diagram/plain/class/
//%20{type:class},
//%20{direction:leftToRight},
//%20Cool%20Class%20Diagram,
[Customer]-orders*>[Order],
[Order]++-0..*>[LineItem],
[Order]-[Aggregate%20root],
)
```

- #1135  (e66f7aa7b9d79e2f9b5c1f3d1ba63ae948216c82)
- https://github.com/markedjs/marked/blame/e66f7aa7b9d79e2f9b5c1f3d1ba63ae948216c82/lib/marked.js
- #1223
- https://regexr.com/4l5ou

<!--

	If no issue exists that you're aware of. The maintainers should be able to figure out if it's a duplicate.

## Expectation

`\x00-\x09\x0b-\x20` - will also contain `\s`, except `\n` (`\13` || `\x0a`) character. (`/\t /`)

## Result

Describe the output you received from marked

## What was attempted

Describe what code combination got you there

-->

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
