### PR TITLE
fix changing global defaults

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,5 +1,3 @@
-let defaults = getDefaults();
-
 function getDefaults() {
   return {
     baseUrl: null,
@@ -22,11 +20,11 @@ function getDefaults() {
 }
 
 function changeDefaults(newDefaults) {
-  defaults = newDefaults;
+  module.exports.defaults = newDefaults;
 }
 
 module.exports = {
-  defaults,
+  defaults: getDefaults(),
   getDefaults,
   changeDefaults
 };

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -71,3 +71,12 @@ describe('Test paragraph token type', () => {
     expect(tokens[7].type).toBe('text');
   });
 });
+
+describe('changeDefaults', () => {
+  it('should change global defaults', () => {
+    const { defaults, changeDefaults } = require('../../src/defaults');
+    expect(defaults.test).toBeUndefined();
+    changeDefaults({ test: true });
+    expect(require('../../src/defaults').defaults.test).toBe(true);
+  });
+});


### PR DESCRIPTION
**Marked version:** master

## Description

fix regression in `setOptions` being global

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
