### PR TITLE
Node worker threads are stable

### DIFF
--- a/docs/USING_ADVANCED.md
+++ b/docs/USING_ADVANCED.md
@@ -83,10 +83,6 @@ Marked can be run in a [worker thread](https://nodejs.org/api/worker_threads.htm
 
 ### Node Worker Thread
 
-> 🚨 Node Worker Threads are [experimental](https://nodejs.org/api/worker_threads.html#worker_threads_worker_threads) 🚨
->
-> This implementation may change.
-
 ```js
 // markedWorker.js
 


### PR DESCRIPTION
**Marked version:** docs

## Description

Remove warning about node worker threads since they are stable in v12.11.0

## Contributor

- [x] no tests required for this PR.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
