### PR TITLE
marked.use

### DIFF
--- a/docs/USING_PRO.md
+++ b/docs/USING_PRO.md
@@ -112,7 +112,7 @@ const tokenizer = {
       };
     }
 
-    // return false to use original codespan renderer
+    // return false to use original codespan tokenizer
     return false;
   }
 };

--- a/docs/USING_PRO.md
+++ b/docs/USING_PRO.md
@@ -2,6 +2,16 @@
 
 To champion the single-responsibility and open/closed principles, we have tried to make it relatively painless to extend marked. If you are looking to add custom functionality, this is the place to start.
 
+<h2 id="use">marked.use()</h2>
+
+`marked.use(options)` is the recommended way to extend marked. The options object can contain any [option](#/USING_ADVANCED.md#options) available in marked.
+
+The `renderer` and `tokenizer` options can be an object with functions that will be merged into the `renderer` and `tokenizer` respectively.
+
+The `renderer` and `tokenizer` functions can return false to fallback to the previous function.
+
+All other options will overwrite previously set options.
+
 <h2 id="renderer">The renderer</h2>
 
 The renderer defines the output of the parser.

--- a/docs/USING_PRO.md
+++ b/docs/USING_PRO.md
@@ -12,24 +12,25 @@ The renderer defines the output of the parser.
 // Create reference instance
 const marked = require('marked');
 
-// Get reference
-const renderer = new marked.Renderer();
-
 // Override function
-renderer.heading = function(text, level) {
-  const escapedText = text.toLowerCase().replace(/[^\w]+/g, '-');
+const renderer = {
+  heading(text, level) {
+    const escapedText = text.toLowerCase().replace(/[^\w]+/g, '-');
 
-  return `
-          <h${level}>
-            <a name="${escapedText}" class="anchor" href="#${escapedText}">
-              <span class="header-link"></span>
-            </a>
-            ${text}
-          </h${level}>`;
+    return `
+            <h${level}>
+              <a name="${escapedText}" class="anchor" href="#${escapedText}">
+                <span class="header-link"></span>
+              </a>
+              ${text}
+            </h${level}>`;
+  }
 };
 
+marked.use({ renderer });
+
 // Run marked
-console.log(marked('# heading+', { renderer }));
+console.log(marked('# heading+'));
 ```
 
 **Output:**
@@ -99,30 +100,33 @@ The tokenizer defines how to turn markdown text into tokens.
 // Create reference instance
 const marked = require('marked');
 
-// Get reference
-const tokenizer = new marked.Tokenizer();
-const originalCodespan = tokenizer.codespan;
 // Override function
-tokenizer.codespan = function(src) {
-  const match = src.match(/\$+([^\$\n]+?)\$+/);
-  if (match) {
-    return {
-      type: 'codespan',
-      raw: match[0],
-      text: match[1].trim()
-    };
+const tokenizer = {
+  codespan(src) {
+    const match = src.match(/\$+([^\$\n]+?)\$+/);
+    if (match) {
+      return {
+        type: 'codespan',
+        raw: match[0],
+        text: match[1].trim()
+      };
+    }
+    const originalTokenizer = new marked.Tokenizer(this.options);
+    return originalTokenizer.codespan.apply(this, arguments);
   }
-  return originalCodespan.apply(this, arguments);
 };
 
+marked.use({ tokenizer });
+
 // Run marked
-console.log(marked('$ latex code $', { tokenizer }));
+console.log(marked('$ latex code $\n\n` other code `'));
 ```
 
 **Output:**
 
 ```html
-<p><code>latext code</code></p>
+<p><code>latex code</code></p>
+<p><code>other code</code></p>
 ```
 
 ### Block level tokenizer methods

--- a/docs/USING_PRO.md
+++ b/docs/USING_PRO.md
@@ -111,8 +111,9 @@ const tokenizer = {
         text: match[1].trim()
       };
     }
-    const originalTokenizer = new marked.Tokenizer(this.options);
-    return originalTokenizer.codespan.apply(this, arguments);
+
+    // return false to use original codespan renderer
+    return false;
   }
 };
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -154,6 +154,7 @@
                     <li>
                         <a href="#/USING_PRO.md">Extensibility</a>
                         <ul>
+                            <li><a href="#/USING_PRO.md#use">marked.use()</a></li>
                             <li><a href="#/USING_PRO.md#renderer">Renderer</a></li>
                             <li><a href="#/USING_PRO.md#tokenizer">Tokenizer</a></li>
                             <li><a href="#/USING_PRO.md#lexer">Lexer</a></li>

--- a/src/marked.js
+++ b/src/marked.js
@@ -136,14 +136,28 @@ marked.use = function(extension) {
   if (extension.renderer) {
     const renderer = marked.defaults.renderer || new Renderer();
     for (const prop in extension.renderer) {
-      renderer[prop] = extension.renderer[prop];
+      const prevRenderer = renderer[prop];
+      renderer[prop] = (...args) => {
+        let ret = extension.renderer[prop].apply(renderer, args);
+        if (ret === false) {
+          ret = prevRenderer.apply(renderer, args);
+        }
+        return ret;
+      };
     }
     opts.renderer = renderer;
   }
   if (extension.tokenizer) {
     const tokenizer = marked.defaults.tokenizer || new Tokenizer();
     for (const prop in extension.tokenizer) {
-      tokenizer[prop] = extension.tokenizer[prop];
+      const prevTokenizer = tokenizer[prop];
+      tokenizer[prop] = (...args) => {
+        let ret = extension.tokenizer[prop].apply(tokenizer, args);
+        if (ret === false) {
+          ret = prevTokenizer.apply(tokenizer, args);
+        }
+        return ret;
+      };
     }
     opts.tokenizer = tokenizer;
   }

--- a/src/marked.js
+++ b/src/marked.js
@@ -128,6 +128,29 @@ marked.getDefaults = getDefaults;
 marked.defaults = defaults;
 
 /**
+ * Use Extension
+ */
+
+marked.use = function(extension) {
+  const opts = merge({}, extension);
+  if (extension.renderer) {
+    const renderer = marked.defaults.renderer || new Renderer();
+    for (const prop in extension.renderer) {
+      renderer[prop] = extension.renderer[prop];
+    }
+    opts.renderer = renderer;
+  }
+  if (extension.tokenizer) {
+    const tokenizer = marked.defaults.tokenizer || new Tokenizer();
+    for (const prop in extension.tokenizer) {
+      tokenizer[prop] = extension.tokenizer[prop];
+    }
+    opts.tokenizer = tokenizer;
+  }
+  marked.setOptions(opts);
+};
+
+/**
  * Expose
  */
 

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -171,6 +171,39 @@ paragraph
     expect(html).toBe('extension2 paragraph\nextension1 html\n<h1 id="heading">heading</h1>\n');
   });
 
+  it('should use previous extension when returning false', () => {
+    const extension1 = {
+      renderer: {
+        paragraph(text) {
+          if (text !== 'original') {
+            return 'extension1 paragraph\n';
+          }
+          return false;
+        }
+      }
+    };
+    const extension2 = {
+      renderer: {
+        paragraph(text) {
+          if (text !== 'extension1' && text !== 'original') {
+            return 'extension2 paragraph\n';
+          }
+          return false;
+        }
+      }
+    };
+    marked.use(extension1);
+    marked.use(extension2);
+    const html = marked(`
+paragraph
+
+extension1
+
+original
+`);
+    expect(html).toBe('extension2 paragraph\nextension1 paragraph\n<p>original</p>\n');
+  });
+
   it('should get options with this.options', () => {
     const extension = {
       renderer: {


### PR DESCRIPTION
**Marked version:** master

## Description

Add function `marked.use` which takes an options object and merges it into marked options.

The `renderer` and `tokenizer` can be an object with functions that will be merged into the `renderer` and `tokenizer` respectively.

The `renderer` and `tokenizer` functions can return `false` to fallback to the previous function.

```js
const extension = {
	breaks: true,
	renderer: {
		html(html) {
			if (html.startsWith('<div')) {
				return html.replace(/</g, '&lt;').replace(/>/g, '&gt;');
			}
			return false;
		}
	}
};
marked.use(extension);
const html = marked(`
<div>
html renderer will use extension
</div>

<span>will fallback to regular html renderer</span>

options from extension
will be used.
`);
console.log(html);
/* will log:
&lt;div&gt;
html renderer will use extension
&lt;/div&gt;

<span>will fallback to regular html renderer</span>

<p>options from extension<br>will be used.</p>

*/
```

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [x] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [x] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [x] Merge PR
