### PR TITLE
Fix GFM tables not breaking on block-level structures

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -111,8 +111,6 @@ block.gfm.table = edit(block.gfm.table)
   .replace('tag', block._tag) // pars can be interrupted by type (6) html blocks
   .getRegex();
 
-console.log(block.gfm.table);
-
 /**
  * Pedantic grammar (original John Gruber's loose markdown specification)
  */

--- a/src/rules.js
+++ b/src/rules.js
@@ -105,7 +105,7 @@ block.gfm.table = edit(block.gfm.table)
   .replace('lheading', '([^\\n]+)\\n {0,3}(=+|-+) *(?:\\n+|$)')
   .replace('blockquote', ' {0,3}>')
   .replace('code', ' {4}[^\\n]')
-  .replace('fences', ' {0,3}(?:`{3,}|~{3,})[^`\\n]*\\n')
+  .replace('fences', ' {0,3}(?:`{3,}(?=[^`\\n]*\\n)|~{3,})[^\\n]*\\n')
   .replace('list', ' {0,3}(?:[*+-]|1[.)]) ') // only lists starting from 1 can interrupt
   .replace('html', '</?(?:tag)(?: +|\\n|/?>)|<(?:script|pre|style|!--)')
   .replace('tag', block._tag) // pars can be interrupted by type (6) html blocks

--- a/src/rules.js
+++ b/src/rules.js
@@ -69,7 +69,7 @@ block.html = edit(block.html, 'i')
 
 block.paragraph = edit(block._paragraph)
   .replace('hr', block.hr)
-  .replace('heading', ' {0,3}#{1,6} +')
+  .replace('heading', ' {0,3}#{1,6} ')
   .replace('|lheading', '') // setex headings don't interrupt commonmark paragraphs
   .replace('blockquote', ' {0,3}>')
   .replace('fences', ' {0,3}(?:`{3,}|~{3,})[^`\\n]*\\n')
@@ -101,7 +101,7 @@ block.gfm = merge({}, block.normal, {
 
 block.gfm.table = edit(block.gfm.table)
   .replace('hr', block.hr)
-  .replace('heading', ' {0,3}#{1,6} +')
+  .replace('heading', ' {0,3}#{1,6} ')
   .replace('lheading', '([^\\n]+)\\n {0,3}(=+|-+) *(?:\\n+|$)')
   .replace('blockquote', ' {0,3}>')
   .replace('code', ' {4}[^\\n]')

--- a/src/rules.js
+++ b/src/rules.js
@@ -104,7 +104,7 @@ block.gfm.table = edit(block.gfm.table)
   .replace('heading', ' {0,3}#{1,6} +')
   .replace('lheading', '([^\\n]+)\\n {0,3}(=+|-+) *(?:\\n+|$)')
   .replace('blockquote', ' {0,3}>')
-  .replace('code', ' {4}[^\\n]+')
+  .replace('code', ' {4}[^\\n]')
   .replace('fences', ' {0,3}(?:`{3,}|~{3,})[^`\\n]*\\n')
   .replace('list', ' {0,3}(?:[*+-]|1[.)]) ') // only lists starting from 1 can interrupt
   .replace('html', '</?(?:tag)(?: +|\\n|/?>)|<(?:script|pre|style|!--)')

--- a/src/rules.js
+++ b/src/rules.js
@@ -94,8 +94,24 @@ block.normal = merge({}, block);
 
 block.gfm = merge({}, block.normal, {
   nptable: /^ *([^|\n ].*\|.*)\n *([-:]+ *\|[-| :]*)(?:\n((?:.*[^>\n ].*(?:\n|$))*)\n*|$)/,
-  table: /^ *\|(.+)\n *\|?( *[-:]+[-| :]*)(?:\n((?: *[^>\n ].*(?:\n|$))*)\n*|$)/
+  table: '^ *\\|(.+)\\n' // Header
+    + ' *\\|?( *[-:]+[-| :]*)' // Align
+    + '(?:\\n((?:(?!^|>|\\n| |hr|heading|lheading|code|fences|list|html).*(?:\\n|$))*)\\n*|$)' // Cells
 });
+
+block.gfm.table = edit(block.gfm.table)
+  .replace('hr', block.hr)
+  .replace('heading', ' {0,3}#{1,6} +')
+  .replace('lheading', '([^\\n]+)\\n {0,3}(=+|-+) *(?:\\n+|$)')
+  .replace('blockquote', ' {0,3}>')
+  .replace('code', ' {4}[^\\n]+')
+  .replace('fences', ' {0,3}(?:`{3,}|~{3,})[^`\\n]*\\n')
+  .replace('list', ' {0,3}(?:[*+-]|1[.)]) ') // only lists starting from 1 can interrupt
+  .replace('html', '</?(?:tag)(?: +|\\n|/?>)|<(?:script|pre|style|!--)')
+  .replace('tag', block._tag) // pars can be interrupted by type (6) html blocks
+  .getRegex();
+
+console.log(block.gfm.table);
 
 /**
  * Pedantic grammar (original John Gruber's loose markdown specification)

--- a/test/specs/new/code_following_table.html
+++ b/test/specs/new/code_following_table.html
@@ -1,0 +1,21 @@
+<table>
+  <thead>
+    <tr>
+      <th>abc</th>
+      <th>def</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>bar</td>
+      <td>foo</td>
+    </tr>
+    <tr>
+      <td>baz</td>
+      <td>boo</td>
+    </tr>
+  </tbody>
+</table>
+<pre><code>a simple
+ *indented* code block
+</code></pre>

--- a/test/specs/new/code_following_table.md
+++ b/test/specs/new/code_following_table.md
@@ -1,0 +1,6 @@
+| abc | def |
+| --- | --- |
+| bar | foo |
+| baz | boo |
+    a simple
+      *indented* code block

--- a/test/specs/new/fences_following_table.html
+++ b/test/specs/new/fences_following_table.html
@@ -1,0 +1,19 @@
+<table>
+  <thead>
+    <tr>
+      <th>abc</th>
+      <th>def</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>bar</td>
+      <td>foo</td>
+    </tr>
+    <tr>
+      <td>baz</td>
+      <td>boo</td>
+    </tr>
+  </tbody>
+</table>
+<pre><code>foobar()</code></pre>

--- a/test/specs/new/fences_following_table.md
+++ b/test/specs/new/fences_following_table.md
@@ -1,0 +1,7 @@
+| abc | def |
+| --- | --- |
+| bar | foo |
+| baz | boo |
+```
+foobar()
+```

--- a/test/specs/new/heading_following_table.html
+++ b/test/specs/new/heading_following_table.html
@@ -1,0 +1,19 @@
+<table>
+  <thead>
+    <tr>
+      <th>abc</th>
+      <th>def</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>bar</td>
+      <td>foo</td>
+    </tr>
+    <tr>
+      <td>baz</td>
+      <td>boo</td>
+    </tr>
+  </tbody>
+</table>
+<h1 id="title">title</h1>

--- a/test/specs/new/heading_following_table.md
+++ b/test/specs/new/heading_following_table.md
@@ -1,0 +1,5 @@
+| abc | def |
+| --- | --- |
+| bar | foo |
+| baz | boo |
+# title

--- a/test/specs/new/hr_following_tables.html
+++ b/test/specs/new/hr_following_tables.html
@@ -1,0 +1,19 @@
+<table>
+  <thead>
+    <tr>
+      <th>abc</th>
+      <th>def</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>bar</td>
+      <td>foo</td>
+    </tr>
+    <tr>
+      <td>baz</td>
+      <td>boo</td>
+    </tr>
+  </tbody>
+</table>
+<hr>

--- a/test/specs/new/hr_following_tables.md
+++ b/test/specs/new/hr_following_tables.md
@@ -1,0 +1,5 @@
+| abc | def |
+| --- | --- |
+| bar | foo |
+| baz | boo |
+___

--- a/test/specs/new/html_following_table.html
+++ b/test/specs/new/html_following_table.html
@@ -1,0 +1,19 @@
+<table>
+  <thead>
+    <tr>
+      <th>abc</th>
+      <th>def</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>bar</td>
+      <td>foo</td>
+    </tr>
+    <tr>
+      <td>baz</td>
+      <td>boo</td>
+    </tr>
+  </tbody>
+</table>
+<div>Some HTML</div>

--- a/test/specs/new/html_following_table.md
+++ b/test/specs/new/html_following_table.md
@@ -1,0 +1,5 @@
+| abc | def |
+| --- | --- |
+| bar | foo |
+| baz | boo |
+<div>Some HTML</div>

--- a/test/specs/new/inlinecode_following_tables.html
+++ b/test/specs/new/inlinecode_following_tables.html
@@ -1,0 +1,22 @@
+<table>
+  <thead>
+    <tr>
+      <th>abc</th>
+      <th>def</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>bar</td>
+      <td>foo</td>
+    </tr>
+    <tr>
+      <td>baz</td>
+      <td>boo</td>
+    </tr>
+    <tr>
+      <td><code>hello</code></td>
+      <td></td>
+    </tr>
+  </tbody>
+</table>

--- a/test/specs/new/inlinecode_following_tables.md
+++ b/test/specs/new/inlinecode_following_tables.md
@@ -1,0 +1,5 @@
+| abc | def |
+| --- | --- |
+| bar | foo |
+| baz | boo |
+`hello`

--- a/test/specs/new/lheading_following_table.html
+++ b/test/specs/new/lheading_following_table.html
@@ -1,0 +1,19 @@
+<table>
+  <thead>
+    <tr>
+      <th>abc</th>
+      <th>def</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>bar</td>
+      <td>foo</td>
+    </tr>
+    <tr>
+      <td>baz</td>
+      <td>boo</td>
+    </tr>
+  </tbody>
+</table>
+<h1 id="title">title</h1>

--- a/test/specs/new/lheading_following_table.md
+++ b/test/specs/new/lheading_following_table.md
@@ -1,0 +1,6 @@
+| abc | def |
+| --- | --- |
+| bar | foo |
+| baz | boo |
+title
+=====

--- a/test/specs/new/list_following_table.html
+++ b/test/specs/new/list_following_table.html
@@ -1,0 +1,23 @@
+<table>
+  <thead>
+    <tr>
+      <th>abc</th>
+      <th>def</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>bar</td>
+      <td>foo</td>
+    </tr>
+    <tr>
+      <td>baz</td>
+      <td>boo</td>
+    </tr>
+  </tbody>
+</table>
+<ul>
+  <li>foo</li>
+  <li>bar</li>
+  <li>baz</li>
+</ul>

--- a/test/specs/new/list_following_table.md
+++ b/test/specs/new/list_following_table.md
@@ -1,0 +1,7 @@
+| abc | def |
+| --- | --- |
+| bar | foo |
+| baz | boo |
+- foo
+- bar
+- baz

--- a/test/specs/new/strong_following_tables.html
+++ b/test/specs/new/strong_following_tables.html
@@ -1,0 +1,22 @@
+<table>
+  <thead>
+    <tr>
+      <th>abc</th>
+      <th>def</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>bar</td>
+      <td>foo</td>
+    </tr>
+    <tr>
+      <td>baz</td>
+      <td>boo</td>
+    </tr>
+    <tr>
+      <td><strong>strong</strong></td>
+      <td></td>
+    </tr>
+  </tbody>
+</table>

--- a/test/specs/new/strong_following_tables.md
+++ b/test/specs/new/strong_following_tables.md
@@ -1,0 +1,5 @@
+| abc | def |
+| --- | --- |
+| bar | foo |
+| baz | boo |
+**strong**

--- a/test/specs/new/text_following_tables.html
+++ b/test/specs/new/text_following_tables.html
@@ -1,0 +1,22 @@
+<table>
+  <thead>
+    <tr>
+      <th>abc</th>
+      <th>def</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>bar</td>
+      <td>foo</td>
+    </tr>
+    <tr>
+      <td>baz</td>
+      <td>boo</td>
+    </tr>
+    <tr>
+      <td>hello</td>
+      <td></td>
+    </tr>
+  </tbody>
+</table>

--- a/test/specs/new/text_following_tables.md
+++ b/test/specs/new/text_following_tables.md
@@ -1,0 +1,5 @@
+| abc | def |
+| --- | --- |
+| bar | foo |
+| baz | boo |
+hello


### PR DESCRIPTION
<!--

	If release PR, add ?template=release.md to the PR url to use the release PR template.

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->

**Marked version:** 8.0

<!-- The NPM version or commit hash having the issue -->

**Markdown flavor:** GitHub Flavored Markdown

## Description

- Fixes #1467 

## What was attempted

Edited rules.js to break GFM tables properly using similar syntax used to break paragraphs.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR);

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
