### PR TITLE
Add missing syntax render functions to TextRenderer

### DIFF
--- a/src/TextRenderer.js
+++ b/src/TextRenderer.js
@@ -3,7 +3,54 @@
  * returns only the textual part of the token
  */
 module.exports = class TextRenderer {
-  // no need for block level renderers
+  code(code) {
+    return code;
+  }
+
+  blockquote(text) {
+    return text;
+  }
+
+  html() {
+    return '';
+  }
+
+  heading(text) {
+    return text;
+  }
+
+  hr() {
+    return '';
+  }
+
+  list(body) {
+    return body;
+  }
+
+  listitem(text) {
+    return text + '\n';
+  }
+
+  checkbox() {
+    return '';
+  }
+
+  paragraph(text) {
+    return text + '\n';
+  }
+
+  table() {
+    return '';
+  }
+
+  tablerow() {
+    return '';
+  }
+
+  tablecell() {
+    return '';
+  }
+
   strong(text) {
     return text;
   }
@@ -35,4 +82,9 @@ module.exports = class TextRenderer {
   br() {
     return '';
   }
+
+  link(href, title, text) {
+    return '' + text;
+  }
+
 };


### PR DESCRIPTION
The following code currently leads to errors such as `TypeError: this.renderer.listitem is not a function`:

```javascript
marked(text, { renderer: new marked.TextRenderer });
```

This change provides a fix for those errors.


<!--

	If release PR, add ?template=release.md to the PR url to use the release PR template.

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->

**Marked version:**

<!-- The NPM version or commit hash having the issue -->

**Markdown flavor:** Markdown.pl|CommonMark|GitHub Flavored Markdown|n/a

## Description

- Fixes #### (if fixing a known issue; otherwise, describe issue using the following format)

<!--

	If no issue exists that you're aware of. The maintainers should be able to figure out if it's a duplicate.

## Expectation

Describe the output you are expecting from marked

## Result

Describe the output you received from marked

## What was attempted

Describe what code combination got you there

-->

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
