### PR TITLE
add walkTokens and fix highlight async

### DIFF
--- a/docs/USING_ADVANCED.md
+++ b/docs/USING_ADVANCED.md
@@ -58,6 +58,7 @@ console.log(marked(markdownString));
 |smartLists  |`boolean` |`false`  |v0.2.8   |If true, use smarter list behavior than those found in `markdown.pl`.|
 |smartypants |`boolean` |`false`  |v0.2.9   |If true, use "smart" typographic punctuation for things like quotes and dashes.|
 |tokenizer    |`object`  |`new Tokenizer()`|v1.0.0|An object containing functions to create tokens from markdown. See [extensibility](/#/USING_PRO.md) for more details.|
+|walkTokens   |`function`  |`null`|v1.1.0|A function which is called for every token. See [extensibility](/#/USING_PRO.md) for more details.|
 |xhtml       |`boolean` |`false`  |v0.3.2   |If true, emit self-closing HTML tags for void elements (&lt;br/&gt;, &lt;img/&gt;, etc.) with a "/" as required by XHTML.|
 
 <h2 id="highlight">Asynchronous highlighting</h2>

--- a/docs/USING_PRO.md
+++ b/docs/USING_PRO.md
@@ -10,6 +10,8 @@ The `renderer` and `tokenizer` options can be an object with functions that will
 
 The `renderer` and `tokenizer` functions can return false to fallback to the previous function.
 
+The `walkTokens` option can be a function that will be called with every token before rendering. When calling `use` multiple times with different `walkTokens` functions each function will be called in the **reverse** order in which they were assigned.
+
 All other options will overwrite previously set options.
 
 <h2 id="renderer">The renderer</h2>
@@ -186,6 +188,35 @@ https://daringfireball.net/projects/smartypants/
 ```js
 smartypants('"this ... string"')
 // "“this … string”"
+```
+
+<h2 id="walk-tokens">Walk Tokens</h2>
+
+The walkTokens function gets called with every token. Child tokens are called before moving on to sibling tokens. Each token is passed by reference so updates are persisted when passed to the parser. The return value of the function is ignored.
+
+**Example:** Overriding heading tokens to start at h2.
+
+```js
+const marked = require('marked');
+
+// Override function
+const walkTokens = (token) => {
+  if (token.type === 'heading') {
+    token.depth += 1;
+  }
+};
+
+marked.use({ walkTokens });
+
+// Run marked
+console.log(marked('# heading 2\n\n## heading 3'));
+```
+
+**Output:**
+
+```html
+<h2 id="heading-2">heading 2</h2>
+<h3 id="heading-3">heading 3</h3>
 ```
 
 <h2 id="lexer">The lexer</h2>

--- a/docs/index.html
+++ b/docs/index.html
@@ -157,6 +157,7 @@
                             <li><a href="#/USING_PRO.md#use">marked.use()</a></li>
                             <li><a href="#/USING_PRO.md#renderer">Renderer</a></li>
                             <li><a href="#/USING_PRO.md#tokenizer">Tokenizer</a></li>
+                            <li><a href="#/USING_PRO.md#walk-tokens">Walk Tokens</a></li>
                             <li><a href="#/USING_PRO.md#lexer">Lexer</a></li>
                             <li><a href="#/USING_PRO.md#parser">Parser</a></li>
                         </ul>

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -269,6 +269,7 @@ module.exports = class Tokenizer {
         }
 
         list.items.push({
+          type: 'list_item',
           raw,
           task: istask,
           checked: ischecked,

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -16,6 +16,7 @@ function getDefaults() {
     smartLists: false,
     smartypants: false,
     tokenizer: null,
+    walkTokens: null,
     xhtml: false
   };
 }

--- a/src/marked.js
+++ b/src/marked.js
@@ -179,47 +179,31 @@ marked.use = function(extension) {
 };
 
 /**
- * Iterate over every token
+ * Run callback for every token
  */
 
 marked.walkTokens = function(tokens, callback) {
-  let ret;
   for (const token of tokens) {
-    ret = callback(token);
-    if (ret === false) {
-      return false;
-    }
+    callback(token);
     switch (token.type) {
       case 'table': {
         for (const cell of token.tokens.header) {
-          ret = marked.walkTokens(cell, callback);
-          if (ret === false) {
-            return false;
-          }
+          marked.walkTokens(cell, callback);
         }
         for (const row of token.tokens.cells) {
           for (const cell of row) {
-            ret = marked.walkTokens(cell, callback);
-            if (ret === false) {
-              return false;
-            }
+            marked.walkTokens(cell, callback);
           }
         }
         break;
       }
       case 'list': {
-        ret = marked.walkTokens(token.items, callback);
-        if (ret === false) {
-          return false;
-        }
+        marked.walkTokens(token.items, callback);
         break;
       }
       default: {
         if (token.tokens) {
-          ret = marked.walkTokens(token.tokens, callback);
-          if (ret === false) {
-            return false;
-          }
+          marked.walkTokens(token.tokens, callback);
         }
       }
     }

--- a/test/unit/Lexer-spec.js
+++ b/test/unit/Lexer-spec.js
@@ -307,6 +307,7 @@ a | b
             loose: false,
             items: [
               {
+                type: 'list_item',
                 raw: '- item 1',
                 task: false,
                 checked: undefined,
@@ -320,6 +321,7 @@ a | b
                 }]
               },
               {
+                type: 'list_item',
                 raw: '- item 2\n',
                 task: false,
                 checked: undefined,

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -295,8 +295,8 @@ text 1
   });
 });
 
-describe('iterateTokens', () => {
-  it('should iterate over every token', () => {
+describe('walkTokens', () => {
+  it('should walk over every token', () => {
     const markdown = `
 paragraph
 
@@ -336,7 +336,7 @@ br
 `;
     const tokens = marked.lexer(markdown, { ...marked.getDefaults(), breaks: true });
     const tokensSeen = [];
-    marked.iterateTokens(tokens, (token) => {
+    marked.walkTokens(tokens, (token) => {
       tokensSeen.push([token.type, (token.raw || '').replace(/\n/g, '')]);
     });
 

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -229,3 +229,167 @@ paragraph
     expect(html).toBe('arrow no options\nfunction options\nshorthand options\n');
   });
 });
+
+describe('async highlight', () => {
+  let highlight, markdown;
+  beforeEach(() => {
+    highlight = jasmine.createSpy('highlight', (text, lang, callback) => {
+      setImmediate(() => {
+        callback(null, `async ${text || ''}`);
+      });
+    });
+    markdown = `
+\`\`\`lang1
+text 1
+\`\`\`
+
+> \`\`\`lang2
+> text 2
+> \`\`\`
+
+- \`\`\`lang3
+  text 3
+  \`\`\`
+`;
+  });
+
+  it('should highlight codeblocks async', (done) => {
+    highlight.and.callThrough();
+
+    marked(markdown, { highlight }, (err, html) => {
+      if (err) {
+        fail(err);
+      }
+
+      expect(html).toBe(`<pre><code class="language-lang1">async text 1</code></pre>
+<blockquote>
+<pre><code class="language-lang2">async text 2</code></pre>
+</blockquote>
+<ul>
+<li><pre><code class="language-lang3">async text 3</code></pre>
+</li>
+</ul>
+`);
+      done();
+    });
+  });
+
+  it('should call callback for each error in highlight', (done) => {
+    highlight.and.callFake((lang, text, callback) => {
+      callback(new Error('highlight error'));
+    });
+
+    let numErrors = 0;
+    marked(markdown, { highlight }, (err, html) => {
+      expect(err).toBeTruthy();
+      expect(html).toBeUndefined();
+
+      if (err) {
+        numErrors++;
+      }
+
+      if (numErrors === 3) {
+        done();
+      }
+    });
+  });
+});
+
+describe('iterateTokens', () => {
+  it('should iterate over every token', () => {
+    const markdown = `
+paragraph
+
+---
+
+# heading
+
+\`\`\`
+code
+\`\`\`
+
+| a | b |
+|---|---|
+| 1 | 2 |
+| 3 | 4 |
+
+> blockquote
+
+- list
+
+<div>html</div>
+
+[link](https://example.com)
+
+![image](https://example.com/image.jpg)
+
+**strong**
+
+*em*
+
+\`codespan\`
+
+~~del~~
+
+br
+br
+`;
+    const tokens = marked.lexer(markdown, { ...marked.getDefaults(), breaks: true });
+    const tokensSeen = [];
+    marked.iterateTokens(tokens, (token) => {
+      tokensSeen.push([token.type, (token.raw || '').replace(/\n/g, '')]);
+    });
+
+    expect(tokensSeen).toEqual([
+      ['paragraph', 'paragraph'],
+      ['text', 'paragraph'],
+      ['space', ''],
+      ['hr', '---'],
+      ['heading', '# heading'],
+      ['text', 'heading'],
+      ['code', '```code```'],
+      ['table', '| a | b ||---|---|| 1 | 2 || 3 | 4 |'],
+      ['text', 'a'],
+      ['text', 'b'],
+      ['text', '1'],
+      ['text', '2'],
+      ['text', '3'],
+      ['text', '4'],
+      ['blockquote', '> blockquote'],
+      ['paragraph', 'blockquote'],
+      ['text', 'blockquote'],
+      ['list', '- list'],
+      ['list_item', '- list'],
+      ['text', 'list'],
+      ['text', 'list'],
+      ['space', ''],
+      ['html', '<div>html</div>'],
+      ['paragraph', '[link](https://example.com)'],
+      ['link', '[link](https://example.com)'],
+      ['text', 'link'],
+      ['space', ''],
+      ['paragraph', '![image](https://example.com/image.jpg)'],
+      ['image', '![image](https://example.com/image.jpg)'],
+      ['space', ''],
+      ['paragraph', '**strong**'],
+      ['strong', '**strong**'],
+      ['text', 'strong'],
+      ['space', ''],
+      ['paragraph', '*em*'],
+      ['em', '*em*'],
+      ['text', 'em'],
+      ['space', ''],
+      ['paragraph', '`codespan`'],
+      ['codespan', '`codespan`'],
+      ['space', ''],
+      ['paragraph', '~~del~~'],
+      ['del', '~~del~~'],
+      ['text', 'del'],
+      ['space', ''],
+      ['paragraph', 'brbr'],
+      ['text', 'br'],
+      ['br', ''],
+      ['text', 'br']
+    ]);
+  });
+});

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -132,6 +132,18 @@ describe('use extension', () => {
     expect(html).toBe('<p>extension</p>\n');
   });
 
+  it('should use walkTokens', () => {
+    let walked = 0;
+    const extension = {
+      walkTokens(token) {
+        walked++;
+      }
+    };
+    marked.use(extension);
+    marked('text');
+    expect(walked).toBe(2);
+  });
+
   it('should use options from extension', () => {
     const extension = {
       headerIds: false
@@ -139,6 +151,29 @@ describe('use extension', () => {
     marked.use(extension);
     const html = marked('# heading');
     expect(html).toBe('<h1>heading</h1>\n');
+  });
+
+  it('should call all walkTokens in reverse order', () => {
+    let walkedOnce = 0;
+    let walkedTwice = 0;
+    const extension1 = {
+      walkTokens(token) {
+        if (token.walkedOnce) {
+          walkedTwice++;
+        }
+      }
+    };
+    const extension2 = {
+      walkTokens(token) {
+        walkedOnce++;
+        token.walkedOnce = true;
+      }
+    };
+    marked.use(extension1);
+    marked.use(extension2);
+    marked('text');
+    expect(walkedOnce).toBe(2);
+    expect(walkedTwice).toBe(2);
   });
 
   it('should use last extension function and not override others', () => {


### PR DESCRIPTION
**Marked version:** 1.0.0

## Description

Using an async highlighting function was broken in v1.0.0 when we moved block tokens in blockquote and lists from the top level of the tokens array to a `tokens` property on the blockquote or listitem token.

This PR adds a public method to easily iterate over all tokens and send each token to a function specified by the user (`marked.walkTokens(tokens, callback)`) and uses that function to highlight code blocks asynchronously.

This also adds a `walkTokens` option so extensions can use it to run a function for each token.

**Example:** Overriding heading tokens to start at h2.

```js
const marked = require('marked');

// Override function
const walkTokens = (token) => {
  if (token.type === 'heading') {
    token.depth += 1;
  }
};

marked.use({ walkTokens });

// Run marked
console.log(marked('# heading 2\n\n## heading 3'));
```

**Output:**

```html
<h2 id="heading-2">heading 2</h2>
<h3 id="heading-3">heading 3</h3>
```

- Fixes #1656 

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression
- [x] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [x] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [x] Merge PR
