### PR TITLE
fix image links with escaped brackets

### DIFF
--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -9,6 +9,7 @@ const {
 function outputLink(cap, link, raw) {
   const href = link.href;
   const title = link.title ? escape(link.title) : null;
+  const text = cap[1].replace(/\\([\[\]])/g, '$1');
 
   if (cap[0].charAt(0) !== '!') {
     return {
@@ -16,15 +17,15 @@ function outputLink(cap, link, raw) {
       raw,
       href,
       title,
-      text: cap[1]
+      text
     };
   } else {
     return {
       type: 'image',
       raw,
-      text: escape(cap[1]),
       href,
-      title
+      title,
+      text: escape(text)
     };
   }
 }

--- a/src/rules.js
+++ b/src/rules.js
@@ -198,7 +198,7 @@ inline.tag = edit(inline.tag)
   .replace('attribute', inline._attribute)
   .getRegex();
 
-inline._label = /(?:\[(?:\\.|[^\[\]])*\]|\\.|`[^`]*`|[^\[\]\\`])*?/;
+inline._label = /(?:\[(?:\\.|[^\[\]\\])*\]|\\.|`[^`]*`|[^\[\]\\`])*?/;
 inline._href = /<(?:\\[<>]?|[^\s<>\\])*>|[^\s\x00-\x1f]*/;
 inline._title = /"(?:\\"?|[^"\\])*"|'(?:\\'?|[^'\\])*'|\((?:\\\)?|[^)\\])*\)/;
 

--- a/src/rules.js
+++ b/src/rules.js
@@ -198,7 +198,7 @@ inline.tag = edit(inline.tag)
   .replace('attribute', inline._attribute)
   .getRegex();
 
-inline._label = /(?:\[[^\[\]]*\]|\\.|`[^`]*`|[^\[\]\\`])*?/;
+inline._label = /(?:\[(?:\\.|[^\[\]])*\]|\\.|`[^`]*`|[^\[\]\\`])*?/;
 inline._href = /<(?:\\[<>]?|[^\s<>\\])*>|[^\s\x00-\x1f]*/;
 inline._title = /"(?:\\"?|[^"\\])*"|'(?:\\'?|[^'\\])*'|\((?:\\\)?|[^)\\])*\)/;
 

--- a/test/specs/new/image_links.html
+++ b/test/specs/new/image_links.html
@@ -1,0 +1,11 @@
+<p>
+	<a href="https://example.com/">
+		<img src="https://example.com/image.jpg" alt="test" title="title" />
+	</a>
+</p>
+
+<p>
+	<a href="https://example.com/">
+		<img src="https://example.com/image.jpg" alt="[test]" title="[title]" />
+	</a>
+</p>

--- a/test/specs/new/image_links.md
+++ b/test/specs/new/image_links.md
@@ -1,0 +1,3 @@
+[![test](https://example.com/image.jpg "title")](https://example.com/)
+
+[![\[test\]](https://example.com/image.jpg "[title]")](https://example.com/)


### PR DESCRIPTION
**Marked version:** 1.1.0

## Description

Fix image link with `\[` or `\]` in alt text

[demo](https://marked.js.org/demo/?text=%23%20Expected%20result%0A%0A%5B!%5BManny%20Pacquiao%5D(https%3A%2F%2Fimg.youtube.com%2Fvi%2Fs6bCmZmy9aQ%2F0.jpg%20%22manny%22)%5D(https%3A%2F%2Fyoutu.be%2Fs6bCmZmy9aQ)%0A%0A%23%20Actual%20result%0A%0A%5B!%5B%5C%5BManny%20Pacquiao%5C%5D%5D(https%3A%2F%2Fimg.youtube.com%2Fvi%2Fs6bCmZmy9aQ%2F0.jpg%20%22manny%22)%5D(https%3A%2F%2Fyoutu.be%2Fs6bCmZmy9aQ)%0A%0A%0A&options=%7B%0A%20%22baseUrl%22%3A%20null%2C%0A%20%22breaks%22%3A%20true%2C%0A%20%22gfm%22%3A%20true%2C%0A%20%22headerIds%22%3A%20true%2C%0A%20%22headerPrefix%22%3A%20%22%22%2C%0A%20%22highlight%22%3A%20null%2C%0A%20%22langPrefix%22%3A%20%22language-%22%2C%0A%20%22mangle%22%3A%20true%2C%0A%20%22pedantic%22%3A%20false%2C%0A%20%22sanitize%22%3A%20false%2C%0A%20%22sanitizer%22%3A%20null%2C%0A%20%22silent%22%3A%20false%2C%0A%20%22smartLists%22%3A%20false%2C%0A%20%22smartypants%22%3A%20false%2C%0A%20%22tokenizer%22%3A%20null%2C%0A%20%22walkTokens%22%3A%20null%2C%0A%20%22xhtml%22%3A%20false%0A%7D&version=1.1.0)

- Fixes #1681

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression

## Committer

In most cases, this should be a different person than the contributor.

- [x] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [x] Merge PR
