### PR TITLE
fix underscore emphasis then comma

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -169,7 +169,7 @@ const inline = {
   reflink: /^!?\[(label)\]\[(?!\s*\])((?:\\[\[\]]?|[^\[\]\\])+)\]/,
   nolink: /^!?\[(?!\s*\])((?:\[[^\[\]]*\]|\\[\[\]]|[^\[\]])*)\](?:\[\])?/,
   strong: /^__([^\s_])__(?!_)|^\*\*([^\s*])\*\*(?!\*)|^__([^\s][\s\S]*?[^\s])__(?!_)|^\*\*([^\s][\s\S]*?[^\s])\*\*(?!\*)/,
-  em: /^_([^\s_])_(?!_)|^_([^\s_<][\s\S]*?[^\s_])_(?!_|[^\spunctuation])|^_([^\s_<][\s\S]*?[^\s])_(?!_|[^\spunctuation])|^\*([^\s*<\[])\*(?!\*)|^\*([^\s<"][\s\S]*?[^\s\[\*])\*(?![\]`punctuation])|^\*([^\s*"<\[][\s\S]*[^\s])\*(?!\*)/,
+  em: /^_([^\s_])_(?!_)|^_([^\s_<][\s\S]*?[^\s_])_(?!_|[^\s,punctuation])|^_([^\s_<][\s\S]*?[^\s])_(?!_|[^\s,punctuation])|^\*([^\s*<\[])\*(?!\*)|^\*([^\s<"][\s\S]*?[^\s\[\*])\*(?![\]`punctuation])|^\*([^\s*"<\[][\s\S]*[^\s])\*(?!\*)/,
   code: /^(`+)([^`]|[^`][\s\S]*?[^`])\1(?!`)/,
   br: /^( {2,}|\\)\n(?!\s*$)/,
   del: noopTest,
@@ -178,6 +178,7 @@ const inline = {
 
 // list of punctuation marks from common mark spec
 // without ` and ] to workaround Rule 17 (inline code blocks/links)
+// without , to work around example 393
 inline._punctuation = '!"#$%&\'()*+\\-./:;<=>?@\\[^_{|}~';
 inline.em = edit(inline.em).replace(/punctuation/g, inline._punctuation).getRegex();
 

--- a/test/specs/new/emphasis_extra tests.html
+++ b/test/specs/new/emphasis_extra tests.html
@@ -1,1 +1,1 @@
-<p><em>test</em>. <em>test</em>: <em>test</em>! <em>test</em>? <em>test</em>-</p>
+<p><em>test</em>. <em>test</em>: <em>test</em>! <em>test</em>? <em>test</em>- <em>test</em>,</p>

--- a/test/specs/new/emphasis_extra tests.md
+++ b/test/specs/new/emphasis_extra tests.md
@@ -1,1 +1,6 @@
-_test_. _test_: _test_! _test_? _test_-
+_test_.
+_test_:
+_test_!
+_test_?
+_test_-
+_test_,


### PR DESCRIPTION
**Marked version:** 1.0.0

## Description

Fix regression when comma is after underscore emphasis

[CommonMark Demo](https://spec.commonmark.org/dingus/?text=_test_%2C)
[Marked Demo, version 1.0.0 doesn’t work](https://marked.js.org/demo/?text=_test_%2C&options=&version=1.0.0)
[Marked Demo, version 0.8.2 works](https://marked.js.org/demo/?text=_test_%2C&options=&version=0.8.2)

Fixes #1659 

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression

## Committer

In most cases, this should be a different person than the contributor.

- [x] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [x] Merge PR
