### PR TITLE
Fix backtick for code in links

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -255,7 +255,7 @@ inline.tag = edit(inline.tag)
   .replace('attribute', inline._attribute)
   .getRegex();
 
-inline._label = /(?:\[(?:\\.|[^\[\]\\])*\]|\\.|`[^`]*`|[^\[\]\\`])*?/;
+inline._label = /(?:\[(?:\\.|[^\[\]\\])*\]|\\.|`.*`|[^\[\]\\`])*?/;
 inline._href = /<(?:\\[<>]?|[^\s<>\\])*>|[^\s\x00-\x1f]*/;
 inline._title = /"(?:\\"?|[^"\\])*"|'(?:\\'?|[^'\\])*'|\((?:\\\)?|[^)\\])*\)/;
 


### PR DESCRIPTION
Previously, when there as an inline code as a link label, it would only work if the backticks were single-opened and single-closed
(as in 1 backtick opening the code block + 1 backtick closing the code block).

Now one can use more than 1 backtick to open/close the inline code block as a link label.

<!--

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->

**Marked version:** 1.2.2

<!-- The NPM version or commit hash having the issue -->

**Markdown flavor:** GitHub Flavored Markdown

## Description

- Fixes #1663

## Expectation

Links should support having inline code blocks opened with multiple backticks (2nd link in the example below). Even if the backtick closes the code block, there still should be a link (3rd link in the example below).

![image](https://user-images.githubusercontent.com/6208958/96854631-19e09100-1432-11eb-9a65-aec0245fb7be.png)

Reference:

https://spec.commonmark.org/dingus/?text=start%20links%0A%0A%5B%60%20this%20is%20a%20backtick%20and%20it%20does%20not%20break%20stuff%20%60%5D(https%3A%2F%2Fexample.com)%0A%0A%5B%60%60%20this%20is%20a%20backtick%20%60%20and%20it%20breaks%20stuff%20%60%60%5D(https%3A%2F%2Fexample.com)%0A%0A%5B%60%20this%20is%20a%20backtick%20%60%20which%20stops%20being%20code%20but%20is%20still%20a%20link%60%5D(https%3A%2F%2Fexample.com)%0A%0Aend%20links%0A%0A

(I included the screenshot because the custom commonmark URL only seems to work on Chrome, not Firefox)

## Result

Marked, however, does not support the scenarios described above. It only supports code blocks in links when they are opened with a single backtick and closed with a single backtick.

Reference:

https://marked.js.org/demo/?text=start%20links%0A%0A%5B%60%20this%20is%20a%20backtick%20and%20it%20does%20not%20break%20stuff%20%60%5D(https%3A%2F%2Fexample.com)%0A%0A%5B%60%60%20this%20is%20a%20backtick%20%60%20and%20it%20breaks%20stuff%20%60%60%5D(https%3A%2F%2Fexample.com)%0A%0A%5B%60%20this%20is%20a%20backtick%20%60%20which%20stops%20being%20code%20but%20is%20still%20a%20link%60%5D(https%3A%2F%2Fexample.com)%0A%0Aend%20links%0A&options=%7B%0A%20%22baseUrl%22%3A%20null%2C%0A%20%22breaks%22%3A%20false%2C%0A%20%22gfm%22%3A%20true%2C%0A%20%22headerIds%22%3A%20true%2C%0A%20%22headerPrefix%22%3A%20%22%22%2C%0A%20%22highlight%22%3A%20null%2C%0A%20%22langPrefix%22%3A%20%22language-%22%2C%0A%20%22mangle%22%3A%20true%2C%0A%20%22pedantic%22%3A%20false%2C%0A%20%22sanitize%22%3A%20false%2C%0A%20%22sanitizer%22%3A%20null%2C%0A%20%22silent%22%3A%20false%2C%0A%20%22smartLists%22%3A%20false%2C%0A%20%22smartypants%22%3A%20false%2C%0A%20%22tokenizer%22%3A%20null%2C%0A%20%22xhtml%22%3A%20false%0A%7D&version=master

## What was attempted

Now, instead of matching only a single-opening backtick + no backticks + single-closing backtick, as in ``` `[^`]*` ```, anything can be matched inside the backticks, as in ``` `.*` ```.

It correctly parsed the links, as shown below when I ran it locally:

![image](https://user-images.githubusercontent.com/6208958/96855667-6e384080-1433-11eb-97d3-fb481fc04764.png)

<!--

	If no issue exists that you're aware of. The maintainers should be able to figure out if it's a duplicate.

## Expectation

Describe the output you are expecting from marked

## Result

Describe the output you received from marked

## What was attempted

Describe what code combination got you there

-->

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
