### PR TITLE
Remove incorrectly used browser field

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "version": "0.7.0",
   "main": "./src/marked.js",
   "module": "./lib/marked.esm.js",
-  "browser": {
-    "./src/marked.js": "./lib/marked.js"
-  },
   "bin": "./bin/marked",
   "man": "./man/marked.1",
   "files": [


### PR DESCRIPTION
This is a common misconception - but browser field is not for pointing to a fully browser-compatible file (like in your case you have wanted to point with it to the UMD bundle). It exists to alias files depending on node-specific modules/APIs to files that can be used in browsers (so for example with node-specific modules/APIs stubbed) after bundling etc. 

For example webpack picks "browser" field over "module" by default if provided and that kinda makes "module" file not-used - but the intention is to actually use it.

As you don't depend on any node-specific stuff the appropriate course of action is to just remove this field from your package.json