### PR TITLE
render code with and without language with the trailing newline

### DIFF
--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -25,7 +25,7 @@ module.exports = class Renderer {
     if (!lang) {
       return '<pre><code>'
         + (escaped ? code : escape(code, true))
-        + '</code></pre>';
+        + '</code></pre>\n';
     }
 
     return '<pre><code class="'

--- a/test/specs/new/code_compensation_indent.html
+++ b/test/specs/new/code_compensation_indent.html
@@ -2,5 +2,6 @@
 <ol>
 <li><p>This is a list element.</p>
 <pre><code>const x = 5;
-const y = x + 5;</code></pre></li>
+const y = x + 5;</code></pre>
+</li>
 </ol>

--- a/test/specs/new/code_consistent_newline.html
+++ b/test/specs/new/code_consistent_newline.html
@@ -1,0 +1,3 @@
+<pre><code class="language-js">const value = 42;</code></pre>
+<pre><code>const value = 42;</code></pre>
+<p>Code blocks contain trailing new line.</p>

--- a/test/specs/new/code_consistent_newline.md
+++ b/test/specs/new/code_consistent_newline.md
@@ -1,0 +1,10 @@
+---
+renderExact: true
+---
+```js
+const value = 42;
+```
+
+    const value = 42;
+
+Code blocks contain trailing new line.


### PR DESCRIPTION
<!--

	If release PR, add ?template=release.md to the PR url to use the release PR template.

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->

**Marked version:**

1.0.0

**Markdown flavor:** n/a

## Expectation

Code blocks with and without language are both rendered with the trailing new line.

## Result

Code block with language has trailing newline, but code block without language does not.

## What was attempted

?

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR)

## Committer

In most cases, this should be a different person than the contributor.

- [x] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [x] Merge PR
