### PR TITLE
Parse inline

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -62,7 +62,7 @@ $ marked -s "*hello world*"
 </html>
 ```
 
-**Node**
+**Node.js**
 
 ```js
 const marked = require("marked");

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -66,7 +66,7 @@ $ marked -s "*hello world*"
 
 ```js
 const marked = require("marked");
-const html = marked('# Marked in browser\n\nRendered by **marked**.');
+const html = marked('# Marked in Node.js\n\nRendered by **marked**.');
 ```
 
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -62,6 +62,13 @@ $ marked -s "*hello world*"
 </html>
 ```
 
+**Node**
+
+```js
+const marked = require("marked");
+const html = marked('# Marked in browser\n\nRendered by **marked**.');
+```
+
 
 Marked offers [advanced configurations](/using_advanced) and [extensibility](/using_pro) as well.
 
@@ -82,4 +89,3 @@ By supporting the above Markdown flavors, it's possible that Marked can help you
 The only completely secure system is the one that doesn't exist in the first place. Having said that, we take the security of Marked very seriously.
 
 Therefore, please disclose potential security issues by email to the project [committers](/authors) as well as the [listed owners within NPM](https://docs.npmjs.com/cli/owner). We will provide an initial assessment of security reports within 48 hours and should apply patches within 2 weeks (also, feel free to contribute a fix for the issue).
-

--- a/docs/USING_ADVANCED.md
+++ b/docs/USING_ADVANCED.md
@@ -66,7 +66,11 @@ console.log(marked(markdownString));
 You can parse inline markdown by running markdown through `marked.parseInline`.
 
 ```js
-marked.parseInline(markdownString, options)
+const blockHtml = marked('**strong** _em_');
+console.log(blockHtml); // '<p><strong>strong</strong> <em>em</em></p>'
+
+const inlineHtml = marked.parseInline('**strong** _em_');
+console.log(inlineHtml); // '<strong>strong</strong> <em>em</em>'
 ```
 
 <h2 id="highlight">Asynchronous highlighting</h2>

--- a/docs/USING_ADVANCED.md
+++ b/docs/USING_ADVANCED.md
@@ -61,6 +61,14 @@ console.log(marked(markdownString));
 |walkTokens   |`function`  |`null`|v1.1.0|A function which is called for every token. See [extensibility](/using_pro) for more details.|
 |xhtml       |`boolean` |`false`  |v0.3.2   |If true, emit self-closing HTML tags for void elements (&lt;br/&gt;, &lt;img/&gt;, etc.) with a "/" as required by XHTML.|
 
+<h2 id="inline">Inline Markdown</h2>
+
+You can parse inline markdown by running markdown through `marked.parseInline`.
+
+```js
+marked.parseInline(markdownString, options)
+```
+
 <h2 id="highlight">Asynchronous highlighting</h2>
 
 Unlike `highlight.js` the `pygmentize.js` library uses asynchronous highlighting. This example demonstrates that marked is agnostic when it comes to the highlighter you use.

--- a/docs/_document.html
+++ b/docs/_document.html
@@ -38,6 +38,7 @@
                         <a href="/using_advanced">Advanced Usage</a>
                         <ul>
                             <li><a href="/using_advanced#options">Options</a></li>
+                            <li><a href="/using_advanced#inline">Inline Markdown</a></li>
                             <li><a href="/using_advanced#highlight">Highlighting</a></li>
                             <li><a href="/using_advanced#workers">Workers</a></li>
                         </ul>
@@ -80,7 +81,7 @@
             var sectionName = match[2];
             window.location.href = '/' + pageName + sectionName;
         }
-        
+
         var navLinks = document.querySelectorAll('nav a');
 
         function hashChange() {

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -93,6 +93,14 @@ module.exports = class Lexer {
   }
 
   /**
+   * Static Lex Inline Method
+   */
+  static lexInline(src, options) {
+    const lexer = new Lexer(options);
+    return lexer.inlineTokens(src);
+  }
+
+  /**
    * Preprocessing
    */
   lex(src) {

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -28,6 +28,14 @@ module.exports = class Parser {
   }
 
   /**
+   * Static Parse Inline Method
+   */
+  static parseInline(tokens, options) {
+    const parser = new Parser(options);
+    return parser.parseInline(tokens);
+  }
+
+  /**
    * Parse Loop
    */
   parse(tokens, top = true) {

--- a/src/marked.js
+++ b/src/marked.js
@@ -213,6 +213,39 @@ marked.walkTokens = function(tokens, callback) {
 };
 
 /**
+ * Parse Inline
+ */
+marked.parseInline = function(src, opt) {
+  // throw error in case of non string input
+  if (typeof src === 'undefined' || src === null) {
+    throw new Error('marked.parseInline(): input parameter is undefined or null');
+  }
+  if (typeof src !== 'string') {
+    throw new Error('marked.parseInline(): input parameter is of type '
+      + Object.prototype.toString.call(src) + ', string expected');
+  }
+
+  opt = merge({}, marked.defaults, opt || {});
+  checkSanitizeDeprecation(opt);
+
+  try {
+    const tokens = Lexer.lexInline(src, opt);
+    if (opt.walkTokens) {
+      marked.walkTokens(tokens, opt.walkTokens);
+    }
+    return Parser.parseInline(tokens, opt);
+  } catch (e) {
+    e.message += '\nPlease report this to https://github.com/markedjs/marked.';
+    if (opt.silent) {
+      return '<p>An error occurred:</p><pre>'
+        + escape(e.message + '', true)
+        + '</pre>';
+    }
+    throw e;
+  }
+};
+
+/**
  * Expose
  */
 

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -120,7 +120,7 @@ describe('inlineLexer', () => {
   });
 });
 
-fdescribe('parseInline', () => {
+describe('parseInline', () => {
   it('should parse inline tokens', () => {
     const md = '**strong** _em_';
     const html = marked.parseInline(md);

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -120,6 +120,22 @@ describe('inlineLexer', () => {
   });
 });
 
+fdescribe('parseInline', () => {
+  it('should parse inline tokens', () => {
+    const md = '**strong** _em_';
+    const html = marked.parseInline(md);
+
+    expect(html).toBe('<strong>strong</strong> <em>em</em>');
+  });
+
+  it('should not parse block tokens', () => {
+    const md = '# header\n\n_em_';
+    const html = marked.parseInline(md);
+
+    expect(html).toBe('# header\n\n<em>em</em>');
+  });
+});
+
 describe('use extension', () => {
   it('should use renderer', () => {
     const extension = {


### PR DESCRIPTION
**Marked version:** v1.1.1

## Description

Create a method (`marked.parseInline()`) that will parse only inline markdown. This is useful for parsing fragments of markdown that should only contain inline elements.

Example:

```js
const marked = require('marked');
const blockHtml = marked('**strong** _em_');
console.log(blockHtml); // '<p><strong>strong</strong> <em>em</em></p>'
const inlineHtml = marked.parseInline('**strong** _em_');
console.log(inlineHtml); // '<strong>strong</strong> <em>em</em>'
```

- Fixes #1760
- Fixes #395

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [x] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [x] Draft GitHub release notes have been updated.
- [x] CI is green (no forced merge required).
- [x] Merge PR
