### PR TITLE
fix: fix indented code in list item

### DIFF
--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -226,7 +226,7 @@ module.exports = class Tokenizer {
         // Remove the list item's bullet
         // so it is seen as the next token.
         space = item.length;
-        item = item.replace(/^ *([*+-]|\d+[.)]) */, '');
+        item = item.replace(/^ *([*+-]|\d+[.)]) ?/, '');
 
         // Outdent whatever the
         // list item contains. Hacky.

--- a/test/specs/commonmark/commonmark.0.29.json
+++ b/test/specs/commonmark/commonmark.0.29.json
@@ -53,8 +53,7 @@
     "example": 7,
     "start_line": 424,
     "end_line": 433,
-    "section": "Tabs",
-    "shouldFail": true
+    "section": "Tabs"
   },
   {
     "markdown": "    foo\n\tbar\n",

--- a/test/specs/gfm/commonmark.0.29.json
+++ b/test/specs/gfm/commonmark.0.29.json
@@ -53,8 +53,7 @@
     "example": 7,
     "start_line": 424,
     "end_line": 433,
-    "section": "Tabs",
-    "shouldFail": true
+    "section": "Tabs"
   },
   {
     "markdown": "    foo\n\tbar\n",


### PR DESCRIPTION
**Marked version:** 1.1.1

## Description

fixes indented code in list item. Passes 100% tabs spec.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression

## Committer

In most cases, this should be a different person than the contributor.

- [ ] Draft GitHub release notes have been updated.
- [ ] CI is green (no forced merge required).
- [ ] Merge PR
