### PR TITLE
[WIP] Tokenizer Array using Stringified functions

### DIFF
--- a/lib/marked.esm.js
+++ b/lib/marked.esm.js
@@ -1,6 +1,6 @@
 /**
  * marked - a markdown parser
- * Copyright (c) 2011-2020, Christopher Jeffrey. (MIT Licensed)
+ * Copyright (c) 2011-2021, Christopher Jeffrey. (MIT Licensed)
  * https://github.com/markedjs/marked
  */
 
@@ -393,13 +393,13 @@ var Tokenizer_1 = class Tokenizer {
     }
   }
 
-  code(src, tokens) {
+  code(src, lastToken) {
     const cap = this.rules.block.code.exec(src);
     if (cap) {
-      const lastToken = tokens[tokens.length - 1];
       // An indented code block cannot interrupt a paragraph.
       if (lastToken && lastToken.type === 'paragraph') {
         return {
+          type: 'continue',
           raw: cap[0],
           text: cap[0].trimRight()
         };
@@ -721,12 +721,12 @@ var Tokenizer_1 = class Tokenizer {
     }
   }
 
-  text(src, tokens) {
+  text(src, lastToken) {
     const cap = this.rules.block.text.exec(src);
     if (cap) {
-      const lastToken = tokens[tokens.length - 1];
       if (lastToken && lastToken.type === 'text') {
         return {
+          type: 'continue',
           raw: cap[0],
           text: cap[0]
         };
@@ -1441,6 +1441,38 @@ var Lexer_1 = class Lexer {
       }
     }
     this.tokenizer.rules = rules;
+
+    this.blockTokenizers = [
+      { name: 'newline', func: this.newline },
+      { name: 'code', func: this.code },
+      { name: 'fences', func: this.fences },
+      { name: 'nptable', func: this.nptable },
+      { name: 'heading', func: this.heading },
+      { name: 'hr', func: this.hr },
+      { name: 'blockquote', func: this.blockquote },
+      { name: 'list', func: this.list },
+      { name: 'html', func: this.html },
+      { name: 'def', func: this.def },
+      { name: 'table', func: this.table },
+      { name: 'lheading', func: this.lheading },
+      { name: 'paragraph', func: this.paragraph },
+      { name: 'text', func: this.text }
+    ];
+
+    this.inlineTokenizers = [
+      { name: 'escape', func: this.escape },
+      { name: 'tag', func: this.tag },
+      { name: 'link', func: this.link },
+      { name: 'reflink', func: this.reflink },
+      { name: 'strong', func: this.strong },
+      { name: 'em', func: this.em },
+      { name: 'codespan', func: this.codespan },
+      { name: 'br', func: this.br },
+      { name: 'del', func: this.del },
+      { name: 'autolink', func: this.autolink },
+      { name: 'url', func: this.url },
+      { name: 'inlineText', func: this.inlineText }
+    ];
   }
 
   /**
@@ -1487,129 +1519,152 @@ var Lexer_1 = class Lexer {
   /**
    * Lexing
    */
+
+//==== Block tokenizers ====//
+  // newline
+  newline(src, params) {
+    let token;
+    if (token = this.tokenizer.space(src)) {
+      return token;
+    }
+  }
+
+  // code
+  code(src, params) {
+    let token;
+    if (token = this.tokenizer.code(src, params.lastToken)) {
+      return token;
+    }
+  }
+
+  // fences
+  fences(src, params) {
+    let token;
+    if (token = this.tokenizer.fences(src)) {
+      return token;
+    }
+  }
+
+  // table no leading pipe (gfm)
+  nptable(src, params) {
+    let token;
+    if (token = this.tokenizer.nptable(src)) {
+      return token;
+    }
+  }
+
+  // heading
+  heading(src, params) {
+    let token;
+    if (token = this.tokenizer.heading(src)) {
+      return token;
+    }
+  }
+
+  // hr
+  hr(src, params) {
+    let token;
+    if (token = this.tokenizer.hr(src)) {
+      return token;
+    }
+  }
+
+  // blockquote
+  blockquote(src, params) {
+    let token;
+    if (token = this.tokenizer.blockquote(src)) {
+      token.tokens = this.blockTokens(token.text, [], params.top);
+      return token;
+    }
+  }
+
+  // list
+  list(src, params) {
+    let token;
+    if (token = this.tokenizer.list(src)) {
+      const l = token.items.length;
+      let i;
+      for (i = 0; i < l; i++) {
+        token.items[i].tokens = this.blockTokens(token.items[i].text, [], false);
+      }
+      return token;
+    }
+  }
+
+  // html
+  html(src, params) {
+    let token;
+    if (token = this.tokenizer.html(src)) {
+      return token;
+    }
+  }
+
+  // def
+  def(src, params) {
+    let token;
+    if (params.top && (token = this.tokenizer.def(src))) {
+      if (!this.tokens.links[token.tag]) {
+        this.tokens.links[token.tag] = {
+          href: token.href,
+          title: token.title
+        };
+      }
+      return token;
+    }
+  }
+
+  // table (gfm)
+  table(src, params) {
+    let token;
+    if (token = this.tokenizer.table(src)) {
+      return token;
+    }
+  }
+
+  // lheading
+  lheading(src, params) {
+    let token;
+    if (token = this.tokenizer.lheading(src, params)) {
+      return token;
+    }
+  }
+
+  // top-level paragraph
+  paragraph(src, params) {
+    let token;
+    if (params.top && (token = this.tokenizer.paragraph(src))) {
+      return token;
+    }
+  }
+
+  // text
+  text(src, params) {
+    let token;
+    if (token = this.tokenizer.text(src, params.lastToken)) {
+      return token;
+    }
+  }
+
   blockTokens(src, tokens = [], top = true) {
+    let token;
     src = src.replace(/^ +$/gm, '');
-    let token, i, l, lastToken;
+
+    const blockParams = {
+      top: top,
+      lastToken: null
+    };
 
     while (src) {
-      // newline
-      if (token = this.tokenizer.space(src)) {
+      if (this.blockTokenizers.some(function(fn) { return token = fn.func.call(this, src, blockParams); }, this)) {
         src = src.substring(token.raw.length);
         if (token.type) {
-          tokens.push(token);
-        }
-        continue;
-      }
-
-      // code
-      if (token = this.tokenizer.code(src, tokens)) {
-        src = src.substring(token.raw.length);
-        if (token.type) {
-          tokens.push(token);
-        } else {
-          lastToken = tokens[tokens.length - 1];
-          lastToken.raw += '\n' + token.raw;
-          lastToken.text += '\n' + token.text;
-        }
-        continue;
-      }
-
-      // fences
-      if (token = this.tokenizer.fences(src)) {
-        src = src.substring(token.raw.length);
-        tokens.push(token);
-        continue;
-      }
-
-      // heading
-      if (token = this.tokenizer.heading(src)) {
-        src = src.substring(token.raw.length);
-        tokens.push(token);
-        continue;
-      }
-
-      // table no leading pipe (gfm)
-      if (token = this.tokenizer.nptable(src)) {
-        src = src.substring(token.raw.length);
-        tokens.push(token);
-        continue;
-      }
-
-      // hr
-      if (token = this.tokenizer.hr(src)) {
-        src = src.substring(token.raw.length);
-        tokens.push(token);
-        continue;
-      }
-
-      // blockquote
-      if (token = this.tokenizer.blockquote(src)) {
-        src = src.substring(token.raw.length);
-        token.tokens = this.blockTokens(token.text, [], top);
-        tokens.push(token);
-        continue;
-      }
-
-      // list
-      if (token = this.tokenizer.list(src)) {
-        src = src.substring(token.raw.length);
-        l = token.items.length;
-        for (i = 0; i < l; i++) {
-          token.items[i].tokens = this.blockTokens(token.items[i].text, [], false);
-        }
-        tokens.push(token);
-        continue;
-      }
-
-      // html
-      if (token = this.tokenizer.html(src)) {
-        src = src.substring(token.raw.length);
-        tokens.push(token);
-        continue;
-      }
-
-      // def
-      if (top && (token = this.tokenizer.def(src))) {
-        src = src.substring(token.raw.length);
-        if (!this.tokens.links[token.tag]) {
-          this.tokens.links[token.tag] = {
-            href: token.href,
-            title: token.title
-          };
-        }
-        continue;
-      }
-
-      // table (gfm)
-      if (token = this.tokenizer.table(src)) {
-        src = src.substring(token.raw.length);
-        tokens.push(token);
-        continue;
-      }
-
-      // lheading
-      if (token = this.tokenizer.lheading(src)) {
-        src = src.substring(token.raw.length);
-        tokens.push(token);
-        continue;
-      }
-
-      // top-level paragraph
-      if (top && (token = this.tokenizer.paragraph(src))) {
-        src = src.substring(token.raw.length);
-        tokens.push(token);
-        continue;
-      }
-
-      // text
-      if (token = this.tokenizer.text(src, tokens)) {
-        src = src.substring(token.raw.length);
-        if (token.type) {
-          tokens.push(token);
-        } else {
-          lastToken = tokens[tokens.length - 1];
-          lastToken.raw += '\n' + token.raw;
-          lastToken.text += '\n' + token.text;
+          if (token.type === 'continue') {
+            blockParams.lastToken.raw += '\n' + token.raw;
+            blockParams.lastToken.text += '\n' + token.text;
+          } else {
+            tokens.push(token);
+            blockParams.lastToken = token;
+          }
         }
         continue;
       }
@@ -1690,18 +1745,124 @@ var Lexer_1 = class Lexer {
     return tokens;
   }
 
+//==== Inline Tokenizers ====//
+  // escape
+  escape(src, params) {
+    let token;
+    if (token = this.tokenizer.escape(src)) {
+      return token;
+    }
+  }
+
+  // tag
+  tag(src, params) {
+    let token;
+    if (token = this.tokenizer.tag(src, params.inLink, params.inRawBlock)) {
+      params.inLink = token.inLink;
+      params.inRawBlock = token.inRawBlock;
+      return token;
+    }
+  }
+
+  // link
+  link(src, params) {
+    let token;
+    if (token = this.tokenizer.link(src)) {
+      if (token.type === 'link') {
+        token.tokens = this.inlineTokens(token.text, [], true, params.inRawBlock);
+      }
+      return token;
+    }
+  }
+
+  // reflink, nolink
+  reflink(src, params) {
+    let token;
+    if (token = this.tokenizer.reflink(src, this.tokens.links)) {
+      if (token.type === 'link') {
+        token.tokens = this.inlineTokens(token.text, [], true, params.inRawBlock);
+      }
+      return token;
+    }
+  }
+
+  // strong
+  strong(src, params) {
+    let token;
+    if (token = this.tokenizer.strong(src, params.maskedSrc, params.prevChar)) {
+      token.tokens = this.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
+      return token;
+    }
+  }
+
+  // em
+  em(src, params) {
+    let token;
+    if (token = this.tokenizer.em(src, params.maskedSrc, params.prevChar)) {
+      token.tokens = this.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
+      return token;
+    }
+  }
+
+  // code
+  codespan(src, params) {
+    let token;
+    if (token = this.tokenizer.codespan(src)) {
+      return token;
+    }
+  }
+
+  // br
+  br(src, params) {
+    let token;
+    if (token = this.tokenizer.br(src)) {
+      return token;
+    }
+  }
+
+  // del (gfm)
+  del(src, params) {
+    let token;
+    if (token = this.tokenizer.del(src)) {
+      token.tokens = this.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
+      return token;
+    }
+  }
+
+  // autolink
+  autolink(src, params) {
+    let token;
+    if (token = this.tokenizer.autolink(src, params.mangle)) {
+      return token;
+    }
+  }
+
+  // url (gfm)
+  url(src, params) {
+    let token;
+    if (!params.inLink && (token = this.tokenizer.url(src, params.mangle))) {
+      return token;
+    }
+  }
+
+  // text
+  inlineText(src, params) {
+    let token;
+    if (token = this.tokenizer.inlineText(src, params.inRawBlock, params.smartypants)) {
+      params.prevChar = token.raw.slice(-1);
+      params.keepPrevChar = true;
+      return token;
+    }
+  }
+
   /**
    * Lexing/Compiling
    */
   inlineTokens(src, tokens = [], inLink = false, inRawBlock = false) {
-    let token;
-
-    // String with links masked to avoid interference with em and strong
+    let match, token;
     let maskedSrc = src;
-    let match;
-    let keepPrevChar, prevChar;
 
-    // Mask out reflinks
+    // Mask out reflinks to avoid interference with em and strong
     if (this.tokens.links) {
       const links = Object.keys(this.tokens.links);
       if (links.length > 0) {
@@ -1717,104 +1878,25 @@ var Lexer_1 = class Lexer {
       maskedSrc = maskedSrc.slice(0, match.index) + '[' + repeatString$1('a', match[0].length - 2) + ']' + maskedSrc.slice(this.tokenizer.rules.inline.blockSkip.lastIndex);
     }
 
+    const inlineParams = {
+      inLink: inLink,
+      inRawBlock: inRawBlock,
+      maskedSrc: maskedSrc,
+      prevChar: false,
+      keepPrevChar: false,
+
+      mangle: mangle,
+      smartypants: smartypants
+    };
+
     while (src) {
-      if (!keepPrevChar) {
-        prevChar = '';
+      if (!inlineParams.keepPrevChar) {
+        inlineParams.prevChar = '';
       }
-      keepPrevChar = false;
-      // escape
-      if (token = this.tokenizer.escape(src)) {
-        src = src.substring(token.raw.length);
-        tokens.push(token);
-        continue;
-      }
+      inlineParams.keepPrevChar = false;
 
-      // tag
-      if (token = this.tokenizer.tag(src, inLink, inRawBlock)) {
+      if (this.inlineTokenizers.some(function(fn) { return token = fn.func.call(this, src, inlineParams); }, this)) {
         src = src.substring(token.raw.length);
-        inLink = token.inLink;
-        inRawBlock = token.inRawBlock;
-        tokens.push(token);
-        continue;
-      }
-
-      // link
-      if (token = this.tokenizer.link(src)) {
-        src = src.substring(token.raw.length);
-        if (token.type === 'link') {
-          token.tokens = this.inlineTokens(token.text, [], true, inRawBlock);
-        }
-        tokens.push(token);
-        continue;
-      }
-
-      // reflink, nolink
-      if (token = this.tokenizer.reflink(src, this.tokens.links)) {
-        src = src.substring(token.raw.length);
-        if (token.type === 'link') {
-          token.tokens = this.inlineTokens(token.text, [], true, inRawBlock);
-        }
-        tokens.push(token);
-        continue;
-      }
-
-      // strong
-      if (token = this.tokenizer.strong(src, maskedSrc, prevChar)) {
-        src = src.substring(token.raw.length);
-        token.tokens = this.inlineTokens(token.text, [], inLink, inRawBlock);
-        tokens.push(token);
-        continue;
-      }
-
-      // em
-      if (token = this.tokenizer.em(src, maskedSrc, prevChar)) {
-        src = src.substring(token.raw.length);
-        token.tokens = this.inlineTokens(token.text, [], inLink, inRawBlock);
-        tokens.push(token);
-        continue;
-      }
-
-      // code
-      if (token = this.tokenizer.codespan(src)) {
-        src = src.substring(token.raw.length);
-        tokens.push(token);
-        continue;
-      }
-
-      // br
-      if (token = this.tokenizer.br(src)) {
-        src = src.substring(token.raw.length);
-        tokens.push(token);
-        continue;
-      }
-
-      // del (gfm)
-      if (token = this.tokenizer.del(src)) {
-        src = src.substring(token.raw.length);
-        token.tokens = this.inlineTokens(token.text, [], inLink, inRawBlock);
-        tokens.push(token);
-        continue;
-      }
-
-      // autolink
-      if (token = this.tokenizer.autolink(src, mangle)) {
-        src = src.substring(token.raw.length);
-        tokens.push(token);
-        continue;
-      }
-
-      // url (gfm)
-      if (!inLink && (token = this.tokenizer.url(src, mangle))) {
-        src = src.substring(token.raw.length);
-        tokens.push(token);
-        continue;
-      }
-
-      // text
-      if (token = this.tokenizer.inlineText(src, inRawBlock, smartypants)) {
-        src = src.substring(token.raw.length);
-        prevChar = token.raw.slice(-1);
-        keepPrevChar = true;
         tokens.push(token);
         continue;
       }

--- a/lib/marked.esm.js
+++ b/lib/marked.esm.js
@@ -1370,6 +1370,7 @@ var rules = {
 const { defaults: defaults$2 } = defaults;
 const { block: block$1, inline: inline$1 } = rules;
 const { repeatString: repeatString$1 } = helpers;
+//Function.prototype.bind = require('fast-bind');
 
 /**
  * smartypants text replacement
@@ -1520,91 +1521,91 @@ var Lexer_1 = class Lexer {
    * Lexing
    */
 
-//==== Block tokenizers ====//
+  //= === Block tokenizers ====//
   // newline
-  newline(src, params) {
+  newline(c, src, params) {
     let token;
-    if (token = this.tokenizer.space(src)) {
+    if (token = c.tokenizer.space(src)) {
       return token;
     }
   }
 
   // code
-  code(src, params) {
+  code(c, src, params) {
     let token;
-    if (token = this.tokenizer.code(src, params.lastToken)) {
+    if (token = c.tokenizer.code(src, params.lastToken)) {
       return token;
     }
   }
 
   // fences
-  fences(src, params) {
+  fences(c, src, params) {
     let token;
-    if (token = this.tokenizer.fences(src)) {
+    if (token = c.tokenizer.fences(src)) {
       return token;
     }
   }
 
   // table no leading pipe (gfm)
-  nptable(src, params) {
+  nptable(c, src, params) {
     let token;
-    if (token = this.tokenizer.nptable(src)) {
+    if (token = c.tokenizer.nptable(src)) {
       return token;
     }
   }
 
   // heading
-  heading(src, params) {
+  heading(c, src, params) {
     let token;
-    if (token = this.tokenizer.heading(src)) {
+    if (token = c.tokenizer.heading(src)) {
       return token;
     }
   }
 
   // hr
-  hr(src, params) {
+  hr(c, src, params) {
     let token;
-    if (token = this.tokenizer.hr(src)) {
+    if (token = c.tokenizer.hr(src)) {
       return token;
     }
   }
 
   // blockquote
-  blockquote(src, params) {
+  blockquote(c, src, params) {
     let token;
-    if (token = this.tokenizer.blockquote(src)) {
-      token.tokens = this.blockTokens(token.text, [], params.top);
+    if (token = c.tokenizer.blockquote(src)) {
+      token.tokens = c.blockTokens(token.text, [], params.top);
       return token;
     }
   }
 
   // list
-  list(src, params) {
+  list(c, src, params) {
     let token;
-    if (token = this.tokenizer.list(src)) {
+    if (token = c.tokenizer.list(src)) {
       const l = token.items.length;
       let i;
       for (i = 0; i < l; i++) {
-        token.items[i].tokens = this.blockTokens(token.items[i].text, [], false);
+        token.items[i].tokens = c.blockTokens(token.items[i].text, [], false);
       }
       return token;
     }
   }
 
   // html
-  html(src, params) {
+  html(c, src, params) {
     let token;
-    if (token = this.tokenizer.html(src)) {
+    if (token = c.tokenizer.html(src)) {
       return token;
     }
   }
 
   // def
-  def(src, params) {
+  def(c, src, params) {
     let token;
-    if (params.top && (token = this.tokenizer.def(src))) {
-      if (!this.tokens.links[token.tag]) {
-        this.tokens.links[token.tag] = {
+    if (params.top && (token = c.tokenizer.def(src))) {
+      if (!c.tokens.links[token.tag]) {
+        c.tokens.links[token.tag] = {
           href: token.href,
           title: token.title
         };
@@ -1614,33 +1615,33 @@ var Lexer_1 = class Lexer {
   }
 
   // table (gfm)
-  table(src, params) {
+  table(c, src, params) {
     let token;
-    if (token = this.tokenizer.table(src)) {
+    if (token = c.tokenizer.table(src)) {
       return token;
     }
   }
 
   // lheading
-  lheading(src, params) {
+  lheading(c, src, params) {
     let token;
-    if (token = this.tokenizer.lheading(src, params)) {
+    if (token = c.tokenizer.lheading(src, params)) {
       return token;
     }
   }
 
   // top-level paragraph
-  paragraph(src, params) {
+  paragraph(c, src, params) {
     let token;
-    if (params.top && (token = this.tokenizer.paragraph(src))) {
+    if (params.top && (token = c.tokenizer.paragraph(src))) {
       return token;
     }
   }
 
   // text
-  text(src, params) {
+  text(c, src, params) {
     let token;
-    if (token = this.tokenizer.text(src, params.lastToken)) {
+    if (token = c.tokenizer.text(src, params.lastToken)) {
       return token;
     }
   }
@@ -1655,7 +1656,7 @@ var Lexer_1 = class Lexer {
     };
 
     while (src) {
-      if (this.blockTokenizers.some(function(fn) { return token = fn.func.call(this, src, blockParams); }, this)) {
+      if (this.blockTokenizers.some((fn) => token = fn.func(this, src, blockParams))) {
         src = src.substring(token.raw.length);
         if (token.type) {
           if (token.type === 'continue') {
@@ -1745,19 +1746,19 @@ var Lexer_1 = class Lexer {
     return tokens;
   }
 
-//==== Inline Tokenizers ====//
+  //= === Inline Tokenizers ====//
   // escape
-  escape(src, params) {
+  escape(c, src, params) {
     let token;
-    if (token = this.tokenizer.escape(src)) {
+    if (token = c.tokenizer.escape(src)) {
       return token;
     }
   }
 
   // tag
-  tag(src, params) {
+  tag(c, src, params) {
     let token;
-    if (token = this.tokenizer.tag(src, params.inLink, params.inRawBlock)) {
+    if (token = c.tokenizer.tag(src, params.inLink, params.inRawBlock)) {
       params.inLink = token.inLink;
       params.inRawBlock = token.inRawBlock;
       return token;
@@ -1765,90 +1766,90 @@ var Lexer_1 = class Lexer {
   }
 
   // link
-  link(src, params) {
+  link(c, src, params) {
     let token;
-    if (token = this.tokenizer.link(src)) {
+    if (token = c.tokenizer.link(src)) {
       if (token.type === 'link') {
-        token.tokens = this.inlineTokens(token.text, [], true, params.inRawBlock);
+        token.tokens = c.inlineTokens(token.text, [], true, params.inRawBlock);
       }
       return token;
     }
   }
 
   // reflink, nolink
-  reflink(src, params) {
+  reflink(c, src, params) {
     let token;
-    if (token = this.tokenizer.reflink(src, this.tokens.links)) {
+    if (token = c.tokenizer.reflink(src, c.tokens.links)) {
       if (token.type === 'link') {
-        token.tokens = this.inlineTokens(token.text, [], true, params.inRawBlock);
+        token.tokens = c.inlineTokens(token.text, [], true, params.inRawBlock);
       }
       return token;
     }
   }
 
   // strong
-  strong(src, params) {
+  strong(c, src, params) {
     let token;
-    if (token = this.tokenizer.strong(src, params.maskedSrc, params.prevChar)) {
-      token.tokens = this.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
+    if (token = c.tokenizer.strong(src, params.maskedSrc, params.prevChar)) {
+      token.tokens = c.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
       return token;
     }
   }
 
   // em
-  em(src, params) {
+  em(c, src, params) {
     let token;
-    if (token = this.tokenizer.em(src, params.maskedSrc, params.prevChar)) {
-      token.tokens = this.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
+    if (token = c.tokenizer.em(src, params.maskedSrc, params.prevChar)) {
+      token.tokens = c.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
       return token;
     }
   }
 
   // code
-  codespan(src, params) {
+  codespan(c, src, params) {
     let token;
-    if (token = this.tokenizer.codespan(src)) {
+    if (token = c.tokenizer.codespan(src)) {
       return token;
     }
   }
 
   // br
-  br(src, params) {
+  br(c, src, params) {
     let token;
-    if (token = this.tokenizer.br(src)) {
+    if (token = c.tokenizer.br(src)) {
       return token;
     }
   }
 
   // del (gfm)
-  del(src, params) {
+  del(c, src, params) {
     let token;
-    if (token = this.tokenizer.del(src)) {
-      token.tokens = this.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
+    if (token = c.tokenizer.del(src)) {
+      token.tokens = c.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
       return token;
     }
   }
 
   // autolink
-  autolink(src, params) {
+  autolink(c, src, params) {
     let token;
-    if (token = this.tokenizer.autolink(src, params.mangle)) {
+    if (token = c.tokenizer.autolink(src, params.mangle)) {
       return token;
     }
   }
 
   // url (gfm)
-  url(src, params) {
+  url(c, src, params) {
     let token;
-    if (!params.inLink && (token = this.tokenizer.url(src, params.mangle))) {
+    if (!params.inLink && (token = c.tokenizer.url(src, params.mangle))) {
       return token;
     }
   }
 
   // text
-  inlineText(src, params) {
+  inlineText(c, src, params) {
     let token;
-    if (token = this.tokenizer.inlineText(src, params.inRawBlock, params.smartypants)) {
+    if (token = c.tokenizer.inlineText(src, params.inRawBlock, params.smartypants)) {
       params.prevChar = token.raw.slice(-1);
       params.keepPrevChar = true;
       return token;
@@ -1895,7 +1896,7 @@ var Lexer_1 = class Lexer {
       }
       inlineParams.keepPrevChar = false;
 
-      if (this.inlineTokenizers.some(function(fn) { return token = fn.func.call(this, src, inlineParams); }, this)) {
+      if (this.inlineTokenizers.some(fn => token = fn.func(this, src, inlineParams))) {
         src = src.substring(token.raw.length);
         tokens.push(token);
         continue;

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1360,7 +1360,8 @@
   var defaults$2 = defaults.defaults;
   var block$1 = rules.block,
       inline$1 = rules.inline;
-  var repeatString$1 = helpers.repeatString;
+  var repeatString$1 = helpers.repeatString; //Function.prototype.bind = require('fast-bind');
+
   /**
    * smartypants text replacement
    */
@@ -1548,83 +1549,83 @@
     /**
      * Lexing
      */
-    //==== Block tokenizers ====//
+    //= === Block tokenizers ====//
     // newline
     ;
 
-    _proto.newline = function newline(src, params) {
+    _proto.newline = function newline(c, src, params) {
       var token;
 
-      if (token = this.tokenizer.space(src)) {
+      if (token = c.tokenizer.space(src)) {
         return token;
       }
     } // code
     ;
 
-    _proto.code = function code(src, params) {
+    _proto.code = function code(c, src, params) {
       var token;
 
-      if (token = this.tokenizer.code(src, params.lastToken)) {
+      if (token = c.tokenizer.code(src, params.lastToken)) {
         return token;
       }
     } // fences
     ;
 
-    _proto.fences = function fences(src, params) {
+    _proto.fences = function fences(c, src, params) {
       var token;
 
-      if (token = this.tokenizer.fences(src)) {
+      if (token = c.tokenizer.fences(src)) {
         return token;
       }
     } // table no leading pipe (gfm)
     ;
 
-    _proto.nptable = function nptable(src, params) {
+    _proto.nptable = function nptable(c, src, params) {
       var token;
 
-      if (token = this.tokenizer.nptable(src)) {
+      if (token = c.tokenizer.nptable(src)) {
         return token;
       }
     } // heading
     ;
 
-    _proto.heading = function heading(src, params) {
+    _proto.heading = function heading(c, src, params) {
       var token;
 
-      if (token = this.tokenizer.heading(src)) {
+      if (token = c.tokenizer.heading(src)) {
         return token;
       }
     } // hr
     ;
 
-    _proto.hr = function hr(src, params) {
+    _proto.hr = function hr(c, src, params) {
       var token;
 
-      if (token = this.tokenizer.hr(src)) {
+      if (token = c.tokenizer.hr(src)) {
         return token;
       }
     } // blockquote
     ;
 
-    _proto.blockquote = function blockquote(src, params) {
+    _proto.blockquote = function blockquote(c, src, params) {
       var token;
 
-      if (token = this.tokenizer.blockquote(src)) {
-        token.tokens = this.blockTokens(token.text, [], params.top);
+      if (token = c.tokenizer.blockquote(src)) {
+        token.tokens = c.blockTokens(token.text, [], params.top);
         return token;
       }
     } // list
     ;
 
-    _proto.list = function list(src, params) {
+    _proto.list = function list(c, src, params) {
       var token;
 
-      if (token = this.tokenizer.list(src)) {
+      if (token = c.tokenizer.list(src)) {
         var l = token.items.length;
         var i;
 
         for (i = 0; i < l; i++) {
-          token.items[i].tokens = this.blockTokens(token.items[i].text, [], false);
+          token.items[i].tokens = c.blockTokens(token.items[i].text, [], false);
         }
 
         return token;
@@ -1632,21 +1633,21 @@
     } // html
     ;
 
-    _proto.html = function html(src, params) {
+    _proto.html = function html(c, src, params) {
       var token;
 
-      if (token = this.tokenizer.html(src)) {
+      if (token = c.tokenizer.html(src)) {
         return token;
       }
     } // def
     ;
 
-    _proto.def = function def(src, params) {
+    _proto.def = function def(c, src, params) {
       var token;
 
-      if (params.top && (token = this.tokenizer.def(src))) {
-        if (!this.tokens.links[token.tag]) {
-          this.tokens.links[token.tag] = {
+      if (params.top && (token = c.tokenizer.def(src))) {
+        if (!c.tokens.links[token.tag]) {
+          c.tokens.links[token.tag] = {
             href: token.href,
             title: token.title
           };
@@ -1657,42 +1658,44 @@
     } // table (gfm)
     ;
 
-    _proto.table = function table(src, params) {
+    _proto.table = function table(c, src, params) {
       var token;
 
-      if (token = this.tokenizer.table(src)) {
+      if (token = c.tokenizer.table(src)) {
         return token;
       }
     } // lheading
     ;
 
-    _proto.lheading = function lheading(src, params) {
+    _proto.lheading = function lheading(c, src, params) {
       var token;
 
-      if (token = this.tokenizer.lheading(src, params)) {
+      if (token = c.tokenizer.lheading(src, params)) {
         return token;
       }
     } // top-level paragraph
     ;
 
-    _proto.paragraph = function paragraph(src, params) {
+    _proto.paragraph = function paragraph(c, src, params) {
       var token;
 
-      if (params.top && (token = this.tokenizer.paragraph(src))) {
+      if (params.top && (token = c.tokenizer.paragraph(src))) {
         return token;
       }
     } // text
     ;
 
-    _proto.text = function text(src, params) {
+    _proto.text = function text(c, src, params) {
       var token;
 
-      if (token = this.tokenizer.text(src, params.lastToken)) {
+      if (token = c.tokenizer.text(src, params.lastToken)) {
         return token;
       }
     };
 
     _proto.blockTokens = function blockTokens(src, tokens, top) {
+      var _this = this;
+
       if (tokens === void 0) {
         tokens = [];
       }
@@ -1710,8 +1713,8 @@
 
       while (src) {
         if (this.blockTokenizers.some(function (fn) {
-          return token = fn.func.call(this, src, blockParams);
-        }, this)) {
+          return token = fn.func(_this, src, blockParams);
+        })) {
           src = src.substring(token.raw.length);
 
           if (token.type) {
@@ -1809,23 +1812,23 @@
       }
 
       return tokens;
-    } //==== Inline Tokenizers ====//
+    } //= === Inline Tokenizers ====//
     // escape
     ;
 
-    _proto.escape = function escape(src, params) {
+    _proto.escape = function escape(c, src, params) {
       var token;
 
-      if (token = this.tokenizer.escape(src)) {
+      if (token = c.tokenizer.escape(src)) {
         return token;
       }
     } // tag
     ;
 
-    _proto.tag = function tag(src, params) {
+    _proto.tag = function tag(c, src, params) {
       var token;
 
-      if (token = this.tokenizer.tag(src, params.inLink, params.inRawBlock)) {
+      if (token = c.tokenizer.tag(src, params.inLink, params.inRawBlock)) {
         params.inLink = token.inLink;
         params.inRawBlock = token.inRawBlock;
         return token;
@@ -1833,12 +1836,12 @@
     } // link
     ;
 
-    _proto.link = function link(src, params) {
+    _proto.link = function link(c, src, params) {
       var token;
 
-      if (token = this.tokenizer.link(src)) {
+      if (token = c.tokenizer.link(src)) {
         if (token.type === 'link') {
-          token.tokens = this.inlineTokens(token.text, [], true, params.inRawBlock);
+          token.tokens = c.inlineTokens(token.text, [], true, params.inRawBlock);
         }
 
         return token;
@@ -1846,12 +1849,12 @@
     } // reflink, nolink
     ;
 
-    _proto.reflink = function reflink(src, params) {
+    _proto.reflink = function reflink(c, src, params) {
       var token;
 
-      if (token = this.tokenizer.reflink(src, this.tokens.links)) {
+      if (token = c.tokenizer.reflink(src, c.tokens.links)) {
         if (token.type === 'link') {
-          token.tokens = this.inlineTokens(token.text, [], true, params.inRawBlock);
+          token.tokens = c.inlineTokens(token.text, [], true, params.inRawBlock);
         }
 
         return token;
@@ -1859,76 +1862,76 @@
     } // strong
     ;
 
-    _proto.strong = function strong(src, params) {
+    _proto.strong = function strong(c, src, params) {
       var token;
 
-      if (token = this.tokenizer.strong(src, params.maskedSrc, params.prevChar)) {
-        token.tokens = this.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
+      if (token = c.tokenizer.strong(src, params.maskedSrc, params.prevChar)) {
+        token.tokens = c.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
         return token;
       }
     } // em
     ;
 
-    _proto.em = function em(src, params) {
+    _proto.em = function em(c, src, params) {
       var token;
 
-      if (token = this.tokenizer.em(src, params.maskedSrc, params.prevChar)) {
-        token.tokens = this.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
+      if (token = c.tokenizer.em(src, params.maskedSrc, params.prevChar)) {
+        token.tokens = c.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
         return token;
       }
     } // code
     ;
 
-    _proto.codespan = function codespan(src, params) {
+    _proto.codespan = function codespan(c, src, params) {
       var token;
 
-      if (token = this.tokenizer.codespan(src)) {
+      if (token = c.tokenizer.codespan(src)) {
         return token;
       }
     } // br
     ;
 
-    _proto.br = function br(src, params) {
+    _proto.br = function br(c, src, params) {
       var token;
 
-      if (token = this.tokenizer.br(src)) {
+      if (token = c.tokenizer.br(src)) {
         return token;
       }
     } // del (gfm)
     ;
 
-    _proto.del = function del(src, params) {
+    _proto.del = function del(c, src, params) {
       var token;
 
-      if (token = this.tokenizer.del(src)) {
-        token.tokens = this.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
+      if (token = c.tokenizer.del(src)) {
+        token.tokens = c.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
         return token;
       }
     } // autolink
     ;
 
-    _proto.autolink = function autolink(src, params) {
+    _proto.autolink = function autolink(c, src, params) {
       var token;
 
-      if (token = this.tokenizer.autolink(src, params.mangle)) {
+      if (token = c.tokenizer.autolink(src, params.mangle)) {
         return token;
       }
     } // url (gfm)
     ;
 
-    _proto.url = function url(src, params) {
+    _proto.url = function url(c, src, params) {
       var token;
 
-      if (!params.inLink && (token = this.tokenizer.url(src, params.mangle))) {
+      if (!params.inLink && (token = c.tokenizer.url(src, params.mangle))) {
         return token;
       }
     } // text
     ;
 
-    _proto.inlineText = function inlineText(src, params) {
+    _proto.inlineText = function inlineText(c, src, params) {
       var token;
 
-      if (token = this.tokenizer.inlineText(src, params.inRawBlock, params.smartypants)) {
+      if (token = c.tokenizer.inlineText(src, params.inRawBlock, params.smartypants)) {
         params.prevChar = token.raw.slice(-1);
         params.keepPrevChar = true;
         return token;
@@ -1940,6 +1943,8 @@
     ;
 
     _proto.inlineTokens = function inlineTokens(src, tokens, inLink, inRawBlock) {
+      var _this2 = this;
+
       if (tokens === void 0) {
         tokens = [];
       }
@@ -1990,8 +1995,8 @@
         inlineParams.keepPrevChar = false;
 
         if (this.inlineTokenizers.some(function (fn) {
-          return token = fn.func.call(this, src, inlineParams);
-        }, this)) {
+          return token = fn.func(_this2, src, inlineParams);
+        })) {
           src = src.substring(token.raw.length);
           tokens.push(token);
           continue;

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1,6 +1,6 @@
 /**
  * marked - a markdown parser
- * Copyright (c) 2011-2020, Christopher Jeffrey. (MIT Licensed)
+ * Copyright (c) 2011-2021, Christopher Jeffrey. (MIT Licensed)
  * https://github.com/markedjs/marked
  */
 
@@ -490,14 +490,14 @@
       }
     };
 
-    _proto.code = function code(src, tokens) {
+    _proto.code = function code(src, lastToken) {
       var cap = this.rules.block.code.exec(src);
 
       if (cap) {
-        var lastToken = tokens[tokens.length - 1]; // An indented code block cannot interrupt a paragraph.
-
+        // An indented code block cannot interrupt a paragraph.
         if (lastToken && lastToken.type === 'paragraph') {
           return {
+            type: 'continue',
             raw: cap[0],
             text: cap[0].trimRight()
           };
@@ -814,14 +814,13 @@
       }
     };
 
-    _proto.text = function text(src, tokens) {
+    _proto.text = function text(src, lastToken) {
       var cap = this.rules.block.text.exec(src);
 
       if (cap) {
-        var lastToken = tokens[tokens.length - 1];
-
         if (lastToken && lastToken.type === 'text') {
           return {
+            type: 'continue',
             raw: cap[0],
             text: cap[0]
           };
@@ -1431,6 +1430,86 @@
       }
 
       this.tokenizer.rules = rules;
+      this.blockTokenizers = [{
+        name: 'newline',
+        func: this.newline
+      }, {
+        name: 'code',
+        func: this.code
+      }, {
+        name: 'fences',
+        func: this.fences
+      }, {
+        name: 'nptable',
+        func: this.nptable
+      }, {
+        name: 'heading',
+        func: this.heading
+      }, {
+        name: 'hr',
+        func: this.hr
+      }, {
+        name: 'blockquote',
+        func: this.blockquote
+      }, {
+        name: 'list',
+        func: this.list
+      }, {
+        name: 'html',
+        func: this.html
+      }, {
+        name: 'def',
+        func: this.def
+      }, {
+        name: 'table',
+        func: this.table
+      }, {
+        name: 'lheading',
+        func: this.lheading
+      }, {
+        name: 'paragraph',
+        func: this.paragraph
+      }, {
+        name: 'text',
+        func: this.text
+      }];
+      this.inlineTokenizers = [{
+        name: 'escape',
+        func: this.escape
+      }, {
+        name: 'tag',
+        func: this.tag
+      }, {
+        name: 'link',
+        func: this.link
+      }, {
+        name: 'reflink',
+        func: this.reflink
+      }, {
+        name: 'strong',
+        func: this.strong
+      }, {
+        name: 'em',
+        func: this.em
+      }, {
+        name: 'codespan',
+        func: this.codespan
+      }, {
+        name: 'br',
+        func: this.br
+      }, {
+        name: 'del',
+        func: this.del
+      }, {
+        name: 'autolink',
+        func: this.autolink
+      }, {
+        name: 'url',
+        func: this.url
+      }, {
+        name: 'inlineText',
+        func: this.inlineText
+      }];
     }
     /**
      * Expose Rules
@@ -1469,7 +1548,149 @@
     /**
      * Lexing
      */
+    //==== Block tokenizers ====//
+    // newline
     ;
+
+    _proto.newline = function newline(src, params) {
+      var token;
+
+      if (token = this.tokenizer.space(src)) {
+        return token;
+      }
+    } // code
+    ;
+
+    _proto.code = function code(src, params) {
+      var token;
+
+      if (token = this.tokenizer.code(src, params.lastToken)) {
+        return token;
+      }
+    } // fences
+    ;
+
+    _proto.fences = function fences(src, params) {
+      var token;
+
+      if (token = this.tokenizer.fences(src)) {
+        return token;
+      }
+    } // table no leading pipe (gfm)
+    ;
+
+    _proto.nptable = function nptable(src, params) {
+      var token;
+
+      if (token = this.tokenizer.nptable(src)) {
+        return token;
+      }
+    } // heading
+    ;
+
+    _proto.heading = function heading(src, params) {
+      var token;
+
+      if (token = this.tokenizer.heading(src)) {
+        return token;
+      }
+    } // hr
+    ;
+
+    _proto.hr = function hr(src, params) {
+      var token;
+
+      if (token = this.tokenizer.hr(src)) {
+        return token;
+      }
+    } // blockquote
+    ;
+
+    _proto.blockquote = function blockquote(src, params) {
+      var token;
+
+      if (token = this.tokenizer.blockquote(src)) {
+        token.tokens = this.blockTokens(token.text, [], params.top);
+        return token;
+      }
+    } // list
+    ;
+
+    _proto.list = function list(src, params) {
+      var token;
+
+      if (token = this.tokenizer.list(src)) {
+        var l = token.items.length;
+        var i;
+
+        for (i = 0; i < l; i++) {
+          token.items[i].tokens = this.blockTokens(token.items[i].text, [], false);
+        }
+
+        return token;
+      }
+    } // html
+    ;
+
+    _proto.html = function html(src, params) {
+      var token;
+
+      if (token = this.tokenizer.html(src)) {
+        return token;
+      }
+    } // def
+    ;
+
+    _proto.def = function def(src, params) {
+      var token;
+
+      if (params.top && (token = this.tokenizer.def(src))) {
+        if (!this.tokens.links[token.tag]) {
+          this.tokens.links[token.tag] = {
+            href: token.href,
+            title: token.title
+          };
+        }
+
+        return token;
+      }
+    } // table (gfm)
+    ;
+
+    _proto.table = function table(src, params) {
+      var token;
+
+      if (token = this.tokenizer.table(src)) {
+        return token;
+      }
+    } // lheading
+    ;
+
+    _proto.lheading = function lheading(src, params) {
+      var token;
+
+      if (token = this.tokenizer.lheading(src, params)) {
+        return token;
+      }
+    } // top-level paragraph
+    ;
+
+    _proto.paragraph = function paragraph(src, params) {
+      var token;
+
+      if (params.top && (token = this.tokenizer.paragraph(src))) {
+        return token;
+      }
+    } // text
+    ;
+
+    _proto.text = function text(src, params) {
+      var token;
+
+      if (token = this.tokenizer.text(src, params.lastToken)) {
+        return token;
+      }
+    };
 
     _proto.blockTokens = function blockTokens(src, tokens, top) {
       if (tokens === void 0) {
@@ -1480,137 +1701,27 @@
         top = true;
       }
 
+      var token;
       src = src.replace(/^ +$/gm, '');
-      var token, i, l, lastToken;
+      var blockParams = {
+        top: top,
+        lastToken: null
+      };
 
       while (src) {
-        // newline
-        if (token = this.tokenizer.space(src)) {
+        if (this.blockTokenizers.some(function (fn) {
+          return token = fn.func.call(this, src, blockParams);
+        }, this)) {
           src = src.substring(token.raw.length);
 
           if (token.type) {
-            tokens.push(token);
-          }
-
-          continue;
-        } // code
-
-
-        if (token = this.tokenizer.code(src, tokens)) {
-          src = src.substring(token.raw.length);
-
-          if (token.type) {
-            tokens.push(token);
-          } else {
-            lastToken = tokens[tokens.length - 1];
-            lastToken.raw += '\n' + token.raw;
-            lastToken.text += '\n' + token.text;
-          }
-
-          continue;
-        } // fences
-
-
-        if (token = this.tokenizer.fences(src)) {
-          src = src.substring(token.raw.length);
-          tokens.push(token);
-          continue;
-        } // heading
-
-
-        if (token = this.tokenizer.heading(src)) {
-          src = src.substring(token.raw.length);
-          tokens.push(token);
-          continue;
-        } // table no leading pipe (gfm)
-
-
-        if (token = this.tokenizer.nptable(src)) {
-          src = src.substring(token.raw.length);
-          tokens.push(token);
-          continue;
-        } // hr
-
-
-        if (token = this.tokenizer.hr(src)) {
-          src = src.substring(token.raw.length);
-          tokens.push(token);
-          continue;
-        } // blockquote
-
-
-        if (token = this.tokenizer.blockquote(src)) {
-          src = src.substring(token.raw.length);
-          token.tokens = this.blockTokens(token.text, [], top);
-          tokens.push(token);
-          continue;
-        } // list
-
-
-        if (token = this.tokenizer.list(src)) {
-          src = src.substring(token.raw.length);
-          l = token.items.length;
-
-          for (i = 0; i < l; i++) {
-            token.items[i].tokens = this.blockTokens(token.items[i].text, [], false);
-          }
-
-          tokens.push(token);
-          continue;
-        } // html
-
-
-        if (token = this.tokenizer.html(src)) {
-          src = src.substring(token.raw.length);
-          tokens.push(token);
-          continue;
-        } // def
-
-
-        if (top && (token = this.tokenizer.def(src))) {
-          src = src.substring(token.raw.length);
-
-          if (!this.tokens.links[token.tag]) {
-            this.tokens.links[token.tag] = {
-              href: token.href,
-              title: token.title
-            };
-          }
-
-          continue;
-        } // table (gfm)
-
-
-        if (token = this.tokenizer.table(src)) {
-          src = src.substring(token.raw.length);
-          tokens.push(token);
-          continue;
-        } // lheading
-
-
-        if (token = this.tokenizer.lheading(src)) {
-          src = src.substring(token.raw.length);
-          tokens.push(token);
-          continue;
-        } // top-level paragraph
-
-
-        if (top && (token = this.tokenizer.paragraph(src))) {
-          src = src.substring(token.raw.length);
-          tokens.push(token);
-          continue;
-        } // text
-
-
-        if (token = this.tokenizer.text(src, tokens)) {
-          src = src.substring(token.raw.length);
-
-          if (token.type) {
-            tokens.push(token);
-          } else {
-            lastToken = tokens[tokens.length - 1];
-            lastToken.raw += '\n' + token.raw;
-            lastToken.text += '\n' + token.text;
+            if (token.type === 'continue') {
+              blockParams.lastToken.raw += '\n' + token.raw;
+              blockParams.lastToken.text += '\n' + token.text;
+            } else {
+              tokens.push(token);
+              blockParams.lastToken = token;
+            }
           }
 
           continue;
@@ -1698,6 +1809,130 @@
       }
 
       return tokens;
+    } //==== Inline Tokenizers ====//
+    // escape
+    ;
+
+    _proto.escape = function escape(src, params) {
+      var token;
+
+      if (token = this.tokenizer.escape(src)) {
+        return token;
+      }
+    } // tag
+    ;
+
+    _proto.tag = function tag(src, params) {
+      var token;
+
+      if (token = this.tokenizer.tag(src, params.inLink, params.inRawBlock)) {
+        params.inLink = token.inLink;
+        params.inRawBlock = token.inRawBlock;
+        return token;
+      }
+    } // link
+    ;
+
+    _proto.link = function link(src, params) {
+      var token;
+
+      if (token = this.tokenizer.link(src)) {
+        if (token.type === 'link') {
+          token.tokens = this.inlineTokens(token.text, [], true, params.inRawBlock);
+        }
+
+        return token;
+      }
+    } // reflink, nolink
+    ;
+
+    _proto.reflink = function reflink(src, params) {
+      var token;
+
+      if (token = this.tokenizer.reflink(src, this.tokens.links)) {
+        if (token.type === 'link') {
+          token.tokens = this.inlineTokens(token.text, [], true, params.inRawBlock);
+        }
+
+        return token;
+      }
+    } // strong
+    ;
+
+    _proto.strong = function strong(src, params) {
+      var token;
+
+      if (token = this.tokenizer.strong(src, params.maskedSrc, params.prevChar)) {
+        token.tokens = this.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
+        return token;
+      }
+    } // em
+    ;
+
+    _proto.em = function em(src, params) {
+      var token;
+
+      if (token = this.tokenizer.em(src, params.maskedSrc, params.prevChar)) {
+        token.tokens = this.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
+        return token;
+      }
+    } // code
+    ;
+
+    _proto.codespan = function codespan(src, params) {
+      var token;
+
+      if (token = this.tokenizer.codespan(src)) {
+        return token;
+      }
+    } // br
+    ;
+
+    _proto.br = function br(src, params) {
+      var token;
+
+      if (token = this.tokenizer.br(src)) {
+        return token;
+      }
+    } // del (gfm)
+    ;
+
+    _proto.del = function del(src, params) {
+      var token;
+
+      if (token = this.tokenizer.del(src)) {
+        token.tokens = this.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
+        return token;
+      }
+    } // autolink
+    ;
+
+    _proto.autolink = function autolink(src, params) {
+      var token;
+
+      if (token = this.tokenizer.autolink(src, params.mangle)) {
+        return token;
+      }
+    } // url (gfm)
+    ;
+
+    _proto.url = function url(src, params) {
+      var token;
+
+      if (!params.inLink && (token = this.tokenizer.url(src, params.mangle))) {
+        return token;
+      }
+    } // text
+    ;
+
+    _proto.inlineText = function inlineText(src, params) {
+      var token;
+
+      if (token = this.tokenizer.inlineText(src, params.inRawBlock, params.smartypants)) {
+        params.prevChar = token.raw.slice(-1);
+        params.keepPrevChar = true;
+        return token;
+      }
     }
     /**
      * Lexing/Compiling
@@ -1717,11 +1952,8 @@
         inRawBlock = false;
       }
 
-      var token; // String with links masked to avoid interference with em and strong
-
-      var maskedSrc = src;
-      var match;
-      var keepPrevChar, prevChar; // Mask out reflinks
+      var match, token;
+      var maskedSrc = src; // Mask out reflinks to avoid interference with em and strong
 
       if (this.tokens.links) {
         var links = Object.keys(this.tokens.links);
@@ -1740,109 +1972,27 @@
         maskedSrc = maskedSrc.slice(0, match.index) + '[' + repeatString$1('a', match[0].length - 2) + ']' + maskedSrc.slice(this.tokenizer.rules.inline.blockSkip.lastIndex);
       }
 
+      var inlineParams = {
+        inLink: inLink,
+        inRawBlock: inRawBlock,
+        maskedSrc: maskedSrc,
+        prevChar: false,
+        keepPrevChar: false,
+        mangle: mangle,
+        smartypants: smartypants
+      };
+
       while (src) {
-        if (!keepPrevChar) {
-          prevChar = '';
+        if (!inlineParams.keepPrevChar) {
+          inlineParams.prevChar = '';
         }
 
-        keepPrevChar = false; // escape
+        inlineParams.keepPrevChar = false;
 
-        if (token = this.tokenizer.escape(src)) {
+        if (this.inlineTokenizers.some(function (fn) {
+          return token = fn.func.call(this, src, inlineParams);
+        }, this)) {
           src = src.substring(token.raw.length);
-          tokens.push(token);
-          continue;
-        } // tag
-
-
-        if (token = this.tokenizer.tag(src, inLink, inRawBlock)) {
-          src = src.substring(token.raw.length);
-          inLink = token.inLink;
-          inRawBlock = token.inRawBlock;
-          tokens.push(token);
-          continue;
-        } // link
-
-
-        if (token = this.tokenizer.link(src)) {
-          src = src.substring(token.raw.length);
-
-          if (token.type === 'link') {
-            token.tokens = this.inlineTokens(token.text, [], true, inRawBlock);
-          }
-
-          tokens.push(token);
-          continue;
-        } // reflink, nolink
-
-
-        if (token = this.tokenizer.reflink(src, this.tokens.links)) {
-          src = src.substring(token.raw.length);
-
-          if (token.type === 'link') {
-            token.tokens = this.inlineTokens(token.text, [], true, inRawBlock);
-          }
-
-          tokens.push(token);
-          continue;
-        } // strong
-
-
-        if (token = this.tokenizer.strong(src, maskedSrc, prevChar)) {
-          src = src.substring(token.raw.length);
-          token.tokens = this.inlineTokens(token.text, [], inLink, inRawBlock);
-          tokens.push(token);
-          continue;
-        } // em
-
-
-        if (token = this.tokenizer.em(src, maskedSrc, prevChar)) {
-          src = src.substring(token.raw.length);
-          token.tokens = this.inlineTokens(token.text, [], inLink, inRawBlock);
-          tokens.push(token);
-          continue;
-        } // code
-
-
-        if (token = this.tokenizer.codespan(src)) {
-          src = src.substring(token.raw.length);
-          tokens.push(token);
-          continue;
-        } // br
-
-
-        if (token = this.tokenizer.br(src)) {
-          src = src.substring(token.raw.length);
-          tokens.push(token);
-          continue;
-        } // del (gfm)
-
-
-        if (token = this.tokenizer.del(src)) {
-          src = src.substring(token.raw.length);
-          token.tokens = this.inlineTokens(token.text, [], inLink, inRawBlock);
-          tokens.push(token);
-          continue;
-        } // autolink
-
-
-        if (token = this.tokenizer.autolink(src, mangle)) {
-          src = src.substring(token.raw.length);
-          tokens.push(token);
-          continue;
-        } // url (gfm)
-
-
-        if (!inLink && (token = this.tokenizer.url(src, mangle))) {
-          src = src.substring(token.raw.length);
-          tokens.push(token);
-          continue;
-        } // text
-
-
-        if (token = this.tokenizer.inlineText(src, inRawBlock, smartypants)) {
-          src = src.substring(token.raw.length);
-          prevChar = token.raw.slice(-1);
-          keepPrevChar = true;
           tokens.push(token);
           continue;
         }

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -220,186 +220,155 @@ module.exports = class Lexer {
    */
 
   // newline
-  newline(params) {
+  newline(src, params) {
     let token;
-    if (token = this.tokenizer.space(params.src)) {
-      params.src = params.src.substring(token.raw.length);
-      if (token.type) {
-        params.tokens.push(token);
-      }
-      return true;
+    if (token = this.tokenizer.space(src)) {
+      return token;
     }
   }
 
   // code
-  code(params) {
+  code(src, params) {
     let token;
-    if (token = this.tokenizer.code(params.src, params.tokens)) {
-      params.src = params.src.substring(token.raw.length);
-      if (token.type) {
-        params.tokens.push(token);
-      } else {
-        params.lastToken = params.tokens[params.tokens.length - 1];
-        params.lastToken.raw += '\n' + token.raw;
-        params.lastToken.text += '\n' + token.text;
-      }
-      return true;
+    if (token = this.tokenizer.code(src, params.lastToken)) {
+      return token;
     }
   }
 
   // fences
-  fences(params) {
+  fences(src, params) {
     let token;
-    if (token = this.tokenizer.fences(params.src)) {
-      params.src = params.src.substring(token.raw.length);
-      params.tokens.push(token);
-      return true;
+    if (token = this.tokenizer.fences(src)) {
+      return token;
     }
   }
 
   // table no leading pipe (gfm)
-  nptable(params) {
+  nptable(src, params) {
     let token;
-    if (token = this.tokenizer.nptable(params.src)) {
-      params.src = params.src.substring(token.raw.length);
-      params.tokens.push(token);
-      return true;
+    if (token = this.tokenizer.nptable(src)) {
+      return token;
     }
   }
 
   // heading
-  heading(params) {
+  heading(src, params) {
     let token;
-    if (token = this.tokenizer.heading(params.src)) {
-      params.src = params.src.substring(token.raw.length);
-      params.tokens.push(token);
-      return true;
+    if (token = this.tokenizer.heading(src)) {
+      return token;
     }
   }
 
   // hr
-  hr(params) {
+  hr(src, params) {
     let token;
-    if (token = this.tokenizer.hr(params.src)) {
-      params.src = params.src.substring(token.raw.length);
-      params.tokens.push(token);
-      return true;
+    if (token = this.tokenizer.hr(src)) {
+      return token;
     }
   }
 
   // blockquote
-  blockquote(params) {
+  blockquote(src, params) {
     let token;
-    if (token = this.tokenizer.blockquote(params.src)) {
-      params.src = params.src.substring(token.raw.length);
+    if (token = this.tokenizer.blockquote(src)) {
       token.tokens = this.blockTokens(token.text, [], params.top);
-      params.tokens.push(token);
-      return true;
+      return token;
     }
   }
 
   // list
-  list(params) {
+  list(src, params) {
     let token;
-    if (token = this.tokenizer.list(params.src)) {
-      params.src = params.src.substring(token.raw.length);
+    if (token = this.tokenizer.list(src)) {
       const l = token.items.length;
       let i;
       for (i = 0; i < l; i++) {
         token.items[i].tokens = this.blockTokens(token.items[i].text, [], false);
       }
-      params.tokens.push(token);
-      return true;
+      return token;
     }
   }
 
   // html
-  html(params) {
+  html(src, params) {
     let token;
-    if (token = this.tokenizer.html(params.src)) {
-      params.src = params.src.substring(token.raw.length);
-      params.tokens.push(token);
-      return true;
+    if (token = this.tokenizer.html(src)) {
+      return token;
     }
   }
 
   // def
-  def(params) {
+  def(src, params) {
     let token;
-    if (params.top && (token = this.tokenizer.def(params.src))) {
-      params.src = params.src.substring(token.raw.length);
+    if (params.top && (token = this.tokenizer.def(src))) {
       if (!this.tokens.links[token.tag]) {
         this.tokens.links[token.tag] = {
           href: token.href,
           title: token.title
         };
       }
-      return true;
+      return token;
     }
   }
 
   // table (gfm)
-  table(params) {
+  table(src, params) {
     let token;
-    if (token = this.tokenizer.table(params.src)) {
-      params.src = params.src.substring(token.raw.length);
-      params.tokens.push(token);
-      return true;
+    if (token = this.tokenizer.table(src)) {
+      return token;
     }
   }
 
   // lheading
-  lheading(params) {
+  lheading(src, params) {
     let token;
-    if (token = this.tokenizer.lheading(params.src)) {
-      params.src = params.src.substring(token.raw.length);
-      params.tokens.push(token);
-      return true;
+    if (token = this.tokenizer.lheading(src, params)) {
+      return token;
     }
   }
 
   // top-level paragraph
-  paragraph(params) {
+  paragraph(src, params) {
     let token;
-    if (params.top && (token = this.tokenizer.paragraph(params.src))) {
-      params.src = params.src.substring(token.raw.length);
-      params.tokens.push(token);
-      return true;
+    if (params.top && (token = this.tokenizer.paragraph(src))) {
+      return token;
     }
   }
 
   // text
-  text(params) {
+  text(src, params) {
     let token;
-    if (token = this.tokenizer.text(params.src, params.tokens)) {
-      params.src = params.src.substring(token.raw.length);
-      if (token.type) {
-        params.tokens.push(token);
-      } else {
-        params.lastToken = params.tokens[params.tokens.length - 1];
-        params.lastToken.raw += '\n' + token.raw;
-        params.lastToken.text += '\n' + token.text;
-      }
-      return true;
+    if (token = this.tokenizer.text(src, params.lastToken)) {
+      return token;
     }
   }
 
   blockTokens(src, tokens = [], top = true) {
+    let token;
     src = src.replace(/^ +$/gm, '');
 
     const blockParams = {
-      src: src,
-      tokens: tokens,
       top: top,
-      // token: null,
-      lastToken: null//,
+      lastToken: null
     };
 
-    while (blockParams.src) {
-      if (this.blockTokenizers.some(fn => fn.func.call(this, blockParams))) continue;
+    while (src) {
+      if (this.blockTokenizers.some(fn => token = fn.func.call(this, src, blockParams))) {
+        src = src.substring(token.raw.length);
+        if (token.type) {
+          if (token.type === 'continue') {
+            blockParams.lastToken.raw += '\n' + token.raw;
+            blockParams.lastToken.text += '\n' + token.text;
+          } else {
+            tokens.push(token);
+            blockParams.lastToken = token;
+          }
+        }
+        continue;
+      }
 
-      if (blockParams.src) {
-        const errMsg = 'Infinite loop on byte: ' + blockParams.src.charCodeAt(0);
+      if (src) {
+        const errMsg = 'Infinite loop on byte: ' + src.charCodeAt(0);
         if (this.options.silent) {
           console.error(errMsg);
           break;
@@ -409,7 +378,7 @@ module.exports = class Lexer {
       }
     }
 
-    return blockParams.tokens;
+    return tokens;
   }
 
   inline(tokens) {
@@ -478,135 +447,111 @@ module.exports = class Lexer {
   }
 
   // escape
-  escape(params) {
+  escape(src, params) {
     let token;
-    if (token = this.tokenizer.escape(params.src)) {
-      params.src = params.src.substring(token.raw.length);
-      params.tokens.push(token);
-      return true;
+    if (token = this.tokenizer.escape(src)) {
+      return token;
     }
   }
 
   // tag
-  tag(params) {
+  tag(src, params) {
     let token;
-    if (token = this.tokenizer.tag(params.src, params.inLink, params.inRawBlock)) {
-      params.src = params.src.substring(token.raw.length);
+    if (token = this.tokenizer.tag(src, params.inLink, params.inRawBlock)) {
       params.inLink = token.inLink;
       params.inRawBlock = token.inRawBlock;
-      params.tokens.push(token);
-      return true;
+      return token;
     }
   }
 
   // link
-  link(params) {
+  link(src, params) {
     let token;
-    if (token = this.tokenizer.link(params.src)) {
-      params.src = params.src.substring(token.raw.length);
+    if (token = this.tokenizer.link(src)) {
       if (token.type === 'link') {
         token.tokens = this.inlineTokens(token.text, [], true, params.inRawBlock);
       }
-      params.tokens.push(token);
-      return true;
+      return token;
     }
   }
 
   // reflink, nolink
-  reflink(params) {
+  reflink(src, params) {
     let token;
-    if (token = this.tokenizer.reflink(params.src, this.tokens.links)) {
-      params.src = params.src.substring(token.raw.length);
+    if (token = this.tokenizer.reflink(src, this.tokens.links)) {
       if (token.type === 'link') {
         token.tokens = this.inlineTokens(token.text, [], true, params.inRawBlock);
       }
-      params.tokens.push(token);
-      return true;
+      return token;
     }
   }
 
   // strong
-  strong(params) {
+  strong(src, params) {
     let token;
-    if (token = this.tokenizer.strong(params.src, params.maskedSrc, params.prevChar)) {
-      params.src = params.src.substring(token.raw.length);
+    if (token = this.tokenizer.strong(src, params.maskedSrc, params.prevChar)) {
       token.tokens = this.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
-      params.tokens.push(token);
-      return true;
+      return token;
     }
   }
 
   // em
-  em(params) {
+  em(src, params) {
     let token;
-    if (token = this.tokenizer.em(params.src, params.maskedSrc, params.prevChar)) {
-      params.src = params.src.substring(token.raw.length);
+    if (token = this.tokenizer.em(src, params.maskedSrc, params.prevChar)) {
       token.tokens = this.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
-      params.tokens.push(token);
-      return true;
+      return token;
     }
   }
 
   // code
-  codespan(params) {
+  codespan(src, params) {
     let token;
-    if (token = this.tokenizer.codespan(params.src)) {
-      params.src = params.src.substring(token.raw.length);
-      params.tokens.push(token);
-      return true;
+    if (token = this.tokenizer.codespan(src)) {
+      return token;
     }
   }
 
   // br
-  br(params) {
+  br(src, params) {
     let token;
-    if (token = this.tokenizer.br(params.src)) {
-      params.src = params.src.substring(token.raw.length);
-      params.tokens.push(token);
-      return true;
+    if (token = this.tokenizer.br(src)) {
+      return token;
     }
   }
 
   // del (gfm)
-  del(params) {
+  del(src, params) {
     let token;
-    if (token = this.tokenizer.del(params.src)) {
-      params.src = params.src.substring(token.raw.length);
+    if (token = this.tokenizer.del(src)) {
       token.tokens = this.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
-      params.tokens.push(token);
-      return true;
+      return token;
     }
   }
 
   // autolink
-  autolink(params) {
+  autolink(src, params) {
     let token;
-    if (token = this.tokenizer.autolink(params.src, params.mangle)) {
-      params.src = params.src.substring(token.raw.length);
-      params.tokens.push(token);
-      return true;
+    if (token = this.tokenizer.autolink(src, params.mangle)) {
+      return token;
     }
   }
 
   // url (gfm)
-  url(params) {
+  url(src, params) {
     let token;
-    if (!params.inLink && (token = this.tokenizer.url(params.src, params.mangle))) {
-      params.src = params.src.substring(token.raw.length);
-      params.tokens.push(token);
-      return true;
+    if (!params.inLink && (token = this.tokenizer.url(src, params.mangle))) {
+      return token;
     }
   }
 
   // text
-  inlineText(params) {
+  inlineText(src, params) {
     let token;
-    if (token = this.tokenizer.inlineText(params.src, params.inRawBlock, params.smartypants)) {
-      params.src = params.src.substring(token.raw.length);
+    if (token = this.tokenizer.inlineText(src, params.inRawBlock, params.smartypants)) {
       params.prevChar = token.raw.slice(-1);
       params.keepPrevChar = true;
-      params.tokens.push(token);
-      return true;
+      return token;
     }
   }
 
@@ -614,7 +559,7 @@ module.exports = class Lexer {
    * Lexing/Compiling
    */
   inlineTokens(src, tokens = [], inLink = false, inRawBlock = false) {
-    let match;
+    let match, token;
     let maskedSrc = src;
 
     // Mask out reflinks to avoid interference with em and strong
@@ -634,8 +579,6 @@ module.exports = class Lexer {
     }
 
     const inlineParams = {
-      src: src,
-      tokens: tokens,
       inLink: inLink,
       inRawBlock: inRawBlock,
       maskedSrc: maskedSrc,
@@ -646,16 +589,20 @@ module.exports = class Lexer {
       smartypants: smartypants
     };
 
-    while (inlineParams.src) {
+    while (src) {
       if (!inlineParams.keepPrevChar) {
         inlineParams.prevChar = '';
       }
       inlineParams.keepPrevChar = false;
 
-      if (this.inlineTokenizers.some(fn => fn.func.call(this, inlineParams))) continue;
+      if (this.inlineTokenizers.some(fn => token = fn.func.call(this, src, inlineParams))) {
+        src = src.substring(token.raw.length);
+        tokens.push(token);
+        continue;
+      }
 
-      if (inlineParams.src) {
-        const errMsg = 'Infinite loop on byte: ' + inlineParams.src.charCodeAt(0);
+      if (src) {
+        const errMsg = 'Infinite loop on byte: ' + src.charCodeAt(0);
         if (this.options.silent) {
           console.error(errMsg);
           break;
@@ -665,6 +612,6 @@ module.exports = class Lexer {
       }
     }
 
-    return inlineParams.tokens;
+    return tokens;
   }
 };

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -74,42 +74,6 @@ module.exports = class Lexer {
     }
     this.tokenizer.rules = rules;
 
-    // TOO SLOW
-    // this.blockTokenizers = new Map([
-    //   ['newline', this.newline],
-    //   ['code', this.code],
-    //   ['fences', this.fences],
-    //   ['nptable', this.nptable],
-    //   ['heading', this.heading],
-    //   ['hr', this.hr],
-    //   ['blockquote', this.blockquote],
-    //   ['list', this.list],
-    //   ['html', this.html],
-    //   ['def', this.def],
-    //   ['table', this.table],
-    //   ['lheading', this.lheading],
-    //   ['paragraph', this.paragraph],
-    //   ['text', this.text]
-    // ]);
-
-    // this.blockTokenizers = [
-    //   this.newline,
-    //   this.code,
-    //   this.fences,
-    //   this.nptable,
-    //   this.heading,
-    //   this.hr,
-    //   this.blockquote,
-    //   this.list,
-    //   this.html,
-    //   this.def,
-    //   this.table,
-    //   this.lheading,
-    //   this.paragraph,
-    //   this.text
-    // ];
-
-    // Array of objects only slightly slower than raw array (~4720 -> ~4750 ms)
     this.blockTokenizers = [
       { name: 'newline', func: this.newline },
       { name: 'code', func: this.code },
@@ -126,37 +90,6 @@ module.exports = class Lexer {
       { name: 'paragraph', func: this.paragraph },
       { name: 'text', func: this.text }
     ];
-
-    // TOO SLOW
-    // this.inlineTokenizers = new Map([
-    //   ['escape', this.escape],
-    //   ['tag', this.tag],
-    //   ['link', this.link],
-    //   ['reflink', this.reflink],
-    //   ['strong', this.strong],
-    //   ['em', this.em],
-    //   ['codespan', this.codespan],
-    //   ['br', this.br],
-    //   ['del', this.del],
-    //   ['autolink', this.autolink],
-    //   ['url', this.url],
-    //   ['inlineText', this.inlineText]
-    // ]);
-
-    // this.inlineTokenizers = [
-    //   this.escape,
-    //   this.tag,
-    //   this.link,
-    //   this.reflink,
-    //   this.strong,
-    //   this.em,
-    //   this.codespan,
-    //   this.br,
-    //   this.del,
-    //   this.autolink,
-    //   this.url,
-    //   this.inlineText
-    // ];
 
     this.inlineTokenizers = [
       { name: 'escape', func: this.escape },
@@ -219,6 +152,7 @@ module.exports = class Lexer {
    * Lexing
    */
 
+  //= === Block tokenizers ====//
   // newline
   newline(src, params) {
     let token;
@@ -446,6 +380,7 @@ module.exports = class Lexer {
     return tokens;
   }
 
+  //= === Inline Tokenizers ====//
   // escape
   escape(src, params) {
     let token;

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -74,21 +74,22 @@ module.exports = class Lexer {
     }
     this.tokenizer.rules = rules;
 
-    this.blockTokenizers = [
-      this.newline,
-      this.code,
-      this.fences,
-      this.nptable,
-      this.heading,
-      this.hr,
-      this.blockquote,
-      this.list,
-      this.html,
-      this.def,
-      this.table,
-      this.lheading,
-      this.paragraph,
-      this.text];
+    this.blockTokenizers = new Map([
+      ['newline', this.newline],
+      ['code', this.code],
+      ['fences', this.fences],
+      ['nptable', this.nptable],
+      ['heading', this.heading],
+      ['hr', this.hr],
+      ['blockquote', this.blockquote],
+      ['list', this.list],
+      ['html', this.html],
+      ['def', this.def],
+      ['table', this.table],
+      ['lheading', this.lheading],
+      ['paragraph', this.paragraph],
+      ['text', this.text]
+    ]);
   }
 
   /**
@@ -136,184 +137,174 @@ module.exports = class Lexer {
    * Lexing
    */
 
-   // newline
-   newline(params) {
-     if (params.token = params.tokenizer.space(params.src)) {
-       params.src = params.src.substring(params.token.raw.length);
-       if (params.token.type) {
-         params.tokens.push(params.token);
-       }
-       return true;
-     }
-   }//.bind(this);
+  // newline
+  newline(params) {
+    if (params.token = this.tokenizer.space(params.src)) {
+      params.src = params.src.substring(params.token.raw.length);
+      if (params.token.type) {
+        params.tokens.push(params.token);
+      }
+      return true;
+    }
+  }
 
-   // code
-   code(params) {
-     if (params.token = params.tokenizer.code(params.src, params.tokens)) {
-       params.src = params.src.substring(params.token.raw.length);
-       if (params.token.type) {
-         params.tokens.push(params.token);
-       } else {
-         params.lastToken = params.tokens[params.tokens.length - 1];
-         params.lastToken.raw += '\n' + params.token.raw;
-         params.lastToken.text += '\n' + params.token.text;
-       }
-       return true;
-     }
-   }//.bind(this);
+  // code
+  code(params) {
+    if (params.token = this.tokenizer.code(params.src, params.tokens)) {
+      params.src = params.src.substring(params.token.raw.length);
+      if (params.token.type) {
+        params.tokens.push(params.token);
+      } else {
+        params.lastToken = params.tokens[params.tokens.length - 1];
+        params.lastToken.raw += '\n' + params.token.raw;
+        params.lastToken.text += '\n' + params.token.text;
+      }
+      return true;
+    }
+  }
 
-   // fences
-   fences(params) {
-     if (params.token = params.tokenizer.fences(params.src)) {
-       params.src = params.src.substring(params.token.raw.length);
-       params.tokens.push(params.token);
-       return true;
-     }
-   }//.bind(this);
+  // fences
+  fences(params) {
+    if (params.token = this.tokenizer.fences(params.src)) {
+      params.src = params.src.substring(params.token.raw.length);
+      params.tokens.push(params.token);
+      return true;
+    }
+  }
 
-   // table no leading pipe (gfm)
-   nptable(params) {
-     if (params.token = params.tokenizer.nptable(params.src)) {
-       params.src = params.src.substring(params.token.raw.length);
-       params.tokens.push(params.token);
-       return true;
-     }
-   }//.bind(this);
+  // table no leading pipe (gfm)
+  nptable(params) {
+    if (params.token = this.tokenizer.nptable(params.src)) {
+      params.src = params.src.substring(params.token.raw.length);
+      params.tokens.push(params.token);
+      return true;
+    }
+  }
 
-   // heading
-   heading(params) {
-     if (params.token = params.tokenizer.heading(params.src)) {
-       params.src = params.src.substring(params.token.raw.length);
-       params.tokens.push(params.token);
-       return true;
-     }
-   }//.bind(this);
+  // heading
+  heading(params) {
+    if (params.token = this.tokenizer.heading(params.src)) {
+      params.src = params.src.substring(params.token.raw.length);
+      params.tokens.push(params.token);
+      return true;
+    }
+  }
 
-   // hr
-   hr(params) {
-     if (params.token = params.tokenizer.hr(params.src)) {
-       params.src = params.src.substring(params.token.raw.length);
-       params.tokens.push(params.token);
-       return true;
-     }
-   }//.bind(this);
+  // hr
+  hr(params) {
+    if (params.token = this.tokenizer.hr(params.src)) {
+      params.src = params.src.substring(params.token.raw.length);
+      params.tokens.push(params.token);
+      return true;
+    }
+  }
 
-   // blockquote
-   blockquote(params) {
-     if (params.token = params.tokenizer.blockquote(params.src)) {
-       params.src = params.src.substring(params.token.raw.length);
-       params.token.tokens = params.blockTokens(params.token.text, [], params.top);
-       params.tokens.push(params.token);
-       return true;
-     }
-   }//.bind(this);
+  // blockquote
+  blockquote(params) {
+    if (params.token = this.tokenizer.blockquote(params.src)) {
+      params.src = params.src.substring(params.token.raw.length);
+      params.token.tokens = this.blockTokens(params.token.text, [], params.top);
+      params.tokens.push(params.token);
+      return true;
+    }
+  }
 
+  // list
+  list(params) {
+    if (params.token = this.tokenizer.list(params.src)) {
+      params.src = params.src.substring(params.token.raw.length);
+      params.l = params.token.items.length;
+      for (params.i = 0; params.i < params.l; params.i++) {
+        params.token.items[params.i].tokens = this.blockTokens(params.token.items[params.i].text, [], false);
+      }
+      params.tokens.push(params.token);
+      return true;
+    }
+  }
 
-   // list
-   list(params) {
-     if (params.token = params.tokenizer.list(params.src)) {
-       params.src = params.src.substring(params.token.raw.length);
-       params.l = params.token.items.length;
-       for (params.i = 0; params.i < params.l; params.i++) {
-         params.token.items[params.i].tokens = params.blockTokens(params.token.items[params.i].text, [], false);
-       }
-       params.tokens.push(params.token);
-       return true;
-     }
-   }//.bind(this);
+  // html
+  html(params) {
+    if (params.token = this.tokenizer.html(params.src)) {
+      params.src = params.src.substring(params.token.raw.length);
+      params.tokens.push(params.token);
+      return true;
+    }
+  }
 
-   // html
-   html(params) {
-     if (params.token = params.tokenizer.html(params.src)) {
-       params.src = params.src.substring(params.token.raw.length);
-       params.tokens.push(params.token);
-       return true;
-     }
-   }//.bind(this);
+  // def
+  def(params) {
+    if (params.top && (params.token = this.tokenizer.def(params.src))) {
+      params.src = params.src.substring(params.token.raw.length);
+      if (!this.tokens.links[params.token.tag]) {
+        this.tokens.links[params.token.tag] = {
+          href: params.token.href,
+          title: params.token.title
+        };
+      }
+      return true;
+    }
+  }
 
-   // def
-   def(params) {
-     if (params.top && (params.token = params.tokenizer.def(params.src))) {
-       params.src = params.src.substring(params.token.raw.length);
-       if (params.tokens && (!params.tokens.links || !params.tokens.links[params.token.tag])) {
-         params.tokens.links[params.token.tag] = {
-           href: params.token.href,
-           title: params.token.title
-         };
-       }
-       return true;
-     }
-   }//.bind(this);
+  // table (gfm)
+  table(params) {
+    if (params.token = this.tokenizer.table(params.src)) {
+      params.src = params.src.substring(params.token.raw.length);
+      params.tokens.push(params.token);
+      return true;
+    }
+  }
 
-   // table (gfm)
-   table(params) {
-     if (params.token = params.tokenizer.table(params.src)) {
-       params.src = params.src.substring(params.token.raw.length);
-       params.tokens.push(params.token);
-       return true;
-     }
-   }//.bind(this);
+  // lheading
+  lheading(params) {
+    if (params.token = this.tokenizer.lheading(params.src)) {
+      params.src = params.src.substring(params.token.raw.length);
+      params.tokens.push(params.token);
+      return true;
+    }
+  }
 
-   // lheading
-   lheading(params) {
-     if (params.token = params.tokenizer.lheading(params.src)) {
-       params.src = params.src.substring(params.token.raw.length);
-       params.tokens.push(params.token);
-       return true;
-     }
-   }//.bind(this);
+  // top-level paragraph
+  paragraph(params) {
+    if (params.top && (params.token = this.tokenizer.paragraph(params.src))) {
+      params.src = params.src.substring(params.token.raw.length);
+      params.tokens.push(params.token);
+      return true;
+    }
+  }
 
-   // top-level paragraph
-   paragraph(params) {
-     if (params.top && (params.token = params.tokenizer.paragraph(params.src))) {
-       params.src = params.src.substring(params.token.raw.length);
-       params.tokens.push(params.token);
-       return true;
-     }
-   }//.bind(this);
-
-   // text
-   text(params) {
-     if (params.token = params.tokenizer.text(params.src, params.tokens)) {
-       params.src = params.src.substring(params.token.raw.length);
-       if (params.token.type) {
-         params.tokens.push(params.token);
-       } else {
-         params.lastToken = params.tokens[params.tokens.length - 1];
-         params.lastToken.raw += '\n' + params.token.raw;
-         params.lastToken.text += '\n' + params.token.text;
-       }
-       return true;
-     }
-   }//.bind(this);
-
-
+  // text
+  text(params) {
+    if (params.token = this.tokenizer.text(params.src, params.tokens)) {
+      params.src = params.src.substring(params.token.raw.length);
+      if (params.token.type) {
+        params.tokens.push(params.token);
+      } else {
+        params.lastToken = params.tokens[params.tokens.length - 1];
+        params.lastToken.raw += '\n' + params.token.raw;
+        params.lastToken.text += '\n' + params.token.text;
+      }
+      return true;
+    }
+  }
 
   blockTokens(src, tokens = [], top = true) {
-    if(!tokens.links){
-      tokens.links = Object.create(null);
-    }
     src = src.replace(/^ +$/gm, '');
-    let token, i, l, lastToken;
-    let fn;
+    let token, lastToken, i, l, fn;
 
-    let blockParams = {
-      tokenizer : this.tokenizer,
-      blockTokens : this.blockTokens.bind(this),
-      src : src,
-      token : token,
-      tokens : tokens,
-      lastToken : lastToken,
-      top : top,
-      i : i,
-      l : l
+    const blockParams = {
+      src: src,
+      tokens: tokens,
+      top: top,
+      token: token,
+      lastToken: lastToken,
+      i: i,
+      l: l
     };
 
     outerLoop:
     while (blockParams.src) {
-
-      for(fn of this.blockTokenizers) {
-        if(fn(blockParams)) {
+      for (fn of this.blockTokenizers.values()) {
+        if (fn.call(this, blockParams)) {
           continue outerLoop;
         }
       }

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -353,7 +353,7 @@ module.exports = class Lexer {
     };
 
     while (src) {
-      if (this.blockTokenizers.some(fn => token = fn.func.call(this, src, blockParams))) {
+      if (this.blockTokenizers.some(function(fn) { return token = fn.func.call(this, src, blockParams); }, this)) {
         src = src.substring(token.raw.length);
         if (token.type) {
           if (token.type === 'continue') {
@@ -595,7 +595,7 @@ module.exports = class Lexer {
       }
       inlineParams.keepPrevChar = false;
 
-      if (this.inlineTokenizers.some(fn => token = fn.func.call(this, src, inlineParams))) {
+      if (this.inlineTokenizers.some(function(fn) { return token = fn.func.call(this, src, inlineParams); }, this)) {
         src = src.substring(token.raw.length);
         tokens.push(token);
         continue;

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -74,7 +74,7 @@ module.exports = class Lexer {
     }
     this.tokenizer.rules = rules;
 
-// TOO SLOW
+    // TOO SLOW
     // this.blockTokenizers = new Map([
     //   ['newline', this.newline],
     //   ['code', this.code],
@@ -109,25 +109,25 @@ module.exports = class Lexer {
     //   this.text
     // ];
 
-// Array of objects only slightly slower than raw array (~4720 - 4750 ms)
+    // Array of objects only slightly slower than raw array (~4720 -> ~4750 ms)
     this.blockTokenizers = [
-      {name: 'newline', func: this.newline},
-      {name: 'code', func: this.code},
-      {name: 'fences', func: this.fences},
-      {name: 'nptable', func: this.nptable},
-      {name: 'heading', func: this.heading},
-      {name: 'hr', func: this.hr},
-      {name: 'blockquote', func: this.blockquote},
-      {name: 'list', func: this.list},
-      {name: 'html', func: this.html},
-      {name: 'def', func: this.def},
-      {name: 'table', func: this.table},
-      {name: 'lheading', func: this.lheading},
-      {name: 'paragraph', func: this.paragraph},
-      {name: 'text', func: this.text}
+      { name: 'newline', func: this.newline },
+      { name: 'code', func: this.code },
+      { name: 'fences', func: this.fences },
+      { name: 'nptable', func: this.nptable },
+      { name: 'heading', func: this.heading },
+      { name: 'hr', func: this.hr },
+      { name: 'blockquote', func: this.blockquote },
+      { name: 'list', func: this.list },
+      { name: 'html', func: this.html },
+      { name: 'def', func: this.def },
+      { name: 'table', func: this.table },
+      { name: 'lheading', func: this.lheading },
+      { name: 'paragraph', func: this.paragraph },
+      { name: 'text', func: this.text }
     ];
 
-// TOO SLOW
+    // TOO SLOW
     // this.inlineTokenizers = new Map([
     //   ['escape', this.escape],
     //   ['tag', this.tag],
@@ -159,18 +159,18 @@ module.exports = class Lexer {
     // ];
 
     this.inlineTokenizers = [
-      {name: "escape", func: this.escape},
-      {name: "tag",  func: this.tag},
-      {name: "link",  func: this.link},
-      {name: "reflink", func: this.reflink},
-      {name: "strong", func: this.strong},
-      {name: "em", func: this.em},
-      {name: "codespan", func: this.codespan},
-      {name: "br", func: this.br},
-      {name: "del",  func:this.del},
-      {name: "autolink", func: this.autolink},
-      {name: "url", func: this.url},
-      {name: "inlineText", func: this.inlineText}
+      { name: 'escape', func: this.escape },
+      { name: 'tag', func: this.tag },
+      { name: 'link', func: this.link },
+      { name: 'reflink', func: this.reflink },
+      { name: 'strong', func: this.strong },
+      { name: 'em', func: this.em },
+      { name: 'codespan', func: this.codespan },
+      { name: 'br', func: this.br },
+      { name: 'del', func: this.del },
+      { name: 'autolink', func: this.autolink },
+      { name: 'url', func: this.url },
+      { name: 'inlineText', func: this.inlineText }
     ];
   }
 
@@ -386,7 +386,7 @@ module.exports = class Lexer {
     blockTokenizerLoop:
     while (blockParams.src) {
       for (fn of this.blockTokenizers) {
-        if (fn["func"].call(this, blockParams)) {
+        if (fn.func.call(this, blockParams)) {
           continue blockTokenizerLoop;
         }
       }
@@ -640,7 +640,7 @@ module.exports = class Lexer {
       inlineParams.keepPrevChar = false;
 
       for (fn of this.inlineTokenizers) {
-        if (fn["func"].call(this, inlineParams)) {
+        if (fn.func.call(this, inlineParams)) {
           continue inlineTokenizerLoop;
         }
       }

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -2,6 +2,7 @@ const Tokenizer = require('./Tokenizer.js');
 const { defaults } = require('./defaults.js');
 const { block, inline } = require('./rules.js');
 const { repeatString } = require('./helpers.js');
+// Function.prototype.bind = require('fast-bind');
 
 /**
  * smartypants text replacement
@@ -154,89 +155,89 @@ module.exports = class Lexer {
 
   //= === Block tokenizers ====//
   // newline
-  newline(src, params) {
+  newline(c, src, params) {
     let token;
-    if (token = this.tokenizer.space(src)) {
+    if (token = c.tokenizer.space(src)) {
       return token;
     }
   }
 
   // code
-  code(src, params) {
+  code(c, src, params) {
     let token;
-    if (token = this.tokenizer.code(src, params.lastToken)) {
+    if (token = c.tokenizer.code(src, params.lastToken)) {
       return token;
     }
   }
 
   // fences
-  fences(src, params) {
+  fences(c, src, params) {
     let token;
-    if (token = this.tokenizer.fences(src)) {
+    if (token = c.tokenizer.fences(src)) {
       return token;
     }
   }
 
   // table no leading pipe (gfm)
-  nptable(src, params) {
+  nptable(c, src, params) {
     let token;
-    if (token = this.tokenizer.nptable(src)) {
+    if (token = c.tokenizer.nptable(src)) {
       return token;
     }
   }
 
   // heading
-  heading(src, params) {
+  heading(c, src, params) {
     let token;
-    if (token = this.tokenizer.heading(src)) {
+    if (token = c.tokenizer.heading(src)) {
       return token;
     }
   }
 
   // hr
-  hr(src, params) {
+  hr(c, src, params) {
     let token;
-    if (token = this.tokenizer.hr(src)) {
+    if (token = c.tokenizer.hr(src)) {
       return token;
     }
   }
 
   // blockquote
-  blockquote(src, params) {
+  blockquote(c, src, params) {
     let token;
-    if (token = this.tokenizer.blockquote(src)) {
-      token.tokens = this.blockTokens(token.text, [], params.top);
+    if (token = c.tokenizer.blockquote(src)) {
+      token.tokens = c.blockTokens(token.text, [], params.top);
       return token;
     }
   }
 
   // list
-  list(src, params) {
+  list(c, src, params) {
     let token;
-    if (token = this.tokenizer.list(src)) {
+    if (token = c.tokenizer.list(src)) {
       const l = token.items.length;
       let i;
       for (i = 0; i < l; i++) {
-        token.items[i].tokens = this.blockTokens(token.items[i].text, [], false);
+        token.items[i].tokens = c.blockTokens(token.items[i].text, [], false);
       }
       return token;
     }
   }
 
   // html
-  html(src, params) {
+  html(c, src, params) {
     let token;
-    if (token = this.tokenizer.html(src)) {
+    if (token = c.tokenizer.html(src)) {
       return token;
     }
   }
 
   // def
-  def(src, params) {
+  def(c, src, params) {
     let token;
-    if (params.top && (token = this.tokenizer.def(src))) {
-      if (!this.tokens.links[token.tag]) {
-        this.tokens.links[token.tag] = {
+    if (params.top && (token = c.tokenizer.def(src))) {
+      if (!c.tokens.links[token.tag]) {
+        c.tokens.links[token.tag] = {
           href: token.href,
           title: token.title
         };
@@ -246,33 +247,33 @@ module.exports = class Lexer {
   }
 
   // table (gfm)
-  table(src, params) {
+  table(c, src, params) {
     let token;
-    if (token = this.tokenizer.table(src)) {
+    if (token = c.tokenizer.table(src)) {
       return token;
     }
   }
 
   // lheading
-  lheading(src, params) {
+  lheading(c, src, params) {
     let token;
-    if (token = this.tokenizer.lheading(src, params)) {
+    if (token = c.tokenizer.lheading(src, params)) {
       return token;
     }
   }
 
   // top-level paragraph
-  paragraph(src, params) {
+  paragraph(c, src, params) {
     let token;
-    if (params.top && (token = this.tokenizer.paragraph(src))) {
+    if (params.top && (token = c.tokenizer.paragraph(src))) {
       return token;
     }
   }
 
   // text
-  text(src, params) {
+  text(c, src, params) {
     let token;
-    if (token = this.tokenizer.text(src, params.lastToken)) {
+    if (token = c.tokenizer.text(src, params.lastToken)) {
       return token;
     }
   }
@@ -287,7 +288,7 @@ module.exports = class Lexer {
     };
 
     while (src) {
-      if (this.blockTokenizers.some(function(fn) { return token = fn.func.call(this, src, blockParams); }, this)) {
+      if (this.blockTokenizers.some((fn) => token = fn.func(this, src, blockParams))) {
         src = src.substring(token.raw.length);
         if (token.type) {
           if (token.type === 'continue') {
@@ -382,17 +383,17 @@ module.exports = class Lexer {
 
   //= === Inline Tokenizers ====//
   // escape
-  escape(src, params) {
+  escape(c, src, params) {
     let token;
-    if (token = this.tokenizer.escape(src)) {
+    if (token = c.tokenizer.escape(src)) {
       return token;
     }
   }
 
   // tag
-  tag(src, params) {
+  tag(c, src, params) {
     let token;
-    if (token = this.tokenizer.tag(src, params.inLink, params.inRawBlock)) {
+    if (token = c.tokenizer.tag(src, params.inLink, params.inRawBlock)) {
       params.inLink = token.inLink;
       params.inRawBlock = token.inRawBlock;
       return token;
@@ -400,90 +401,90 @@ module.exports = class Lexer {
   }
 
   // link
-  link(src, params) {
+  link(c, src, params) {
     let token;
-    if (token = this.tokenizer.link(src)) {
+    if (token = c.tokenizer.link(src)) {
       if (token.type === 'link') {
-        token.tokens = this.inlineTokens(token.text, [], true, params.inRawBlock);
+        token.tokens = c.inlineTokens(token.text, [], true, params.inRawBlock);
       }
       return token;
     }
   }
 
   // reflink, nolink
-  reflink(src, params) {
+  reflink(c, src, params) {
     let token;
-    if (token = this.tokenizer.reflink(src, this.tokens.links)) {
+    if (token = c.tokenizer.reflink(src, c.tokens.links)) {
       if (token.type === 'link') {
-        token.tokens = this.inlineTokens(token.text, [], true, params.inRawBlock);
+        token.tokens = c.inlineTokens(token.text, [], true, params.inRawBlock);
       }
       return token;
     }
   }
 
   // strong
-  strong(src, params) {
+  strong(c, src, params) {
     let token;
-    if (token = this.tokenizer.strong(src, params.maskedSrc, params.prevChar)) {
-      token.tokens = this.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
+    if (token = c.tokenizer.strong(src, params.maskedSrc, params.prevChar)) {
+      token.tokens = c.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
       return token;
     }
   }
 
   // em
-  em(src, params) {
+  em(c, src, params) {
     let token;
-    if (token = this.tokenizer.em(src, params.maskedSrc, params.prevChar)) {
-      token.tokens = this.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
+    if (token = c.tokenizer.em(src, params.maskedSrc, params.prevChar)) {
+      token.tokens = c.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
       return token;
     }
   }
 
   // code
-  codespan(src, params) {
+  codespan(c, src, params) {
     let token;
-    if (token = this.tokenizer.codespan(src)) {
+    if (token = c.tokenizer.codespan(src)) {
       return token;
     }
   }
 
   // br
-  br(src, params) {
+  br(c, src, params) {
     let token;
-    if (token = this.tokenizer.br(src)) {
+    if (token = c.tokenizer.br(src)) {
       return token;
     }
   }
 
   // del (gfm)
-  del(src, params) {
+  del(c, src, params) {
     let token;
-    if (token = this.tokenizer.del(src)) {
-      token.tokens = this.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
+    if (token = c.tokenizer.del(src)) {
+      token.tokens = c.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
       return token;
     }
   }
 
   // autolink
-  autolink(src, params) {
+  autolink(c, src, params) {
     let token;
-    if (token = this.tokenizer.autolink(src, params.mangle)) {
+    if (token = c.tokenizer.autolink(src, params.mangle)) {
       return token;
     }
   }
 
   // url (gfm)
-  url(src, params) {
+  url(c, src, params) {
     let token;
-    if (!params.inLink && (token = this.tokenizer.url(src, params.mangle))) {
+    if (!params.inLink && (token = c.tokenizer.url(src, params.mangle))) {
       return token;
     }
   }
 
   // text
-  inlineText(src, params) {
+  inlineText(c, src, params) {
     let token;
-    if (token = this.tokenizer.inlineText(src, params.inRawBlock, params.smartypants)) {
+    if (token = c.tokenizer.inlineText(src, params.inRawBlock, params.smartypants)) {
       params.prevChar = token.raw.slice(-1);
       params.keepPrevChar = true;
       return token;
@@ -530,7 +531,7 @@ module.exports = class Lexer {
       }
       inlineParams.keepPrevChar = false;
 
-      if (this.inlineTokenizers.some(function(fn) { return token = fn.func.call(this, src, inlineParams); }, this)) {
+      if (this.inlineTokenizers.some(fn => token = fn.func(this, src, inlineParams))) {
         src = src.substring(token.raw.length);
         tokens.push(token);
         continue;

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -73,6 +73,22 @@ module.exports = class Lexer {
       }
     }
     this.tokenizer.rules = rules;
+
+    this.blockTokenizers = [
+      this.newline,
+      this.code,
+      this.fences,
+      this.nptable,
+      this.heading,
+      this.hr,
+      this.blockquote,
+      this.list,
+      this.html,
+      this.def,
+      this.table,
+      this.lheading,
+      this.paragraph,
+      this.text];
   }
 
   /**
@@ -119,135 +135,191 @@ module.exports = class Lexer {
   /**
    * Lexing
    */
+
+   // newline
+   newline(params) {
+     if (params.token = params.tokenizer.space(params.src)) {
+       params.src = params.src.substring(params.token.raw.length);
+       if (params.token.type) {
+         params.tokens.push(params.token);
+       }
+       return true;
+     }
+   }//.bind(this);
+
+   // code
+   code(params) {
+     if (params.token = params.tokenizer.code(params.src, params.tokens)) {
+       params.src = params.src.substring(params.token.raw.length);
+       if (params.token.type) {
+         params.tokens.push(params.token);
+       } else {
+         params.lastToken = params.tokens[params.tokens.length - 1];
+         params.lastToken.raw += '\n' + params.token.raw;
+         params.lastToken.text += '\n' + params.token.text;
+       }
+       return true;
+     }
+   }//.bind(this);
+
+   // fences
+   fences(params) {
+     if (params.token = params.tokenizer.fences(params.src)) {
+       params.src = params.src.substring(params.token.raw.length);
+       params.tokens.push(params.token);
+       return true;
+     }
+   }//.bind(this);
+
+   // table no leading pipe (gfm)
+   nptable(params) {
+     if (params.token = params.tokenizer.nptable(params.src)) {
+       params.src = params.src.substring(params.token.raw.length);
+       params.tokens.push(params.token);
+       return true;
+     }
+   }//.bind(this);
+
+   // heading
+   heading(params) {
+     if (params.token = params.tokenizer.heading(params.src)) {
+       params.src = params.src.substring(params.token.raw.length);
+       params.tokens.push(params.token);
+       return true;
+     }
+   }//.bind(this);
+
+   // hr
+   hr(params) {
+     if (params.token = params.tokenizer.hr(params.src)) {
+       params.src = params.src.substring(params.token.raw.length);
+       params.tokens.push(params.token);
+       return true;
+     }
+   }//.bind(this);
+
+   // blockquote
+   blockquote(params) {
+     if (params.token = params.tokenizer.blockquote(params.src)) {
+       params.src = params.src.substring(params.token.raw.length);
+       params.token.tokens = params.blockTokens(params.token.text, [], params.top);
+       params.tokens.push(params.token);
+       return true;
+     }
+   }//.bind(this);
+
+
+   // list
+   list(params) {
+     if (params.token = params.tokenizer.list(params.src)) {
+       params.src = params.src.substring(params.token.raw.length);
+       params.l = params.token.items.length;
+       for (params.i = 0; params.i < params.l; params.i++) {
+         params.token.items[params.i].tokens = params.blockTokens(params.token.items[params.i].text, [], false);
+       }
+       params.tokens.push(params.token);
+       return true;
+     }
+   }//.bind(this);
+
+   // html
+   html(params) {
+     if (params.token = params.tokenizer.html(params.src)) {
+       params.src = params.src.substring(params.token.raw.length);
+       params.tokens.push(params.token);
+       return true;
+     }
+   }//.bind(this);
+
+   // def
+   def(params) {
+     if (params.top && (params.token = params.tokenizer.def(params.src))) {
+       params.src = params.src.substring(params.token.raw.length);
+       if (params.tokens && (!params.tokens.links || !params.tokens.links[params.token.tag])) {
+         params.tokens.links[params.token.tag] = {
+           href: params.token.href,
+           title: params.token.title
+         };
+       }
+       return true;
+     }
+   }//.bind(this);
+
+   // table (gfm)
+   table(params) {
+     if (params.token = params.tokenizer.table(params.src)) {
+       params.src = params.src.substring(params.token.raw.length);
+       params.tokens.push(params.token);
+       return true;
+     }
+   }//.bind(this);
+
+   // lheading
+   lheading(params) {
+     if (params.token = params.tokenizer.lheading(params.src)) {
+       params.src = params.src.substring(params.token.raw.length);
+       params.tokens.push(params.token);
+       return true;
+     }
+   }//.bind(this);
+
+   // top-level paragraph
+   paragraph(params) {
+     if (params.top && (params.token = params.tokenizer.paragraph(params.src))) {
+       params.src = params.src.substring(params.token.raw.length);
+       params.tokens.push(params.token);
+       return true;
+     }
+   }//.bind(this);
+
+   // text
+   text(params) {
+     if (params.token = params.tokenizer.text(params.src, params.tokens)) {
+       params.src = params.src.substring(params.token.raw.length);
+       if (params.token.type) {
+         params.tokens.push(params.token);
+       } else {
+         params.lastToken = params.tokens[params.tokens.length - 1];
+         params.lastToken.raw += '\n' + params.token.raw;
+         params.lastToken.text += '\n' + params.token.text;
+       }
+       return true;
+     }
+   }//.bind(this);
+
+
+
   blockTokens(src, tokens = [], top = true) {
+    if(!tokens.links){
+      tokens.links = Object.create(null);
+    }
     src = src.replace(/^ +$/gm, '');
     let token, i, l, lastToken;
+    let fn;
 
-    while (src) {
-      // newline
-      if (token = this.tokenizer.space(src)) {
-        src = src.substring(token.raw.length);
-        if (token.type) {
-          tokens.push(token);
+    let blockParams = {
+      tokenizer : this.tokenizer,
+      blockTokens : this.blockTokens.bind(this),
+      src : src,
+      token : token,
+      tokens : tokens,
+      lastToken : lastToken,
+      top : top,
+      i : i,
+      l : l
+    };
+
+    outerLoop:
+    while (blockParams.src) {
+
+      for(fn of this.blockTokenizers) {
+        if(fn(blockParams)) {
+          continue outerLoop;
         }
-        continue;
       }
 
-      // code
-      if (token = this.tokenizer.code(src, tokens)) {
-        src = src.substring(token.raw.length);
-        if (token.type) {
-          tokens.push(token);
-        } else {
-          lastToken = tokens[tokens.length - 1];
-          lastToken.raw += '\n' + token.raw;
-          lastToken.text += '\n' + token.text;
-        }
-        continue;
-      }
-
-      // fences
-      if (token = this.tokenizer.fences(src)) {
-        src = src.substring(token.raw.length);
-        tokens.push(token);
-        continue;
-      }
-
-      // heading
-      if (token = this.tokenizer.heading(src)) {
-        src = src.substring(token.raw.length);
-        tokens.push(token);
-        continue;
-      }
-
-      // table no leading pipe (gfm)
-      if (token = this.tokenizer.nptable(src)) {
-        src = src.substring(token.raw.length);
-        tokens.push(token);
-        continue;
-      }
-
-      // hr
-      if (token = this.tokenizer.hr(src)) {
-        src = src.substring(token.raw.length);
-        tokens.push(token);
-        continue;
-      }
-
-      // blockquote
-      if (token = this.tokenizer.blockquote(src)) {
-        src = src.substring(token.raw.length);
-        token.tokens = this.blockTokens(token.text, [], top);
-        tokens.push(token);
-        continue;
-      }
-
-      // list
-      if (token = this.tokenizer.list(src)) {
-        src = src.substring(token.raw.length);
-        l = token.items.length;
-        for (i = 0; i < l; i++) {
-          token.items[i].tokens = this.blockTokens(token.items[i].text, [], false);
-        }
-        tokens.push(token);
-        continue;
-      }
-
-      // html
-      if (token = this.tokenizer.html(src)) {
-        src = src.substring(token.raw.length);
-        tokens.push(token);
-        continue;
-      }
-
-      // def
-      if (top && (token = this.tokenizer.def(src))) {
-        src = src.substring(token.raw.length);
-        if (!this.tokens.links[token.tag]) {
-          this.tokens.links[token.tag] = {
-            href: token.href,
-            title: token.title
-          };
-        }
-        continue;
-      }
-
-      // table (gfm)
-      if (token = this.tokenizer.table(src)) {
-        src = src.substring(token.raw.length);
-        tokens.push(token);
-        continue;
-      }
-
-      // lheading
-      if (token = this.tokenizer.lheading(src)) {
-        src = src.substring(token.raw.length);
-        tokens.push(token);
-        continue;
-      }
-
-      // top-level paragraph
-      if (top && (token = this.tokenizer.paragraph(src))) {
-        src = src.substring(token.raw.length);
-        tokens.push(token);
-        continue;
-      }
-
-      // text
-      if (token = this.tokenizer.text(src, tokens)) {
-        src = src.substring(token.raw.length);
-        if (token.type) {
-          tokens.push(token);
-        } else {
-          lastToken = tokens[tokens.length - 1];
-          lastToken.raw += '\n' + token.raw;
-          lastToken.text += '\n' + token.text;
-        }
-        continue;
-      }
-
-      if (src) {
-        const errMsg = 'Infinite loop on byte: ' + src.charCodeAt(0);
+      if (blockParams.src) {
+        const errMsg = 'Infinite loop on byte: ' + blockParams.src.charCodeAt(0);
         if (this.options.silent) {
           console.error(errMsg);
           break;
@@ -257,7 +329,7 @@ module.exports = class Lexer {
       }
     }
 
-    return tokens;
+    return blockParams.tokens;
   }
 
   inline(tokens) {

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -221,10 +221,11 @@ module.exports = class Lexer {
 
   // newline
   newline(params) {
-    if (params.token = this.tokenizer.space(params.src)) {
-      params.src = params.src.substring(params.token.raw.length);
-      if (params.token.type) {
-        params.tokens.push(params.token);
+    let token;
+    if (token = this.tokenizer.space(params.src)) {
+      params.src = params.src.substring(token.raw.length);
+      if (token.type) {
+        params.tokens.push(token);
       }
       return true;
     }
@@ -232,14 +233,15 @@ module.exports = class Lexer {
 
   // code
   code(params) {
-    if (params.token = this.tokenizer.code(params.src, params.tokens)) {
-      params.src = params.src.substring(params.token.raw.length);
-      if (params.token.type) {
-        params.tokens.push(params.token);
+    let token;
+    if (token = this.tokenizer.code(params.src, params.tokens)) {
+      params.src = params.src.substring(token.raw.length);
+      if (token.type) {
+        params.tokens.push(token);
       } else {
         params.lastToken = params.tokens[params.tokens.length - 1];
-        params.lastToken.raw += '\n' + params.token.raw;
-        params.lastToken.text += '\n' + params.token.text;
+        params.lastToken.raw += '\n' + token.raw;
+        params.lastToken.text += '\n' + token.text;
       }
       return true;
     }
@@ -247,80 +249,89 @@ module.exports = class Lexer {
 
   // fences
   fences(params) {
-    if (params.token = this.tokenizer.fences(params.src)) {
-      params.src = params.src.substring(params.token.raw.length);
-      params.tokens.push(params.token);
+    let token;
+    if (token = this.tokenizer.fences(params.src)) {
+      params.src = params.src.substring(token.raw.length);
+      params.tokens.push(token);
       return true;
     }
   }
 
   // table no leading pipe (gfm)
   nptable(params) {
-    if (params.token = this.tokenizer.nptable(params.src)) {
-      params.src = params.src.substring(params.token.raw.length);
-      params.tokens.push(params.token);
+    let token;
+    if (token = this.tokenizer.nptable(params.src)) {
+      params.src = params.src.substring(token.raw.length);
+      params.tokens.push(token);
       return true;
     }
   }
 
   // heading
   heading(params) {
-    if (params.token = this.tokenizer.heading(params.src)) {
-      params.src = params.src.substring(params.token.raw.length);
-      params.tokens.push(params.token);
+    let token;
+    if (token = this.tokenizer.heading(params.src)) {
+      params.src = params.src.substring(token.raw.length);
+      params.tokens.push(token);
       return true;
     }
   }
 
   // hr
   hr(params) {
-    if (params.token = this.tokenizer.hr(params.src)) {
-      params.src = params.src.substring(params.token.raw.length);
-      params.tokens.push(params.token);
+    let token;
+    if (token = this.tokenizer.hr(params.src)) {
+      params.src = params.src.substring(token.raw.length);
+      params.tokens.push(token);
       return true;
     }
   }
 
   // blockquote
   blockquote(params) {
-    if (params.token = this.tokenizer.blockquote(params.src)) {
-      params.src = params.src.substring(params.token.raw.length);
-      params.token.tokens = this.blockTokens(params.token.text, [], params.top);
-      params.tokens.push(params.token);
+    let token;
+    if (token = this.tokenizer.blockquote(params.src)) {
+      params.src = params.src.substring(token.raw.length);
+      token.tokens = this.blockTokens(token.text, [], params.top);
+      params.tokens.push(token);
       return true;
     }
   }
 
   // list
   list(params) {
-    if (params.token = this.tokenizer.list(params.src)) {
-      params.src = params.src.substring(params.token.raw.length);
-      params.l = params.token.items.length;
-      for (params.i = 0; params.i < params.l; params.i++) {
-        params.token.items[params.i].tokens = this.blockTokens(params.token.items[params.i].text, [], false);
+    let token;
+    if (token = this.tokenizer.list(params.src)) {
+      params.src = params.src.substring(token.raw.length);
+      const l = token.items.length;
+      let i;
+      for (i = 0; i < l; i++) {
+        token.items[i].tokens = this.blockTokens(token.items[i].text, [], false);
       }
-      params.tokens.push(params.token);
+      params.tokens.push(token);
       return true;
     }
   }
 
   // html
   html(params) {
-    if (params.token = this.tokenizer.html(params.src)) {
-      params.src = params.src.substring(params.token.raw.length);
-      params.tokens.push(params.token);
+    let token;
+    if (token = this.tokenizer.html(params.src)) {
+      params.src = params.src.substring(token.raw.length);
+      params.tokens.push(token);
       return true;
     }
   }
 
   // def
   def(params) {
-    if (params.top && (params.token = this.tokenizer.def(params.src))) {
-      params.src = params.src.substring(params.token.raw.length);
-      if (!this.tokens.links[params.token.tag]) {
-        this.tokens.links[params.token.tag] = {
-          href: params.token.href,
-          title: params.token.title
+    let token;
+    if (params.top && (token = this.tokenizer.def(params.src))) {
+      params.src = params.src.substring(token.raw.length);
+      if (!this.tokens.links[token.tag]) {
+        this.tokens.links[token.tag] = {
+          href: token.href,
+          title: token.title
         };
       }
       return true;
@@ -329,41 +340,45 @@ module.exports = class Lexer {
 
   // table (gfm)
   table(params) {
-    if (params.token = this.tokenizer.table(params.src)) {
-      params.src = params.src.substring(params.token.raw.length);
-      params.tokens.push(params.token);
+    let token;
+    if (token = this.tokenizer.table(params.src)) {
+      params.src = params.src.substring(token.raw.length);
+      params.tokens.push(token);
       return true;
     }
   }
 
   // lheading
   lheading(params) {
-    if (params.token = this.tokenizer.lheading(params.src)) {
-      params.src = params.src.substring(params.token.raw.length);
-      params.tokens.push(params.token);
+    let token;
+    if (token = this.tokenizer.lheading(params.src)) {
+      params.src = params.src.substring(token.raw.length);
+      params.tokens.push(token);
       return true;
     }
   }
 
   // top-level paragraph
   paragraph(params) {
-    if (params.top && (params.token = this.tokenizer.paragraph(params.src))) {
-      params.src = params.src.substring(params.token.raw.length);
-      params.tokens.push(params.token);
+    let token;
+    if (params.top && (token = this.tokenizer.paragraph(params.src))) {
+      params.src = params.src.substring(token.raw.length);
+      params.tokens.push(token);
       return true;
     }
   }
 
   // text
   text(params) {
-    if (params.token = this.tokenizer.text(params.src, params.tokens)) {
-      params.src = params.src.substring(params.token.raw.length);
-      if (params.token.type) {
-        params.tokens.push(params.token);
+    let token;
+    if (token = this.tokenizer.text(params.src, params.tokens)) {
+      params.src = params.src.substring(token.raw.length);
+      if (token.type) {
+        params.tokens.push(token);
       } else {
         params.lastToken = params.tokens[params.tokens.length - 1];
-        params.lastToken.raw += '\n' + params.token.raw;
-        params.lastToken.text += '\n' + params.token.text;
+        params.lastToken.raw += '\n' + token.raw;
+        params.lastToken.text += '\n' + token.text;
       }
       return true;
     }
@@ -371,25 +386,17 @@ module.exports = class Lexer {
 
   blockTokens(src, tokens = [], top = true) {
     src = src.replace(/^ +$/gm, '');
-    let fn;
 
     const blockParams = {
       src: src,
       tokens: tokens,
       top: top,
-      token: null,
-      lastToken: null,
-      i: 0,
-      l: 0
+      // token: null,
+      lastToken: null//,
     };
 
-    blockTokenizerLoop:
     while (blockParams.src) {
-      for (fn of this.blockTokenizers) {
-        if (fn.func.call(this, blockParams)) {
-          continue blockTokenizerLoop;
-        }
-      }
+      if (this.blockTokenizers.some(fn => fn.func.call(this, blockParams))) continue;
 
       if (blockParams.src) {
         const errMsg = 'Infinite loop on byte: ' + blockParams.src.charCodeAt(0);
@@ -472,121 +479,133 @@ module.exports = class Lexer {
 
   // escape
   escape(params) {
-    if (params.token = this.tokenizer.escape(params.src)) {
-      params.src = params.src.substring(params.token.raw.length);
-      params.tokens.push(params.token);
+    let token;
+    if (token = this.tokenizer.escape(params.src)) {
+      params.src = params.src.substring(token.raw.length);
+      params.tokens.push(token);
       return true;
     }
   }
 
   // tag
   tag(params) {
-    if (params.token = this.tokenizer.tag(params.src, params.inLink, params.inRawBlock)) {
-      params.src = params.src.substring(params.token.raw.length);
-      params.inLink = params.token.inLink;
-      params.inRawBlock = params.token.inRawBlock;
-      params.tokens.push(params.token);
+    let token;
+    if (token = this.tokenizer.tag(params.src, params.inLink, params.inRawBlock)) {
+      params.src = params.src.substring(token.raw.length);
+      params.inLink = token.inLink;
+      params.inRawBlock = token.inRawBlock;
+      params.tokens.push(token);
       return true;
     }
   }
 
   // link
   link(params) {
-    if (params.token = this.tokenizer.link(params.src)) {
-      params.src = params.src.substring(params.token.raw.length);
-      if (params.token.type === 'link') {
-        params.token.tokens = this.inlineTokens(params.token.text, [], true, params.inRawBlock);
+    let token;
+    if (token = this.tokenizer.link(params.src)) {
+      params.src = params.src.substring(token.raw.length);
+      if (token.type === 'link') {
+        token.tokens = this.inlineTokens(token.text, [], true, params.inRawBlock);
       }
-      params.tokens.push(params.token);
+      params.tokens.push(token);
       return true;
     }
   }
 
   // reflink, nolink
   reflink(params) {
-    if (params.token = this.tokenizer.reflink(params.src, this.tokens.links)) {
-      params.src = params.src.substring(params.token.raw.length);
-      if (params.token.type === 'link') {
-        params.token.tokens = this.inlineTokens(params.token.text, [], true, params.inRawBlock);
+    let token;
+    if (token = this.tokenizer.reflink(params.src, this.tokens.links)) {
+      params.src = params.src.substring(token.raw.length);
+      if (token.type === 'link') {
+        token.tokens = this.inlineTokens(token.text, [], true, params.inRawBlock);
       }
-      params.tokens.push(params.token);
+      params.tokens.push(token);
       return true;
     }
   }
 
   // strong
   strong(params) {
-    if (params.token = this.tokenizer.strong(params.src, params.maskedSrc, params.prevChar)) {
-      params.src = params.src.substring(params.token.raw.length);
-      params.token.tokens = this.inlineTokens(params.token.text, [], params.inLink, params.inRawBlock);
-      params.tokens.push(params.token);
+    let token;
+    if (token = this.tokenizer.strong(params.src, params.maskedSrc, params.prevChar)) {
+      params.src = params.src.substring(token.raw.length);
+      token.tokens = this.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
+      params.tokens.push(token);
       return true;
     }
   }
 
   // em
   em(params) {
-    if (params.token = this.tokenizer.em(params.src, params.maskedSrc, params.prevChar)) {
-      params.src = params.src.substring(params.token.raw.length);
-      params.token.tokens = this.inlineTokens(params.token.text, [], params.inLink, params.inRawBlock);
-      params.tokens.push(params.token);
+    let token;
+    if (token = this.tokenizer.em(params.src, params.maskedSrc, params.prevChar)) {
+      params.src = params.src.substring(token.raw.length);
+      token.tokens = this.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
+      params.tokens.push(token);
       return true;
     }
   }
 
   // code
   codespan(params) {
-    if (params.token = this.tokenizer.codespan(params.src)) {
-      params.src = params.src.substring(params.token.raw.length);
-      params.tokens.push(params.token);
+    let token;
+    if (token = this.tokenizer.codespan(params.src)) {
+      params.src = params.src.substring(token.raw.length);
+      params.tokens.push(token);
       return true;
     }
   }
 
   // br
   br(params) {
-    if (params.token = this.tokenizer.br(params.src)) {
-      params.src = params.src.substring(params.token.raw.length);
-      params.tokens.push(params.token);
+    let token;
+    if (token = this.tokenizer.br(params.src)) {
+      params.src = params.src.substring(token.raw.length);
+      params.tokens.push(token);
       return true;
     }
   }
 
   // del (gfm)
   del(params) {
-    if (params.token = this.tokenizer.del(params.src)) {
-      params.src = params.src.substring(params.token.raw.length);
-      params.token.tokens = this.inlineTokens(params.token.text, [], params.inLink, params.inRawBlock);
-      params.tokens.push(params.token);
+    let token;
+    if (token = this.tokenizer.del(params.src)) {
+      params.src = params.src.substring(token.raw.length);
+      token.tokens = this.inlineTokens(token.text, [], params.inLink, params.inRawBlock);
+      params.tokens.push(token);
       return true;
     }
   }
 
   // autolink
   autolink(params) {
-    if (params.token = this.tokenizer.autolink(params.src, params.mangle)) {
-      params.src = params.src.substring(params.token.raw.length);
-      params.tokens.push(params.token);
+    let token;
+    if (token = this.tokenizer.autolink(params.src, params.mangle)) {
+      params.src = params.src.substring(token.raw.length);
+      params.tokens.push(token);
       return true;
     }
   }
 
   // url (gfm)
   url(params) {
-    if (!params.inLink && (params.token = this.tokenizer.url(params.src, params.mangle))) {
-      params.src = params.src.substring(params.token.raw.length);
-      params.tokens.push(params.token);
+    let token;
+    if (!params.inLink && (token = this.tokenizer.url(params.src, params.mangle))) {
+      params.src = params.src.substring(token.raw.length);
+      params.tokens.push(token);
       return true;
     }
   }
 
   // text
   inlineText(params) {
-    if (params.token = this.tokenizer.inlineText(params.src, params.inRawBlock, params.smartypants)) {
-      params.src = params.src.substring(params.token.raw.length);
-      params.prevChar = params.token.raw.slice(-1);
+    let token;
+    if (token = this.tokenizer.inlineText(params.src, params.inRawBlock, params.smartypants)) {
+      params.src = params.src.substring(token.raw.length);
+      params.prevChar = token.raw.slice(-1);
       params.keepPrevChar = true;
-      params.tokens.push(params.token);
+      params.tokens.push(token);
       return true;
     }
   }
@@ -595,7 +614,7 @@ module.exports = class Lexer {
    * Lexing/Compiling
    */
   inlineTokens(src, tokens = [], inLink = false, inRawBlock = false) {
-    let match, fn;
+    let match;
     let maskedSrc = src;
 
     // Mask out reflinks to avoid interference with em and strong
@@ -622,24 +641,18 @@ module.exports = class Lexer {
       maskedSrc: maskedSrc,
       prevChar: false,
       keepPrevChar: false,
-      token: null,
 
       mangle: mangle,
       smartypants: smartypants
     };
 
-    inlineTokenizerLoop:
     while (inlineParams.src) {
       if (!inlineParams.keepPrevChar) {
         inlineParams.prevChar = '';
       }
       inlineParams.keepPrevChar = false;
 
-      for (fn of this.inlineTokenizers) {
-        if (fn.func.call(this, inlineParams)) {
-          continue inlineTokenizerLoop;
-        }
-      }
+      if (this.inlineTokenizers.some(fn => fn.func.call(this, inlineParams))) continue;
 
       if (inlineParams.src) {
         const errMsg = 'Infinite loop on byte: ' + inlineParams.src.charCodeAt(0);

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -74,37 +74,104 @@ module.exports = class Lexer {
     }
     this.tokenizer.rules = rules;
 
-    this.blockTokenizers = new Map([
-      ['newline', this.newline],
-      ['code', this.code],
-      ['fences', this.fences],
-      ['nptable', this.nptable],
-      ['heading', this.heading],
-      ['hr', this.hr],
-      ['blockquote', this.blockquote],
-      ['list', this.list],
-      ['html', this.html],
-      ['def', this.def],
-      ['table', this.table],
-      ['lheading', this.lheading],
-      ['paragraph', this.paragraph],
-      ['text', this.text]
-    ]);
+// TOO SLOW
+    // this.blockTokenizers = new Map([
+    //   ['newline', this.newline],
+    //   ['code', this.code],
+    //   ['fences', this.fences],
+    //   ['nptable', this.nptable],
+    //   ['heading', this.heading],
+    //   ['hr', this.hr],
+    //   ['blockquote', this.blockquote],
+    //   ['list', this.list],
+    //   ['html', this.html],
+    //   ['def', this.def],
+    //   ['table', this.table],
+    //   ['lheading', this.lheading],
+    //   ['paragraph', this.paragraph],
+    //   ['text', this.text]
+    // ]);
 
-    this.inlineTokenizers = new Map([
-      ['escape', this.escape],
-      ['tag', this.tag],
-      ['link', this.link],
-      ['reflink', this.reflink],
-      ['strong', this.strong],
-      ['em', this.em],
-      ['codespan', this.codespan],
-      ['br', this.br],
-      ['del', this.del],
-      ['autolink', this.autolink],
-      ['url', this.url],
-      ['inlineText', this.inlineText]
-    ]);
+    // this.blockTokenizers = [
+    //   this.newline,
+    //   this.code,
+    //   this.fences,
+    //   this.nptable,
+    //   this.heading,
+    //   this.hr,
+    //   this.blockquote,
+    //   this.list,
+    //   this.html,
+    //   this.def,
+    //   this.table,
+    //   this.lheading,
+    //   this.paragraph,
+    //   this.text
+    // ];
+
+// Array of objects only slightly slower than raw array (~4720 - 4750 ms)
+    this.blockTokenizers = [
+      {name: 'newline', func: this.newline},
+      {name: 'code', func: this.code},
+      {name: 'fences', func: this.fences},
+      {name: 'nptable', func: this.nptable},
+      {name: 'heading', func: this.heading},
+      {name: 'hr', func: this.hr},
+      {name: 'blockquote', func: this.blockquote},
+      {name: 'list', func: this.list},
+      {name: 'html', func: this.html},
+      {name: 'def', func: this.def},
+      {name: 'table', func: this.table},
+      {name: 'lheading', func: this.lheading},
+      {name: 'paragraph', func: this.paragraph},
+      {name: 'text', func: this.text}
+    ];
+
+// TOO SLOW
+    // this.inlineTokenizers = new Map([
+    //   ['escape', this.escape],
+    //   ['tag', this.tag],
+    //   ['link', this.link],
+    //   ['reflink', this.reflink],
+    //   ['strong', this.strong],
+    //   ['em', this.em],
+    //   ['codespan', this.codespan],
+    //   ['br', this.br],
+    //   ['del', this.del],
+    //   ['autolink', this.autolink],
+    //   ['url', this.url],
+    //   ['inlineText', this.inlineText]
+    // ]);
+
+    // this.inlineTokenizers = [
+    //   this.escape,
+    //   this.tag,
+    //   this.link,
+    //   this.reflink,
+    //   this.strong,
+    //   this.em,
+    //   this.codespan,
+    //   this.br,
+    //   this.del,
+    //   this.autolink,
+    //   this.url,
+    //   this.inlineText
+    // ];
+
+    this.inlineTokenizers = [
+      {name: "escape", func: this.escape},
+      {name: "tag",  func: this.tag},
+      {name: "link",  func: this.link},
+      {name: "reflink", func: this.reflink},
+      {name: "strong", func: this.strong},
+      {name: "em", func: this.em},
+      {name: "codespan", func: this.codespan},
+      {name: "br", func: this.br},
+      {name: "del",  func:this.del},
+      {name: "autolink", func: this.autolink},
+      {name: "url", func: this.url},
+      {name: "inlineText", func: this.inlineText}
+    ];
   }
 
   /**
@@ -318,8 +385,8 @@ module.exports = class Lexer {
 
     blockTokenizerLoop:
     while (blockParams.src) {
-      for (fn of this.blockTokenizers.values()) {
-        if (fn.call(this, blockParams)) {
+      for (fn of this.blockTokenizers) {
+        if (fn["func"].call(this, blockParams)) {
           continue blockTokenizerLoop;
         }
       }
@@ -572,8 +639,8 @@ module.exports = class Lexer {
       }
       inlineParams.keepPrevChar = false;
 
-      for (fn of this.inlineTokenizers.values()) {
-        if (fn.call(this, inlineParams)) {
+      for (fn of this.inlineTokenizers) {
+        if (fn["func"].call(this, inlineParams)) {
           continue inlineTokenizerLoop;
         }
       }

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -371,16 +371,16 @@ module.exports = class Lexer {
 
   blockTokens(src, tokens = [], top = true) {
     src = src.replace(/^ +$/gm, '');
-    let token, lastToken, i, l, fn;
+    let fn;
 
     const blockParams = {
       src: src,
       tokens: tokens,
       top: top,
-      token: token,
-      lastToken: lastToken,
-      i: i,
-      l: l
+      token: null,
+      lastToken: null,
+      i: 0,
+      l: 0
     };
 
     blockTokenizerLoop:
@@ -595,14 +595,10 @@ module.exports = class Lexer {
    * Lexing/Compiling
    */
   inlineTokens(src, tokens = [], inLink = false, inRawBlock = false) {
-    let token;
-
-    // String with links masked to avoid interference with em and strong
-    let match;
+    let match, fn;
     let maskedSrc = src;
-    let keepPrevChar, prevChar, fn;
 
-    // Mask out reflinks
+    // Mask out reflinks to avoid interference with em and strong
     if (this.tokens.links) {
       const links = Object.keys(this.tokens.links);
       if (links.length > 0) {
@@ -624,9 +620,9 @@ module.exports = class Lexer {
       inLink: inLink,
       inRawBlock: inRawBlock,
       maskedSrc: maskedSrc,
-      prevChar: prevChar,
-      keepPrevChar: keepPrevChar,
-      token: token,
+      prevChar: false,
+      keepPrevChar: false,
+      token: null,
 
       mangle: mangle,
       smartypants: smartypants

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -79,13 +79,13 @@ module.exports = class Tokenizer {
     }
   }
 
-  code(src, tokens) {
+  code(src, lastToken) {
     const cap = this.rules.block.code.exec(src);
     if (cap) {
-      const lastToken = tokens[tokens.length - 1];
       // An indented code block cannot interrupt a paragraph.
       if (lastToken && lastToken.type === 'paragraph') {
         return {
+          type: 'continue',
           raw: cap[0],
           text: cap[0].trimRight()
         };
@@ -407,12 +407,12 @@ module.exports = class Tokenizer {
     }
   }
 
-  text(src, tokens) {
+  text(src, lastToken) {
     const cap = this.rules.block.text.exec(src);
     if (cap) {
-      const lastToken = tokens[tokens.length - 1];
       if (lastToken && lastToken.type === 'text') {
         return {
+          type: 'continue',
           raw: cap[0],
           text: cap[0]
         };


### PR DESCRIPTION
## Description

At risk of flooding the repo with garbage PRs:

Experimental modification of #1872. This one uses a static Lexer (via #1909) which enables some hacky shenanigans due to the reduced setup overhead when.

The array of Tokenizer functions is serialized via `function.stringify()` and then combined into a single large function that runs just as fast as the original inlined code. Speed issues seem to be totally solved, testing on my own machine.

BUT, I understand this is a weird way to do things and potentially vulnerable to who knows what. The format for custom functions would have to be carefully designed to prevent conflicts in the stringifying/inlining step, e.g. if they define a variable that already exists in one of the other functions, combining them will lead to "variable already exists" errors.

On the other hand, if we could figure out a robust way of doing this, we could further inline other functions that we know execute in a predefined sequence (i.e. the functions in Tokenizer.js) for further speed gains. The entire `blockTokens()` step could be "recompiled" into a single large monolithic function rather than the hundreds of function calls every second.

I think this has potential, but needs a good sanity check from someone else.