### PR TITLE
chore(dev-deps): remove eslint-plugin-standard

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,5 @@
 {
   "extends": "standard",
-  "plugins": [
-    "standard"
-  ],
   "rules": {
     "semi": ["error", "always"],
     "indent": ["error", 2, {

--- a/docs/.eslintrc.json
+++ b/docs/.eslintrc.json
@@ -1,8 +1,5 @@
 {
   "extends": "standard",
-  "plugins": [
-    "standard"
-  ],
   "parserOptions": {
     "ecmaVersion": 5,
     "sourceType": "script"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2781,12 +2781,6 @@
       "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
       "dev": true
     },
-    "eslint-plugin-standard": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.1.0.tgz",
-      "integrity": "sha512-ZL7+QRixjTR6/528YNGyDotyffm5OQst/sGxKDwGb9Uqs4In5Egi4+jbobhqJoyoCM6/7v/1A5fhQ7ScMtDjaQ==",
-      "dev": true
-    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-standard": "^4.1.0",
     "front-matter": "^4.0.2",
     "highlight.js": "^10.4.0",
     "jasmine": "^3.6.3",

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,8 +1,5 @@
 {
   "extends": "standard",
-  "plugins": [
-    "standard"
-  ],
   "globals": {
     "expectAsync": "readonly"
   },


### PR DESCRIPTION
[eslint-plugin-standard](https://github.com/standard/eslint-plugin-standard#deprecated-this-package-isnt-used-by-standard-anymore-as-of-standard-v16-see-httpsgithubcomstandardstandardissues1316) is deprecated