### PR TITLE
Codespan newline

### DIFF
--- a/docs/USING_PRO.md
+++ b/docs/USING_PRO.md
@@ -155,7 +155,7 @@ console.log(marked('$ latex code $\n\n` other code `'));
 - table(*string* src)
 - lheading(*string* src)
 - paragraph(*string* src)
-- text(*string* src)
+- text(*string* src, *array* tokens)
 
 ### Inline level tokenizer methods
 

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -112,7 +112,7 @@ module.exports = class Lexer {
    */
   blockTokens(src, tokens = [], top = true) {
     src = src.replace(/^ +$/gm, '');
-    let token, i, l;
+    let token, i, l, lastToken;
 
     while (src) {
       // newline
@@ -127,7 +127,13 @@ module.exports = class Lexer {
       // code
       if (token = this.tokenizer.code(src, tokens)) {
         src = src.substring(token.raw.length);
-        tokens.push(token);
+        if (token.type) {
+          tokens.push(token);
+        } else {
+          lastToken = tokens[tokens.length - 1];
+          lastToken.raw += '\n' + token.raw;
+          lastToken.text += '\n' + token.text;
+        }
         continue;
       }
 
@@ -219,9 +225,15 @@ module.exports = class Lexer {
       }
 
       // text
-      if (token = this.tokenizer.text(src)) {
+      if (token = this.tokenizer.text(src, tokens)) {
         src = src.substring(token.raw.length);
-        tokens.push(token);
+        if (token.type) {
+          tokens.push(token);
+        } else {
+          lastToken = tokens[tokens.length - 1];
+          lastToken.raw += '\n' + token.raw;
+          lastToken.text += '\n' + token.text;
+        }
         continue;
       }
 

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -481,9 +481,9 @@ module.exports = class Tokenizer {
   codespan(src) {
     const cap = this.rules.inline.code.exec(src);
     if (cap) {
-      let text = cap[2];
-      const hasNonSpaceChars = /\S/.test(text);
-      const hasSpaceCharsOnBothEnds = /^\s/.test(text) && /\s$/.test(text);
+      let text = cap[2].replace(/\n/g, ' ');
+      const hasNonSpaceChars = /[^ ]/.test(text);
+      const hasSpaceCharsOnBothEnds = text.startsWith(' ') && text.endsWith(' ');
       if (hasNonSpaceChars && hasSpaceCharsOnBothEnds) {
         text = text.substring(1, text.length - 1);
       }
@@ -491,9 +491,7 @@ module.exports = class Tokenizer {
       return {
         type: 'codespan',
         raw: cap[0],
-        text: !this.options.pedantic
-          ? text.replace(/\n/g, ' ')
-          : text
+        text
       };
     }
   }

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -481,7 +481,13 @@ module.exports = class Tokenizer {
   codespan(src) {
     const cap = this.rules.inline.code.exec(src);
     if (cap) {
-      const text = escape(cap[2].trim(), true);
+      let text = cap[2];
+      const hasNonSpaceChars = /\S/.test(text);
+      const hasSpaceCharsOnBothEnds = /^\s/.test(text) && /\s$/.test(text);
+      if (hasNonSpaceChars && hasSpaceCharsOnBothEnds) {
+        text = text.substring(1, text.length - 1);
+      }
+      text = escape(text, true);
       return {
         type: 'codespan',
         raw: cap[0],

--- a/test/specs/new/codespan_newline.html
+++ b/test/specs/new/codespan_newline.html
@@ -1,0 +1,5 @@
+<p><code>code code</code></p>
+
+<ul>
+<li><code>code code</code></li>
+</ul>

--- a/test/specs/new/codespan_newline.md
+++ b/test/specs/new/codespan_newline.md
@@ -1,0 +1,5 @@
+`code
+code`
+
+- `code
+code`

--- a/test/unit/Lexer-spec.js
+++ b/test/unit/Lexer-spec.js
@@ -806,6 +806,15 @@ a | b
             ]
           });
         });
+
+        it('newline to space', () => {
+          expectInlineTokens({
+            md: '`a\nb`',
+            tokens: [
+              { type: 'codespan', raw: '`a\nb`', text: 'a b' }
+            ]
+          });
+        });
       });
 
       it('br', () => {

--- a/test/unit/Lexer-spec.js
+++ b/test/unit/Lexer-spec.js
@@ -752,12 +752,50 @@ a | b
         });
       });
 
-      it('code', () => {
-        expectInlineTokens({
-          md: '`code`',
-          tokens: [
-            { type: 'codespan', raw: '`code`', text: 'code' }
-          ]
+      describe('codespan', () => {
+        it('code', () => {
+          expectInlineTokens({
+            md: '`code`',
+            tokens: [
+              { type: 'codespan', raw: '`code`', text: 'code' }
+            ]
+          });
+        });
+
+        it('only spaces', () => {
+          expectInlineTokens({
+            md: '`   `',
+            tokens: [
+              { type: 'codespan', raw: '`   `', text: '   ' }
+            ]
+          });
+        });
+
+        it('beginning space', () => {
+          expectInlineTokens({
+            md: '` a`',
+            tokens: [
+              { type: 'codespan', raw: '` a`', text: ' a' }
+            ]
+          });
+        });
+
+        it('end space', () => {
+          expectInlineTokens({
+            md: '`a `',
+            tokens: [
+              { type: 'codespan', raw: '`a `', text: 'a ' }
+            ]
+          });
+        });
+
+        it('begin and end space', () => {
+          expectInlineTokens({
+            md: '` a `',
+            tokens: [
+              { type: 'codespan', raw: '` a `', text: 'a' }
+            ]
+          });
         });
       });
 

--- a/test/unit/Lexer-spec.js
+++ b/test/unit/Lexer-spec.js
@@ -762,7 +762,7 @@ a | b
           });
         });
 
-        it('only spaces', () => {
+        it('only spaces not stripped', () => {
           expectInlineTokens({
             md: '`   `',
             tokens: [
@@ -771,7 +771,7 @@ a | b
           });
         });
 
-        it('beginning space', () => {
+        it('beginning space only not stripped', () => {
           expectInlineTokens({
             md: '` a`',
             tokens: [
@@ -780,7 +780,7 @@ a | b
           });
         });
 
-        it('end space', () => {
+        it('end space only not stripped', () => {
           expectInlineTokens({
             md: '`a `',
             tokens: [
@@ -789,7 +789,7 @@ a | b
           });
         });
 
-        it('begin and end space', () => {
+        it('begin and end spaces are stripped', () => {
           expectInlineTokens({
             md: '` a `',
             tokens: [
@@ -798,7 +798,34 @@ a | b
           });
         });
 
-        it('begin and end multiple space', () => {
+        it('begin and end newlines are stripped', () => {
+          expectInlineTokens({
+            md: '`\na\n`',
+            tokens: [
+              { type: 'codespan', raw: '`\na\n`', text: 'a' }
+            ]
+          });
+        });
+
+        it('begin and end tabs are not stripped', () => {
+          expectInlineTokens({
+            md: '`\ta\t`',
+            tokens: [
+              { type: 'codespan', raw: '`\ta\t`', text: '\ta\t' }
+            ]
+          });
+        });
+
+        it('begin and end newlines', () => {
+          expectInlineTokens({
+            md: '`\na\n`',
+            tokens: [
+              { type: 'codespan', raw: '`\na\n`', text: 'a' }
+            ]
+          });
+        });
+
+        it('begin and end multiple spaces only one stripped', () => {
           expectInlineTokens({
             md: '`  a  `',
             tokens: [

--- a/test/unit/Lexer-spec.js
+++ b/test/unit/Lexer-spec.js
@@ -797,6 +797,15 @@ a | b
             ]
           });
         });
+
+        it('begin and end multiple space', () => {
+          expectInlineTokens({
+            md: '`  a  `',
+            tokens: [
+              { type: 'codespan', raw: '`  a  `', text: ' a ' }
+            ]
+          });
+        });
       });
 
       it('br', () => {


### PR DESCRIPTION
**Marked version:** v1.0.0

## Description

- Code spans with a newline should turn the newline into a space according to the [commonmark spec](https://spec.commonmark.org/0.29/#example-335).

- Code spans only remove one space from each end if the text begins and ends with white-space

- fixes any list items with more than one line of text.

- Fixes #1651
- Fixes #1655
## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR)

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
