### PR TITLE
v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "marked",
-  "version": "0.8.2",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marked",
   "description": "A markdown parser built for speed",
   "author": "Christopher Jeffrey",
-  "version": "0.8.2",
+  "version": "1.0.0",
   "main": "./src/marked.js",
   "bin": "./bin/marked",
   "man": "./man/marked.1",


### PR DESCRIPTION
I think we are ready to release v1.0.0 :tada:

This release is meant to be non-breaking for most users so they can get onto a stable release easily.

The only users that will need to change their code are users who are extending the lexer or parser currently. Those users should move to extending the `tokenizer` and `renderer` with the new [`marked.use()`](https://marked.js.org/#/USING_PRO.md#use) function.

After v1.0.0 is released we can look into moving some of the current options into extensions in future releases (as well as making marked more spec compliant). We can maintain some extensions under the @markedjs group but hopefully the community will also follow with some extensions of their own.

# Release Notes

## Breaking changes

- Add inline tokens to `marked.lexer` output #1627
- Treat escape token same way as plain text tokens #1642 
- Add `Tokenizer` to allow extending token creation #1637

## Features

- Add `marked.use()` method to extend options #1646 

## Fixes

- Fix intra-word emphasis can match the wrong asterisks #1636
- Fix italics modifier (`_`) breaks links containing underscores #1641 
- Fix closing delimited * incorrect for consecutive ocurrences #1644

## Docs

- Fix lexer data token in demo #1638

## CI

- Move to GitHub Actions #1635 
- Update devDependencies #1648

---

## Publisher

- [ ] `$ npm version` has been run.
- [ ] Release notes in [draft GitHub release](https://github.com/markedjs/marked/releases) are up to date
- [ ] Release notes include which flavors and versions of Markdown are supported by this release
- [ ] Committer checklist is complete.
- [ ] Merge PR.
- [ ] Publish GitHub release using `master` with correct version number.
- [ ] `$ npm publish` has been run.
- [ ] Create draft GitHub release to prepare next release.

Note: If merges to `master` occur after submitting this PR and before running `$ npm pubish` you should be able to

1. pull from `upstream/master` (`git pull upstream master`) into the branch holding this version,
2. run `$ npm run build` to regenerate the `min` file, and
3. commit and push the updated changes.

## Committer

In most cases, this should be someone different than the publisher.

- [x] Version in `package.json` has been updated (see [PUBLISHING.md](https://github.com/markedjs/marked/blob/master/docs/PUBLISHING.md)).
- [x] The `marked.min.js` has been updated; or,
- [ ] release does not change library.
- [x] CI is green (no forced merge required).
