### PR TITLE
fix build user

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ jobs:
       script: |
         npm run build
         if ! git diff --quiet; then
-          git config --global user.email "travis@travis-ci.org"
-          git config --global user.name "Travis-CI"
+          git config --global user.email "<>"
+          git config --global user.name "MarkedJS bot"
           git config credential.helper "store --file=.git/credentials"
           echo "https://${GITHUB_TOKEN}:@github.com" > .git/credentials
           git commit -am '🗜️ build [skip ci]'


### PR DESCRIPTION
## Description

I think this will fix the wrong user showing up as the committer for the build step on travis ci.

![image](https://user-images.githubusercontent.com/97994/70343597-4f31bf80-181d-11ea-824d-88c567eda522.png)

`<>` is used to indicate no email address according to [stackoverflow](https://stackoverflow.com/a/28933328/806777).

## Contributor

- [x] no tests required for this PR.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
