### PR TITLE
Treat escape token same way we treat plain text tokens

### DIFF
--- a/src/Parser.js
+++ b/src/Parser.js
@@ -200,7 +200,7 @@ module.exports = class Parser {
       token = tokens[i];
       switch (token.type) {
         case 'escape': {
-          out += token.text;
+          out += renderer.text(token.text);
           break;
         }
         case 'html': {


### PR DESCRIPTION
## Description

- Treat escape token as text token for the purpose of creating custom Renderer

## Expectation

Marked should alow treating escaped characters the same way it allows treating unescaped characters for the cases where we need to perform plain text transformation in the Render implementation.

## Result

Escaped characters, like `\#` are passed to result raw, but unescaped characters are passed to Render.text() as normal.

## Contributor

- [x] no tests required for this PR.

## Committer

In most cases, this should be a different person than the contributor.

- [x] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [x] Merge PR
