### PR TITLE
NFE: add dry run capabilities to default slugger

### DIFF
--- a/docs/USING_PRO.md
+++ b/docs/USING_PRO.md
@@ -85,10 +85,12 @@ slugger.slug('foo-1') // foo-1-2
 `slugger.slug` can also be called with the `dryrun` option for stateless operation:
 ```js
 slugger.slug('foo')                    // foo
-slugger.slug('foo', { dryrun: true })  // foo-1
 slugger.slug('foo')                    // foo-1
-slugger.slug('foo', { dryrun: true })  // foo-2
 slugger.slug('foo')                    // foo-2
+slugger.slug('foo', { dryrun: true })  // foo-3
+slugger.slug('foo', { dryrun: true })  // foo-3
+slugger.slug('foo')                    // foo-3
+slugger.slug('foo')                    // foo-4
 ...
 ```
 

--- a/docs/USING_PRO.md
+++ b/docs/USING_PRO.md
@@ -82,6 +82,16 @@ slugger.slug('foo-1') // foo-1-2
 ...
 ```
 
+`slugger` also has a stateless method `slugText` which does not update the internal accumulator:
+```js
+slugger.slug('foo')      // foo
+slugger.slugText('foo')  // foo-1
+slugger.slug('foo')      // foo-1
+slugger.slugText('foo')  // foo-2
+slugger.slug('foo')      // foo-2
+...
+```
+
 `flags` has the following properties:
 
 ```js

--- a/docs/USING_PRO.md
+++ b/docs/USING_PRO.md
@@ -82,13 +82,13 @@ slugger.slug('foo-1') // foo-1-2
 ...
 ```
 
-`slugger` also has a stateless method `slugText` which does not update the internal accumulator:
+`slugger.slug` can also be called with the `dryrun` option for stateless operation:
 ```js
-slugger.slug('foo')      // foo
-slugger.slugText('foo')  // foo-1
-slugger.slug('foo')      // foo-1
-slugger.slugText('foo')  // foo-2
-slugger.slug('foo')      // foo-2
+slugger.slug('foo')                    // foo
+slugger.slug('foo', { dryrun: true })  // foo-1
+slugger.slug('foo')                    // foo-1
+slugger.slug('foo', { dryrun: true })  // foo-2
+slugger.slug('foo')                    // foo-2
 ...
 ```
 

--- a/src/Slugger.js
+++ b/src/Slugger.js
@@ -6,11 +6,8 @@ module.exports = class Slugger {
     this.seen = {};
   }
 
-  /**
-   * Convert string to unique id
-   */
-  slug(value) {
-    let slug = value
+  serialize(value) {
+    return value
       .toLowerCase()
       .trim()
       // remove html tags
@@ -18,16 +15,41 @@ module.exports = class Slugger {
       // remove unwanted chars
       .replace(/[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,./:;<=>?@[\]^`{|}~]/g, '')
       .replace(/\s/g, '-');
+  }
 
+  /**
+   * Finds the next safe (unique) slug to use
+   */
+  getNextSafeSlug(originalSlug, isDryRun) {
+    let slug = originalSlug;
+    let occurenceAccumulator = 0;
     if (this.seen.hasOwnProperty(slug)) {
-      const originalSlug = slug;
+      occurenceAccumulator = this.seen[originalSlug];
       do {
-        this.seen[originalSlug]++;
-        slug = originalSlug + '-' + this.seen[originalSlug];
+        occurenceAccumulator++;
+        slug = originalSlug + '-' + occurenceAccumulator;
       } while (this.seen.hasOwnProperty(slug));
     }
-    this.seen[slug] = 0;
-
+    if (!isDryRun) {
+      this.seen[originalSlug] = occurenceAccumulator;
+      this.seen[slug] = 0;
+    }
     return slug;
+  }
+
+  /**
+   * Convert string to unique id
+   */
+  slug(value) {
+    const slug = this.serialize(value);
+    return this.getNextSafeSlug(slug);
+  }
+
+  /**
+   * Get slug text without incrementing accumulator
+   */
+  slugText(value) {
+    const slug = this.serialize(value);
+    return this.getNextSafeSlug(slug, true);
   }
 };

--- a/src/Slugger.js
+++ b/src/Slugger.js
@@ -39,17 +39,11 @@ module.exports = class Slugger {
 
   /**
    * Convert string to unique id
+   * @param {object} options
+   * @param {boolean} options.dryrun Generates the next unique slug without updating the internal accumulator.
    */
-  slug(value) {
+  slug(value, options = {}) {
     const slug = this.serialize(value);
-    return this.getNextSafeSlug(slug);
-  }
-
-  /**
-   * Get slug text without incrementing accumulator
-   */
-  slugText(value) {
-    const slug = this.serialize(value);
-    return this.getNextSafeSlug(slug, true);
+    return this.getNextSafeSlug(slug, options.dryrun);
   }
 };

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -64,10 +64,16 @@ describe('Test slugger functionality', () => {
     expect(slugger.slug('<em>html</em>')).toBe('html');
   });
 
-  it('should not increment seen when just getting text', () => {
+  it('should not increment seen when using dryrun option', () => {
     const slugger = new marked.Slugger();
-    slugger.slugText('<h1>This Section</h1>');
+    slugger.slug('<h1>This Section</h1>', { dryrun: true });
     expect(slugger.slug('<h1>This Section</h1>')).toBe('this-section');
+  });
+
+  it('should still return the next unique id when using dryrun', () => {
+    const slugger = new marked.Slugger();
+    expect(slugger.slug('<h1>This Section</h1>')).toBe('this-section');
+    expect(slugger.slug('<h1>This Section</h1>', { dryrun: true })).toBe('this-section-1');
   });
 });
 

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -66,7 +66,7 @@ describe('Test slugger functionality', () => {
 
   it('should not increment seen when using dryrun option', () => {
     const slugger = new marked.Slugger();
-    slugger.slug('<h1>This Section</h1>', { dryrun: true });
+    expect(slugger.slug('<h1>This Section</h1>', { dryrun: true })).toBe('this-section');
     expect(slugger.slug('<h1>This Section</h1>')).toBe('this-section');
   });
 

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -75,6 +75,17 @@ describe('Test slugger functionality', () => {
     expect(slugger.slug('<h1>This Section</h1>')).toBe('this-section');
     expect(slugger.slug('<h1>This Section</h1>', { dryrun: true })).toBe('this-section-1');
   });
+
+  it('should be repeatable in a sequence', () => {
+    const slugger = new marked.Slugger();
+    expect(slugger.slug('foo')).toBe('foo');
+    expect(slugger.slug('foo')).toBe('foo-1');
+    expect(slugger.slug('foo')).toBe('foo-2');
+    expect(slugger.slug('foo', { dryrun: true })).toBe('foo-3');
+    expect(slugger.slug('foo', { dryrun: true })).toBe('foo-3');
+    expect(slugger.slug('foo')).toBe('foo-3');
+    expect(slugger.slug('foo')).toBe('foo-4');
+  });
 });
 
 describe('Test paragraph token type', () => {

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -63,6 +63,12 @@ describe('Test slugger functionality', () => {
     const slugger = new marked.Slugger();
     expect(slugger.slug('<em>html</em>')).toBe('html');
   });
+
+  it('should not increment seen when just getting text', () => {
+    const slugger = new marked.Slugger();
+    slugger.slugText('<h1>This Section</h1>');
+    expect(slugger.slug('<h1>This Section</h1>')).toBe('this-section');
+  });
 });
 
 describe('Test paragraph token type', () => {


### PR DESCRIPTION
<!--

	If release PR, add ?template=release.md to the PR url to use the release PR template.

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->

**Marked version: 1.1.0**

<!-- The NPM version or commit hash having the issue -->

**Markdown flavor: n/a**

## Description

This PR adds a feature that allows the developer to use the default slugger without updating the internal accumulator. I have seen a use case for this when developers are implementing their own custom renderers. For example, see [this function](https://github.com/tc39/proposal-temporal/blob/5838233ecf733f70361880f237ed8c3fa8d5b837/docs/buildDocs.js#L45-L64) in the TC39 temporal-proposal repository. The changes made can be summarized as:
- Extends the default slugger with the ability to generate slug text without trigger internal communication.
- Separates slugger responsibilities into methods for re-use.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [x] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [x] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [x] Merge PR
