### PR TITLE
fix image parentheses

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -723,7 +723,8 @@ InlineLexer.prototype.output = function(src) {
     if (cap = this.rules.link.exec(src)) {
       var lastParenIndex = findClosingBracket(cap[2], '()');
       if (lastParenIndex > -1) {
-        var linkLen = 4 + cap[1].length + lastParenIndex;
+        var start = cap[0].indexOf('!') === 0 ? 5 : 4;
+        var linkLen = start + cap[1].length + lastParenIndex;
         cap[2] = cap[2].substring(0, lastParenIndex);
         cap[0] = cap[0].substring(0, linkLen).trim();
         cap[3] = '';

--- a/test/specs/new/image_paren.html
+++ b/test/specs/new/image_paren.html
@@ -1,0 +1,3 @@
+<p><img src="img1.svg" alt=""> (or <img src="img2.svg" alt="">)</p>
+
+<p><img src="img1.svg" alt="one"> (or <img src="img2.svg" alt="two">)</p>

--- a/test/specs/new/image_paren.md
+++ b/test/specs/new/image_paren.md
@@ -1,0 +1,3 @@
+![](img1.svg) (or ![](img2.svg))
+
+![one](img1.svg) (or ![two](img2.svg))


### PR DESCRIPTION
**Marked version:** 0.7.0


## Description

Fix image surrounded by parentheses

fixes #1556

[demo](https://marked.js.org/demo/?outputType=html&text=!%5B%5D(img1.svg)%20(or%20!%5B%5D(img2.svg))&options=%7B%0A%20%22baseUrl%22%3A%20null%2C%0A%20%22breaks%22%3A%20false%2C%0A%20%22gfm%22%3A%20true%2C%0A%20%22headerIds%22%3A%20true%2C%0A%20%22headerPrefix%22%3A%20%22%22%2C%0A%20%22highlight%22%3A%20null%2C%0A%20%22langPrefix%22%3A%20%22language-%22%2C%0A%20%22mangle%22%3A%20true%2C%0A%20%22pedantic%22%3A%20false%2C%0A%20%22sanitize%22%3A%20false%2C%0A%20%22sanitizer%22%3A%20null%2C%0A%20%22silent%22%3A%20false%2C%0A%20%22smartLists%22%3A%20false%2C%0A%20%22smartypants%22%3A%20false%2C%0A%20%22xhtml%22%3A%20false%0A%7D&version=0.7.0) works in v0.6.3 but not v0.7.0

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
