### PR TITLE
fix: Add type to def token

### DIFF
--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -320,6 +320,7 @@ module.exports = class Tokenizer {
       if (cap[3]) cap[3] = cap[3].substring(1, cap[3].length - 1);
       const tag = cap[1].toLowerCase().replace(/\s+/g, ' ');
       return {
+        type: 'def',
         tag,
         raw: cap[0],
         href: cap[2],


### PR DESCRIPTION
<!--

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->

**Marked version:** 1.2.3

<!-- The NPM version or commit hash having the issue -->

**Markdown flavor:** Markdown.pl|CommonMark|GitHub Flavored Markdown|n/a

## Description

Added `def` token because it didn't have a type only.

## What was attempted

When I tried to switch the type of tokens in a TypeScript project, I noticed the problem that type doesn't always exist and found that type was missing only in the def token.

## Contributor

- [x] no tests required for this PR.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
