### PR TITLE
Converting tabs to appropriate number of spaces for proper alignment.

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -4,7 +4,9 @@
  * https://github.com/markedjs/marked
  */
 
-;(function(root) {
+var tabToSpace = require('tab-to-space');
+
+(function(root) {
 'use strict';
 
 /**
@@ -168,8 +170,9 @@ Lexer.lex = function(src, options) {
 
 Lexer.prototype.lex = function(src) {
   src = src
-    .replace(/\r\n|\r/g, '\n')
-    .replace(/\t/g, '    ');
+    .replace(/\r\n|\r/g, '\n');
+
+  src = tabToSpace(src);
 
   return this.token(src, true);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1936,6 +1936,11 @@
         "get-port": "^3.1.0"
       }
     },
+    "tab-to-space": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tab-to-space/-/tab-to-space-1.0.1.tgz",
+      "integrity": "sha512-JoYzbAIeVRPhpCN9cQ/+I0J1j/IXc0WnttmPy75vjXLzeAmUm7LgookGFOmrB4FcPNMSHskGJnBTBQi/0LrfBA=="
+    },
     "table": {
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",

--- a/package.json
+++ b/package.json
@@ -62,5 +62,8 @@
   },
   "engines": {
     "node": ">=0.10.0"
+  },
+  "dependencies": {
+    "tab-to-space": "1.0.1"
   }
 }


### PR DESCRIPTION
<!--

	If release PR, add ?template=release.md to the PR url to use the release PR template.

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->

**Marked version: 0.7.0**

**Markdown flavor:** Markdown.pl|CommonMark|GitHub Flavored Markdown|n/a

## Description

- Fixes #1559

## Expectation
I expect the output to be the same what it was looking while I wrote the text.
The output is different when the text contains tabs.
I expect such output:
<img width="538" alt="image" src="https://user-images.githubusercontent.com/22790328/66267288-b5658a80-e84c-11e9-8963-81a603376f4d.png">

## Result
This is the output I am getting:
![image](https://user-images.githubusercontent.com/22790328/66267298-c8785a80-e84c-11e9-9f20-6bcff2f5a067.png)


## What was attempted
I have included my package [tab-to-space](https://www.npmjs.com/package/tab-to-space) to convert tabs to the appropriate number of spaces in the Lexer prototype. This solves the alignment issue.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
