### PR TITLE
fix: leave whitespace only lines alone

### DIFF
--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -120,7 +120,9 @@ module.exports = class Lexer {
    * Lexing
    */
   blockTokens(src, tokens = [], top = true) {
-    src = src.replace(/^ +$/gm, '');
+    if (this.options.pedantic) {
+      src = src.replace(/^ +$/gm, '');
+    }
     let token, i, l, lastToken;
 
     while (src) {

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -22,6 +22,8 @@ module.exports = class Renderer {
       }
     }
 
+    code = code.replace(/\n$/, '') + '\n';
+
     if (!lang) {
       return '<pre><code>'
         + (escaped ? code : escape(code, true))

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -91,7 +91,7 @@ module.exports = class Tokenizer {
         };
       }
 
-      const text = cap[0].replace(/^ {4}/gm, '');
+      const text = cap[0].replace(/^ {1,4}/gm, '');
       return {
         type: 'code',
         raw: cap[0],

--- a/src/rules.js
+++ b/src/rules.js
@@ -8,8 +8,8 @@ const {
  * Block-Level Grammar
  */
 const block = {
-  newline: /^\n+/,
-  code: /^( {4}[^\n]+\n*)+/,
+  newline: /^(?: *(?:\n|$))+/,
+  code: /^( {4}[^\n]+(?:\n(?: *(?:\n|$))*)?)+/,
   fences: /^ {0,3}(`{3,}(?=[^`\n]*\n)|~{3,})([^\n]*)\n(?:|([\s\S]*?)\n)(?: {0,3}\1[~`]* *(?:\n+|$)|$)/,
   hr: /^ {0,3}((?:- *){3,}|(?:_ *){3,}|(?:\* *){3,})(?:\n+|$)/,
   heading: /^ {0,3}(#{1,6})(?=\s|$)(.*)(?:\n+|$)/,
@@ -31,7 +31,7 @@ const block = {
   lheading: /^([^\n]+)\n {0,3}(=+|-+) *(?:\n+|$)/,
   // regex template, placeholders will be replaced according to different paragraph
   // interruption rules of commonmark and the original markdown spec:
-  _paragraph: /^([^\n]+(?:\n(?!hr|heading|lheading|blockquote|fences|list|html)[^\n]+)*)/,
+  _paragraph: /^([^\n]+(?:\n(?!hr|heading|lheading|blockquote|fences|list|html| +\n)[^\n]+)*)/,
   text: /^[^\n]+/
 };
 

--- a/test/specs/new/code_compensation_indent.html
+++ b/test/specs/new/code_compensation_indent.html
@@ -2,6 +2,7 @@
 <ol>
 <li><p>This is a list element.</p>
 <pre><code>const x = 5;
-const y = x + 5;</code></pre>
+const y = x + 5;
+</code></pre>
 </li>
 </ol>

--- a/test/specs/new/code_consistent_newline.html
+++ b/test/specs/new/code_consistent_newline.html
@@ -1,3 +1,5 @@
-<pre><code class="language-js">const value = 42;</code></pre>
-<pre><code>const value = 42;</code></pre>
+<pre><code class="language-js">const value = 42;
+</code></pre>
+<pre><code>const value = 42;
+</code></pre>
 <p>Code blocks contain trailing new line.</p>

--- a/test/specs/new/whiltespace_lines.html
+++ b/test/specs/new/whiltespace_lines.html
@@ -4,7 +4,9 @@
   
 b
 
-c</code></pre>
+c
+</code></pre>
 <pre><code>a
   
-b</code></pre>
+b
+</code></pre>

--- a/test/specs/new/whiltespace_lines.html
+++ b/test/specs/new/whiltespace_lines.html
@@ -1,0 +1,10 @@
+<p>paragraph</p>
+<p>test</p>
+<pre><code>a
+  
+b
+
+c</code></pre>
+<pre><code>a
+  
+b</code></pre>

--- a/test/specs/new/whiltespace_lines.md
+++ b/test/specs/new/whiltespace_lines.md
@@ -1,0 +1,18 @@
+---
+renderExact: true
+---
+paragraph
+  
+test
+
+    a
+      
+    b
+  
+    c
+
+```
+a
+  
+b
+```

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -335,12 +335,15 @@ text 1
         fail(err);
       }
 
-      expect(html).toBe(`<pre><code class="language-lang1">async text 1</code></pre>
+      expect(html).toBe(`<pre><code class="language-lang1">async text 1
+</code></pre>
 <blockquote>
-<pre><code class="language-lang2">async text 2</code></pre>
+<pre><code class="language-lang2">async text 2
+</code></pre>
 </blockquote>
 <ul>
-<li><pre><code class="language-lang3">async text 3</code></pre>
+<li><pre><code class="language-lang3">async text 3
+</code></pre>
 </li>
 </ul>
 `);
@@ -378,12 +381,15 @@ text 1
         fail(err);
       }
 
-      expect(html).toBe(`<pre><code class="language-lang1">async text 1</code></pre>
+      expect(html).toBe(`<pre><code class="language-lang1">async text 1
+</code></pre>
 <blockquote>
-<pre><code class="language-lang2">async text 2</code></pre>
+<pre><code class="language-lang2">async text 2
+</code></pre>
 </blockquote>
 <ul>
-<li><pre><code class="language-lang3">async text 3</code></pre>
+<li><pre><code class="language-lang3">async text 3
+</code></pre>
 </li>
 </ul>
 `);


### PR DESCRIPTION
**Marked version:** v1.2.7

## Description

The whitespace is removed from lines with only whitespace. This causes problems in code blocks where the whitespace matters.

This PR keeps the spaces in blank lines and adds them to output.

This PR also adds a new line character to the end of all code blocks.

- Fixes #1884 

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
