### PR TITLE
Add `npm run rules`

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -82,6 +82,31 @@ To see time comparisons between Marked and other popular Markdown libraries:
 npm run bench
 ```
 
+To see the compiled rules from `src/rules.js`:
+
+```bash
+npm run rules
+```
+
+You can specify one or more `rule path`s to only show certain rules:
+
+```bash
+npm run rules -- block.gfm.item inline.pedantic.br
+
+{
+  block: {
+    gfm: {
+      item: /^( *)((?:[*+-]|\\d{1,9}\\.)) ?[^\\n]*(?:\\n(?!\\1(?:[*+-]|\\d{1,9}\\.) ?)[^\\n]*)*/gm
+    }
+  },
+  inline: {
+    pedantic: {
+      br: /^( {2,}|\\\\)\\n(?!\\s*$)/
+    }
+  }
+}
+```
+
 To check for (and fix) standardized syntax (lint):
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "test:lint": "eslint bin/marked .",
     "test:redos": "node test/vuln-regex.js",
     "test:update": "node test/update-specs.js",
+    "rules": "node test/rules.js",
     "bench": "npm run rollup && node test/bench.js",
     "lint": "eslint --fix bin/marked .",
     "build:reset": "git checkout upstream/master lib/marked.js lib/marked.esm.js marked.min.js",

--- a/test/rules.js
+++ b/test/rules.js
@@ -1,0 +1,74 @@
+const rules = require('../src/rules.js');
+
+const COLOR = {
+  reset: '\x1b[0m',
+  bright: '\x1b[1m',
+  dim: '\x1b[2m',
+  underscore: '\x1b[4m',
+  blink: '\x1b[5m',
+  reverse: '\x1b[7m',
+  hidden: '\x1b[8m',
+
+  fgBlack: '\x1b[30m',
+  fgRed: '\x1b[31m',
+  fgGreen: '\x1b[32m',
+  fgYellow: '\x1b[33m',
+  fgBlue: '\x1b[34m',
+  fgMagenta: '\x1b[35m',
+  fgCyan: '\x1b[36m',
+  fgWhite: '\x1b[37m',
+
+  bgBlack: '\x1b[40m',
+  bgRed: '\x1b[41m',
+  bgGreen: '\x1b[42m',
+  bgYellow: '\x1b[43m',
+  bgBlue: '\x1b[44m',
+  bgMagenta: '\x1b[45m',
+  bgCyan: '\x1b[46m',
+  bgWhite: '\x1b[47m'
+};
+
+function propsToString(obj) {
+  if (obj === null) {
+    return null;
+  }
+  if (obj.constructor.name === 'Object') {
+    if (obj.exec && obj.exec.name === 'noopTest') {
+      return null;
+    }
+    for (const prop in obj) {
+      obj[prop] = propsToString(obj[prop]);
+    }
+    return obj;
+  }
+  return obj.toString();
+}
+
+let rulesObj = {};
+if (process.argv.length > 2) {
+  for (let i = 2; i < process.argv.length; i++) {
+    const rulePath = process.argv[i].split('.');
+    let rulesList = rulesObj;
+    let rule = rules;
+    while (rulePath.length > 1) {
+      const prop = rulePath.shift();
+      if (!rulesList[prop]) {
+        rulesList[prop] = {};
+        rulesList = rulesList[prop];
+      }
+      if (rule) {
+        rule = rule[prop];
+      }
+    }
+    rulesList[rulePath[0]] = rule && rule[rulePath[0]] ? rule[rulePath[0]] : null;
+  }
+} else {
+  rulesObj = rules;
+}
+
+rulesObj = propsToString(rulesObj);
+let output = JSON.stringify(rulesObj, null, 2);
+output = output.replace(/^(\s*)"(.*)": null,?$/gm, `$1${COLOR.fgGreen}$2${COLOR.reset}: undefined`);
+output = output.replace(/^(\s*)"(.*)": {$/gm, `$1${COLOR.fgGreen}$2${COLOR.reset}: {`);
+output = output.replace(/^(\s*)"(.*)": "(.*)",?$/gm, `$1${COLOR.fgGreen}$2${COLOR.reset}: ${COLOR.fgRed}$3${COLOR.reset}`);
+console.log(output, COLOR.reset);


### PR DESCRIPTION
## Description

This is just a developer tool to show the fully compiled rules from `src/rules.js` by running `npm run rules`

![image](https://user-images.githubusercontent.com/97994/87069815-79959200-c1dd-11ea-8890-f489eae0580c.png)

You can also specify paths to get just certain rules:

![image](https://user-images.githubusercontent.com/97994/87069842-84e8bd80-c1dd-11ea-98f6-1991033c90c9.png)


## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [x] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [x] Merge PR
