### PR TITLE
Remove changeDefaults

### DIFF
--- a/src/InlineLexer.js
+++ b/src/InlineLexer.js
@@ -1,5 +1,5 @@
 const Renderer = require('./Renderer.js');
-const { defaults } = require('./defaults.js');
+const getDefaults = require('./defaults.js');
 const { inline } = require('./rules.js');
 const {
   findClosingBracket,
@@ -11,7 +11,7 @@ const {
  */
 module.exports = class InlineLexer {
   constructor(links, options) {
-    this.options = options || defaults;
+    this.options = options || getDefaults();
     this.links = links;
     this.rules = inline.normal;
     this.options.renderer = this.options.renderer || new Renderer();

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -1,4 +1,4 @@
-const { defaults } = require('./defaults.js');
+const getDefaults = require('./defaults.js');
 const { block } = require('./rules.js');
 const {
   rtrim,
@@ -13,7 +13,7 @@ module.exports = class Lexer {
   constructor(options) {
     this.tokens = [];
     this.tokens.links = Object.create(null);
-    this.options = options || defaults;
+    this.options = options || getDefaults();
     this.rules = block.normal;
 
     if (this.options.pedantic) {

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -2,7 +2,7 @@ const Renderer = require('./Renderer.js');
 const Slugger = require('./Slugger.js');
 const InlineLexer = require('./InlineLexer.js');
 const TextRenderer = require('./TextRenderer.js');
-const { defaults } = require('./defaults.js');
+const getDefaults = require('./defaults.js');
 const {
   merge,
   unescape
@@ -15,7 +15,7 @@ module.exports = class Parser {
   constructor(options) {
     this.tokens = [];
     this.token = null;
-    this.options = options || defaults;
+    this.options = options || getDefaults();
     this.options.renderer = this.options.renderer || new Renderer();
     this.renderer = this.options.renderer;
     this.renderer.options = this.options;

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -1,4 +1,4 @@
-const { defaults } = require('./defaults.js');
+const getDefaults = require('./defaults.js');
 const {
   cleanUrl,
   escape
@@ -9,7 +9,7 @@ const {
  */
 module.exports = class Renderer {
   constructor(options) {
-    this.options = options || defaults;
+    this.options = options || getDefaults();
   }
 
   code(code, infostring, escaped) {

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,6 +1,4 @@
-let defaults = getDefaults();
-
-function getDefaults() {
+module.exports = function getDefaults() {
   return {
     baseUrl: null,
     breaks: false,
@@ -19,14 +17,4 @@ function getDefaults() {
     smartypants: false,
     xhtml: false
   };
-}
-
-function changeDefaults(newDefaults) {
-  defaults = newDefaults;
-}
-
-module.exports = {
-  defaults,
-  getDefaults,
-  changeDefaults
 };

--- a/src/marked.js
+++ b/src/marked.js
@@ -9,11 +9,7 @@ const {
   checkSanitizeDeprecation,
   escape
 } = require('./helpers.js');
-const {
-  getDefaults,
-  changeDefaults,
-  defaults
-} = require('./defaults.js');
+const getDefaults = require('./defaults.js');
 
 /**
  * Marked
@@ -119,13 +115,12 @@ function marked(src, opt, callback) {
 marked.options =
 marked.setOptions = function(opt) {
   merge(marked.defaults, opt);
-  changeDefaults(marked.defaults);
   return marked;
 };
 
 marked.getDefaults = getDefaults;
 
-marked.defaults = defaults;
+marked.defaults = getDefaults();
 
 /**
  * Expose


### PR DESCRIPTION
As far as I can tell this has stayed unused - `changeDefaults` was only changing a local variable and that didn't affect anything. There are also no tests associated with it.

I've wanted also to remove `defaults` as it seems a duplication of `getDefaults`, but you actually indirectly rely on it - because it's not a constant value, this actually is a static property of `marked` and you allow for consumers to mutate this with `setOptions`. I would like to strongly argue that this is not good - if one wants to use marked with custom options they should provide it for a particular call/instance. It's highly dangerous to allow mutation on such a global/shared state - other module using marked and mutating this might affect how marked behave for me and this is totally unexpected from the user's point of view.