### PR TITLE
Add tests to show parser breaking when links end with underscores

### DIFF
--- a/test/specs/new/underscore_link.html
+++ b/test/specs/new/underscore_link.html
@@ -1,0 +1,1 @@
+<p><a href="https://www.google.com/maps_">https://www.google.com/maps_</a></p>

--- a/test/specs/new/underscore_link.md
+++ b/test/specs/new/underscore_link.md
@@ -1,0 +1,4 @@
+---
+sanitize: true
+---
+https://www.google.com/maps_


### PR DESCRIPTION
**Marked version:** 0.8.0

**Markdown flavor:** Markdown.pl|CommonMark|GitHub Flavored Markdown|n/a

## Description

When parsing a block of markdown content that contain inline links, links ending with underscores are not parsed correctly. The following link https://www.google.com/maps_ should be parsed as [https://www.google.com/maps_](https://www.google.com/maps_)

I've created a test case which highlights the issue. I'll dig around to see if I can find where this happens.

## Expectation

Expected: [https://www.google.com/maps_](https://www.google.com/maps_)

## Result

Result: [https://www.google.com/maps](https://www.google.com/maps)_
