### PR TITLE
fix: allow sublist to be single space in pedantic

### DIFF
--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -241,8 +241,11 @@ module.exports = class Tokenizer {
         // Backpedal if it does not belong in this list.
         if (i !== l - 1) {
           bnext = this.rules.block.listItemStart.exec(itemMatch[i + 1]);
-
-          if (bnext[1].length > bcurr[0].length || bnext[1].length > 3) {
+          if (
+            !this.options.pedantic
+              ? bnext[1].length > bcurr[0].length || bnext[1].length > 3
+              : bnext[1].length > bcurr[1].length
+          ) {
             // nested list
             itemMatch.splice(i, 2, itemMatch[i] + '\n' + itemMatch[i + 1]);
             i--;

--- a/test/specs/new/list_align_pedantic.html
+++ b/test/specs/new/list_align_pedantic.html
@@ -1,0 +1,15 @@
+<ul>
+	<li>one
+		<ul>
+			<li>two</li>
+			<li>three</li>
+			<li>four
+				<ul>
+					<li>five</li>
+					<li>six</li>
+					<li>seven</li>
+				</ul>
+			</li>
+		</ul>
+	</li>
+</ul>

--- a/test/specs/new/list_align_pedantic.md
+++ b/test/specs/new/list_align_pedantic.md
@@ -1,0 +1,10 @@
+---
+pedantic: true
+---
+- one
+ - two
+  - three
+    - four
+     - five
+      - six
+       - seven


### PR DESCRIPTION
<!--

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->

**Marked version:** v1.2.8

<!-- The NPM version or commit hash having the issue -->

**Markdown flavor:** Markdown.pl

## Description

Sublists with single space are rendered as sublists in pedantic.

- Fixes #1923

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
