### PR TITLE
Org. owner to Styfle

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,3 +8,4 @@ Having said that, we take the security of Marked very seriously.
 Please disclose potential security issues by email to the project [committers](https://marked.js.org/#/AUTHORS.md) as well as the [listed owners within NPM](https://docs.npmjs.com/cli/owner).
 We will provide an initial assessment of security reports within 48 hours and should apply patches within 2 weeks
 (also, feel free to contribute a fix for the issue).
+


### PR DESCRIPTION
**@mention the contributor:**

## Recommendation to:

- [x] Change user group
- [ ] Add a badge
- [ ] Remove a badge

I would like to recommend that @styfle be promoted to an owner on the MarkedJS GitHub organization.

When we started this journey almost three years ago my desire(s) was (were) pretty simple. I actually can't believe it's taken this long for me to realize Steve wasn't already an owner.

Over the years he has stepped up to create a very robust documentation site, which we didn't have before. The site has done wonders to make issue creation and support easier for our users. The latest being #1742 being the latest in a long, long list.

My part in this has always been to primarily to watch out for the community, chip in where I can on code and reviews, and that sort of thing. @styfle and @UziTech have done a lot of heavy lifting making that job easier and have been there helping turn this project around since those early days.

Thank you.

## As the one mentioned, I would like to:

- [x] accept the recommendation; or,
- [ ] graciously decline; or,
- [ ] dispute the recommendation

within 30 days, if you have not indicated which option you are taking one of the following will happen:

1. If adding a badge, we will assume you are graciously declining.
2. If removing a badge, we will assume you do not want to dispute the recommendation; therefore, the badge will be removed.

Note: All committers must approve via review before merging, the disapproving committer can simply close the PR.