### PR TITLE
fix: fix link with angle brackets around href

### DIFF
--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -489,8 +489,6 @@ module.exports = class Tokenizer {
         if (link) {
           href = link[1];
           title = link[3];
-        } else {
-          title = '';
         }
       } else {
         title = cap[3] ? cap[3].slice(1, -1) : '';

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -505,11 +505,10 @@ module.exports = class Tokenizer {
           href = href.slice(1, -1);
         }
       }
-      const token = outputLink(cap, {
+      return outputLink(cap, {
         href: href ? href.replace(this.rules.inline._escapes, '$1') : href,
         title: title ? title.replace(this.rules.inline._escapes, '$1') : title
       }, cap[0]);
-      return token;
     }
   }
 
@@ -527,8 +526,7 @@ module.exports = class Tokenizer {
           text
         };
       }
-      const token = outputLink(cap, link, cap[0]);
-      return token;
+      return outputLink(cap, link, cap[0]);
     }
   }
 

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -466,7 +466,7 @@ module.exports = class Tokenizer {
 
         // ending angle bracket cannot be escaped
         const rtrimSlash = rtrim(trimmedUrl.slice(0, -1), '\\');
-        if (!((trimmedUrl.length - rtrimSlash.length) & 1)) {
+        if ((trimmedUrl.length - rtrimSlash.length) % 2 === 0) {
           return;
         }
       } else {

--- a/src/rules.js
+++ b/src/rules.js
@@ -260,7 +260,7 @@ inline.tag = edit(inline.tag)
   .getRegex();
 
 inline._label = /(?:\[(?:\\.|[^\[\]\\])*\]|\\.|`[^`]*`|[^\[\]\\`])*?/;
-inline._href = /<(?:\\[<>]?|[^\s<>\\])*>|[^\s\x00-\x1f]*/;
+inline._href = /<(?:\\.|[^\n<>\\])+>|[^\s\x00-\x1f]*/;
 inline._title = /"(?:\\"?|[^"\\])*"|'(?:\\'?|[^'\\])*'|\((?:\\\)?|[^)\\])*\)/;
 
 inline.link = edit(inline.link)

--- a/test/specs/commonmark/commonmark.0.29.json
+++ b/test/specs/commonmark/commonmark.0.29.json
@@ -3939,8 +3939,7 @@
     "example": 486,
     "start_line": 7543,
     "end_line": 7547,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "[link](foo\nbar)\n",
@@ -3964,8 +3963,7 @@
     "example": 489,
     "start_line": 7571,
     "end_line": 7575,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "[link](<foo\\>)\n",
@@ -3973,8 +3971,7 @@
     "example": 490,
     "start_line": 7579,
     "end_line": 7583,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "[a](<b)c\n[a](<b)c>\n[a](<b>c)\n",
@@ -3982,8 +3979,7 @@
     "example": 491,
     "start_line": 7588,
     "end_line": 7596,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "[link](\\(foo\\))\n",

--- a/test/specs/gfm/commonmark.0.29.json
+++ b/test/specs/gfm/commonmark.0.29.json
@@ -3939,8 +3939,7 @@
     "example": 486,
     "start_line": 7543,
     "end_line": 7547,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "[link](foo\nbar)\n",
@@ -3964,8 +3963,7 @@
     "example": 489,
     "start_line": 7571,
     "end_line": 7575,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "[link](<foo\\>)\n",
@@ -3973,8 +3971,7 @@
     "example": 490,
     "start_line": 7579,
     "end_line": 7583,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "[a](<b)c\n[a](<b)c>\n[a](<b>c)\n",
@@ -3982,8 +3979,7 @@
     "example": 491,
     "start_line": 7588,
     "end_line": 7596,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "[link](\\(foo\\))\n",

--- a/test/specs/new/link_lt.html
+++ b/test/specs/new/link_lt.html
@@ -1,1 +1,3 @@
-<p><a href="%3Ctest">URL</a></p>
+<p><a href="test">URL</a></p>
+
+<p><a href="test%5C">URL</a></p>

--- a/test/specs/new/link_lt.md
+++ b/test/specs/new/link_lt.md
@@ -1,1 +1,6 @@
+---
+pedantic: true
+---
 [URL](<test)
+
+[URL](<test\>)


### PR DESCRIPTION
**Marked version:** v1.2.5

## Description

Fixes CommonMark tests [486](https://spec.commonmark.org/0.29/#example-486), [489](https://spec.commonmark.org/0.29/#example-489), [490](https://spec.commonmark.org/0.29/#example-490), [491](https://spec.commonmark.org/0.29/#example-491)

- Fixes #1639

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
