### PR TITLE
add browser field to point to es5

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "author": "Christopher Jeffrey",
   "version": "1.0.0",
   "main": "./src/marked.js",
+  "browser": "./lib/marked.js",
   "bin": "./bin/marked",
   "man": "./man/marked.1",
   "files": [


### PR DESCRIPTION
**Marked version:** 1.0.0

## Description

Add `browser` field to `package.json` that points to `lib/marked.js` so webpack will use es5 version to bundle for browsers.

- Fixes #1630

## Contributor

- [x] no tests required for this PR.

## Committer

In most cases, this should be a different person than the contributor.

- [x] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [x] Merge PR
