### PR TITLE
Fix GFM Example 116

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -10,7 +10,7 @@ const {
 const block = {
   newline: /^\n+/,
   code: /^( {4}[^\n]+\n*)+/,
-  fences: /^ {0,3}(`{3,}|~{3,})([^`~\n]*)\n(?:|([\s\S]*?)\n)(?: {0,3}\1[~`]* *(?:\n+|$)|$)/,
+  fences: /^ {0,3}(`{3,}(?=[^`\n]*\n)|~{3,})([^\n]*)\n(?:|([\s\S]*?)\n)(?: {0,3}\1[~`]* *(?:\n+|$)|$)/,
   hr: /^ {0,3}((?:- *){3,}|(?:_ *){3,}|(?:\* *){3,})(?:\n+|$)/,
   heading: /^ {0,3}(#{1,6}) +([^\n]*?)(?: +#+)? *(?:\n+|$)/,
   blockquote: /^( {0,3}> ?(paragraph|[^\n]*)(?:\n|$))+/,
@@ -72,7 +72,7 @@ block.paragraph = edit(block._paragraph)
   .replace('heading', ' {0,3}#{1,6} +')
   .replace('|lheading', '') // setex headings don't interrupt commonmark paragraphs
   .replace('blockquote', ' {0,3}>')
-  .replace('fences', ' {0,3}(?:`{3,}|~{3,})[^`\\n]*\\n')
+  .replace('fences', ' {0,3}(?:`{3,}(?=[^`\\n]*\\n)|~{3,})[^\\n]*\\n')
   .replace('list', ' {0,3}(?:[*+-]|1[.)]) ') // only lists starting from 1 can interrupt
   .replace('html', '</?(?:tag)(?: +|\\n|/?>)|<(?:script|pre|style|!--)')
   .replace('tag', block._tag) // pars can be interrupted by type (6) html blocks

--- a/test/specs/commonmark/commonmark.0.29.json
+++ b/test/specs/commonmark/commonmark.0.29.json
@@ -930,8 +930,7 @@
     "example": 116,
     "start_line": 1996,
     "end_line": 2003,
-    "section": "Fenced code blocks",
-    "shouldFail": true
+    "section": "Fenced code blocks"
   },
   {
     "markdown": "```\n``` aaa\n```\n",

--- a/test/specs/gfm/commonmark.0.29.json
+++ b/test/specs/gfm/commonmark.0.29.json
@@ -930,8 +930,7 @@
     "example": 116,
     "start_line": 1996,
     "end_line": 2003,
-    "section": "Fenced code blocks",
-    "shouldFail": true
+    "section": "Fenced code blocks"
   },
   {
     "markdown": "```\n``` aaa\n```\n",

--- a/test/specs/new/fences_breaking_paragraphs.html
+++ b/test/specs/new/fences_breaking_paragraphs.html
@@ -1,0 +1,14 @@
+<p>A paragraph</p>
+<pre><code class="language-A">Here is code in
+backtick fences</code></pre>
+<p>B paragraph</p>
+<pre><code class="language-B">Here is code in
+tilde fences</code></pre>
+<p>C paragraph</p>
+<pre><code class="language-`C~">Alternative
+tilde fences</code></pre>
+<p>D paragraph ```~D` Invalid use of backtick fences</p>
+<pre><code>
+This will be read as
+part of a codeblock
+that ends with the file</code></pre>

--- a/test/specs/new/fences_breaking_paragraphs.md
+++ b/test/specs/new/fences_breaking_paragraphs.md
@@ -1,0 +1,27 @@
+A paragraph
+```A
+Here is code in
+backtick fences
+```
+
+B paragraph
+~~~B
+Here is code in
+tilde fences
+~~~
+
+C paragraph
+~~~`C~
+Alternative
+tilde fences
+~~~
+
+D paragraph
+```~D`
+Invalid use of
+backtick fences
+```
+
+This will be read as
+part of a codeblock
+that ends with the file


### PR DESCRIPTION
<!--

	If release PR, add ?template=release.md to the PR url to use the release PR template.

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->

**Marked version:** 8.0

<!-- The NPM version or commit hash having the issue -->

**Markdown flavor:** CommonMark & GitHub Flavored Markdown

## Description

- Fixes GFM ([Example 116](https://github.github.com/gfm/#example-116)). Only code fences made from backticks [cannot have other backticks in the same line](https://github.github.com/gfm/#example-115). Fences with tildes [can have both tildes and backticks.](https://github.github.com/gfm/#example-116). This change allows the tilde case to work correctly.

Also adds tests for detection of these fences if they should or not break paragraphs.

Implementing code as discussed in https://github.com/markedjs/marked/pull/1598#discussion_r377252499

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression

## Committer

In most cases, this should be a different person than the contributor.

- [x] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [x] Merge PR
