### PR TITLE
chore(docs): update versioning and other docs

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -8,6 +8,7 @@ all code is your original work. `</legalese>`
 
 ## Marked
 
+Copyright (c) 2018+, MarkedJS (https://github.com/markedjs/)
 Copyright (c) 2011-2018, Christopher Jeffrey (https://github.com/chjj/)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -30,8 +31,8 @@ THE SOFTWARE.
 
 ## Markdown
 
-Copyright © 2004, John Gruber 
-http://daringfireball.net/ 
+Copyright © 2004, John Gruber
+http://daringfireball.net/
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 [![gzip size](https://badgen.net/badgesize/gzip/https://cdn.jsdelivr.net/npm/marked/marked.min.js)](https://cdn.jsdelivr.net/npm/marked/marked.min.js)
 [![install size](https://badgen.net/packagephobia/install/marked)](https://packagephobia.now.sh/result?p=marked)
 [![downloads](https://badgen.net/npm/dt/marked)](https://www.npmjs.com/package/marked)
-[![dep](https://badgen.net/david/dep/markedjs/marked?label=deps)](https://david-dm.org/markedjs/marked)
-[![dev dep](https://badgen.net/david/dev/markedjs/marked?label=devDeps)](https://david-dm.org/markedjs/marked?type=dev)
 [![github actions](https://github.com/markedjs/marked/workflows/Tests/badge.svg)](https://github.com/markedjs/marked/actions)
 [![snyk](https://snyk.io/test/npm/marked/badge.svg)](https://snyk.io/test/npm/marked)
 

--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -65,6 +65,8 @@ Marked takes an encompassing approach to its community. As such, you can think o
   </tbody>
 </table>
 
+## Contributors
+
 <table>
   <tbody>
     <tr>

--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -53,7 +53,13 @@ Marked takes an encompassing approach to its community. As such, you can think o
         <small>Release Wrangler; Titan of the test harness; Dr. DevOps</small>
       </td>
       <td align="center" valign="top">
-        &nbsp;
+        <a href="https://github.com/calculuschild">
+          <img width="100" height="100" src="https://github.com/calculuschild.png?s=150">
+        </a>
+        <br>
+        <a href="https://github.com/calculuschild">Trevor Buckner</a>
+        <div>Committer</div>
+        <small>Master of Marked</small>
       </td>
     </tr>
   </tbody>

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -12,4 +12,4 @@ We follow [semantic versioning](https://semver.org) where the following sequence
 
 1. **Major:** There is at least one change to the public API or a break from the [CommonMark](https://spec.commonmark.org/current/) or [GFM](https://github.github.com/gfm/) spec.
 2. **Minor:** There is at least one new feature added to the public API.
-3. **Patch:** No breaking changes, no new features.
+3. **Patch:** Changes that move marked closer to spec compliance or change a public API that does not break backwards compatibility.

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -8,14 +8,8 @@ Marked uses [semantic-release](https://github.com/semantic-release/semantic-rele
 
 ## Versioning
 
-We follow [semantic versioning](https://semver.org) where the following sequence is true `[major].[minor].[patch]`; therefore, consider the following implications of the release you are preparing:
+We follow [semantic versioning](https://semver.org) where the following sequence is true `[major].[minor].[patch]`:
 
-1. **Major:** There is at least one change not deemed backward compatible.
-2. **Minor:** There is at least one new feature added to the release.
+1. **Major:** There is at least one change to the public API or a break from the [CommonMark](https://spec.commonmark.org/current/) or [GFM](https://github.github.com/gfm/) spec.
+2. **Minor:** There is at least one new feature added to the public API.
 3. **Patch:** No breaking changes, no new features.
-
-What to expect while Marked is a zero-major (0.x.y):
-
-1. The major will remain at zero; thereby, alerting consumers to the potentially volatile nature of the package.
-2. The minor will tend to be more analogous to a `major` release.
-3. The patch will tend to be more analogous to a `minor` release or a collection of bug fixes (patches).

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -12,4 +12,4 @@ We follow [semantic versioning](https://semver.org) where the following sequence
 
 1. **Major:** There is at least one change to the public API or a break from the [CommonMark](https://spec.commonmark.org/current/) or [GFM](https://github.github.com/gfm/) spec.
 2. **Minor:** There is at least one new feature added to the public API.
-3. **Patch:** Changes that move marked closer to spec compliance or change a public API that does not break backwards compatibility.
+3. **Patch:** Changes that move Marked closer to spec compliance or change a public API that does not break backwards compatibility.

--- a/docs/_document.html
+++ b/docs/_document.html
@@ -64,7 +64,12 @@
                     </li>
                     <li><a href="/code_of_conduct">Code of Conduct</a></li>
                     <li><a href="/authors">Authors</a></li>
-                    <li><a href="/publishing">Publishing</a></li>
+                    <li>
+                      <a href="/publishing">Publishing</a>
+                      <ul>
+                          <li><a href="/publishing#versioning">Versioning</a></li>
+                      </ul>
+                    </li>
                     <li><a href="/license">License</a></li>
                 </ul>
             </nav>


### PR DESCRIPTION
## Description

- Add @calculuschild to Authors table.
- Add link to Versioning docs in sidebar.
- Update Versioning to be more specific on what counts as a breaking change.
- Remove Deps badges since https://david-dm.org is down. (fixes #1833)
- Add MarkedJS copyright to license.

## Contributor

- [x] no tests required for this PR.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
