### PR TITLE
fix: Join adjacent inlineText tokens

### DIFF
--- a/docs/USING_PRO.md
+++ b/docs/USING_PRO.md
@@ -157,7 +157,7 @@ console.log(marked('$ latex code $\n\n` other code `'));
 ### Block level tokenizer methods
 
 - space(*string* src)
-- code(*string* src, *array* tokens)
+- code(*string* src)
 - fences(*string* src)
 - heading(*string* src)
 - nptable(*string* src)
@@ -169,7 +169,7 @@ console.log(marked('$ latex code $\n\n` other code `'));
 - table(*string* src)
 - lheading(*string* src)
 - paragraph(*string* src)
-- text(*string* src, *array* tokens)
+- text(*string* src)
 
 ### Inline level tokenizer methods
 

--- a/lib/marked.esm.js
+++ b/lib/marked.esm.js
@@ -1816,11 +1816,10 @@ var Lexer_1 = class Lexer {
         prevChar = token.raw.slice(-1);
         keepPrevChar = true;
         const lastToken = tokens[tokens.length - 1];
-        if(lastToken && lastToken.type === 'text') {
+        if (lastToken && lastToken.type === 'text') {
           lastToken.raw += token.raw;
           lastToken.text += token.text;
-        }
-        else {
+        } else {
           tokens.push(token);
         }
         continue;

--- a/lib/marked.esm.js
+++ b/lib/marked.esm.js
@@ -1815,7 +1815,14 @@ var Lexer_1 = class Lexer {
         src = src.substring(token.raw.length);
         prevChar = token.raw.slice(-1);
         keepPrevChar = true;
-        tokens.push(token);
+        const lastToken = tokens[tokens.length - 1];
+        if(lastToken && lastToken.type === 'text') {
+          lastToken.raw += token.raw;
+          lastToken.text += token.text;
+        }
+        else {
+          tokens.push(token);
+        }
         continue;
       }
 

--- a/lib/marked.esm.js
+++ b/lib/marked.esm.js
@@ -391,18 +391,9 @@ var Tokenizer_1 = class Tokenizer {
     }
   }
 
-  code(src, tokens) {
+  code(src) {
     const cap = this.rules.block.code.exec(src);
     if (cap) {
-      const lastToken = tokens[tokens.length - 1];
-      // An indented code block cannot interrupt a paragraph.
-      if (lastToken && lastToken.type === 'paragraph') {
-        return {
-          raw: cap[0],
-          text: cap[0].trimRight()
-        };
-      }
-
       const text = cap[0].replace(/^ {1,4}/gm, '');
       return {
         type: 'code',
@@ -719,17 +710,9 @@ var Tokenizer_1 = class Tokenizer {
     }
   }
 
-  text(src, tokens) {
+  text(src) {
     const cap = this.rules.block.text.exec(src);
     if (cap) {
-      const lastToken = tokens[tokens.length - 1];
-      if (lastToken && lastToken.type === 'text') {
-        return {
-          raw: cap[0],
-          text: cap[0]
-        };
-      }
-
       return {
         type: 'text',
         raw: cap[0],
@@ -1502,14 +1485,15 @@ var Lexer_1 = class Lexer {
       }
 
       // code
-      if (token = this.tokenizer.code(src, tokens)) {
+      if (token = this.tokenizer.code(src)) {
         src = src.substring(token.raw.length);
-        if (token.type) {
-          tokens.push(token);
-        } else {
-          lastToken = tokens[tokens.length - 1];
+        lastToken = tokens[tokens.length - 1];
+        // An indented code block cannot interrupt a paragraph.
+        if (lastToken && lastToken.type === 'paragraph') {
           lastToken.raw += '\n' + token.raw;
           lastToken.text += '\n' + token.text;
+        } else {
+          tokens.push(token);
         }
         continue;
       }
@@ -1602,14 +1586,14 @@ var Lexer_1 = class Lexer {
       }
 
       // text
-      if (token = this.tokenizer.text(src, tokens)) {
+      if (token = this.tokenizer.text(src)) {
         src = src.substring(token.raw.length);
-        if (token.type) {
-          tokens.push(token);
-        } else {
-          lastToken = tokens[tokens.length - 1];
+        lastToken = tokens[tokens.length - 1];
+        if (lastToken && lastToken.type === 'text') {
           lastToken.raw += '\n' + token.raw;
           lastToken.text += '\n' + token.text;
+        } else {
+          tokens.push(token);
         }
         continue;
       }
@@ -1694,7 +1678,7 @@ var Lexer_1 = class Lexer {
    * Lexing/Compiling
    */
   inlineTokens(src, tokens = [], inLink = false, inRawBlock = false) {
-    let token;
+    let token, lastToken;
 
     // String with links masked to avoid interference with em and strong
     let maskedSrc = src;
@@ -1734,7 +1718,13 @@ var Lexer_1 = class Lexer {
         src = src.substring(token.raw.length);
         inLink = token.inLink;
         inRawBlock = token.inRawBlock;
-        tokens.push(token);
+        const lastToken = tokens[tokens.length - 1];
+        if (lastToken && token.type === 'text' && lastToken.type === 'text') {
+          lastToken.raw += token.raw;
+          lastToken.text += token.text;
+        } else {
+          tokens.push(token);
+        }
         continue;
       }
 
@@ -1751,10 +1741,16 @@ var Lexer_1 = class Lexer {
       // reflink, nolink
       if (token = this.tokenizer.reflink(src, this.tokens.links)) {
         src = src.substring(token.raw.length);
+        const lastToken = tokens[tokens.length - 1];
         if (token.type === 'link') {
           token.tokens = this.inlineTokens(token.text, [], true, inRawBlock);
+          tokens.push(token);
+        } else if (lastToken && token.type === 'text' && lastToken.type === 'text') {
+          lastToken.raw += token.raw;
+          lastToken.text += token.text;
+        } else {
+          tokens.push(token);
         }
-        tokens.push(token);
         continue;
       }
 
@@ -1815,7 +1811,7 @@ var Lexer_1 = class Lexer {
         src = src.substring(token.raw.length);
         prevChar = token.raw.slice(-1);
         keepPrevChar = true;
-        const lastToken = tokens[tokens.length - 1];
+        lastToken = tokens[tokens.length - 1];
         if (lastToken && lastToken.type === 'text') {
           lastToken.raw += token.raw;
           lastToken.text += token.text;

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -488,19 +488,10 @@
       }
     };
 
-    _proto.code = function code(src, tokens) {
+    _proto.code = function code(src) {
       var cap = this.rules.block.code.exec(src);
 
       if (cap) {
-        var lastToken = tokens[tokens.length - 1]; // An indented code block cannot interrupt a paragraph.
-
-        if (lastToken && lastToken.type === 'paragraph') {
-          return {
-            raw: cap[0],
-            text: cap[0].trimRight()
-          };
-        }
-
         var text = cap[0].replace(/^ {1,4}/gm, '');
         return {
           type: 'code',
@@ -812,19 +803,10 @@
       }
     };
 
-    _proto.text = function text(src, tokens) {
+    _proto.text = function text(src) {
       var cap = this.rules.block.text.exec(src);
 
       if (cap) {
-        var lastToken = tokens[tokens.length - 1];
-
-        if (lastToken && lastToken.type === 'text') {
-          return {
-            raw: cap[0],
-            text: cap[0]
-          };
-        }
-
         return {
           type: 'text',
           raw: cap[0],
@@ -1497,15 +1479,15 @@
         } // code
 
 
-        if (token = this.tokenizer.code(src, tokens)) {
+        if (token = this.tokenizer.code(src)) {
           src = src.substring(token.raw.length);
+          lastToken = tokens[tokens.length - 1]; // An indented code block cannot interrupt a paragraph.
 
-          if (token.type) {
-            tokens.push(token);
-          } else {
-            lastToken = tokens[tokens.length - 1];
+          if (lastToken && lastToken.type === 'paragraph') {
             lastToken.raw += '\n' + token.raw;
             lastToken.text += '\n' + token.text;
+          } else {
+            tokens.push(token);
           }
 
           continue;
@@ -1603,15 +1585,15 @@
         } // text
 
 
-        if (token = this.tokenizer.text(src, tokens)) {
+        if (token = this.tokenizer.text(src)) {
           src = src.substring(token.raw.length);
+          lastToken = tokens[tokens.length - 1];
 
-          if (token.type) {
-            tokens.push(token);
-          } else {
-            lastToken = tokens[tokens.length - 1];
+          if (lastToken && lastToken.type === 'text') {
             lastToken.raw += '\n' + token.raw;
             lastToken.text += '\n' + token.text;
+          } else {
+            tokens.push(token);
           }
 
           continue;
@@ -1718,7 +1700,7 @@
         inRawBlock = false;
       }
 
-      var token; // String with links masked to avoid interference with em and strong
+      var token, lastToken; // String with links masked to avoid interference with em and strong
 
       var maskedSrc = src;
       var match;
@@ -1759,7 +1741,15 @@
           src = src.substring(token.raw.length);
           inLink = token.inLink;
           inRawBlock = token.inRawBlock;
-          tokens.push(token);
+          var _lastToken = tokens[tokens.length - 1];
+
+          if (_lastToken && token.type === 'text' && _lastToken.type === 'text') {
+            _lastToken.raw += token.raw;
+            _lastToken.text += token.text;
+          } else {
+            tokens.push(token);
+          }
+
           continue;
         } // link
 
@@ -1778,12 +1768,18 @@
 
         if (token = this.tokenizer.reflink(src, this.tokens.links)) {
           src = src.substring(token.raw.length);
+          var _lastToken2 = tokens[tokens.length - 1];
 
           if (token.type === 'link') {
             token.tokens = this.inlineTokens(token.text, [], true, inRawBlock);
+            tokens.push(token);
+          } else if (_lastToken2 && token.type === 'text' && _lastToken2.type === 'text') {
+            _lastToken2.raw += token.raw;
+            _lastToken2.text += token.text;
+          } else {
+            tokens.push(token);
           }
 
-          tokens.push(token);
           continue;
         } // strong
 
@@ -1844,7 +1840,7 @@
           src = src.substring(token.raw.length);
           prevChar = token.raw.slice(-1);
           keepPrevChar = true;
-          var lastToken = tokens[tokens.length - 1];
+          lastToken = tokens[tokens.length - 1];
 
           if (lastToken && lastToken.type === 'text') {
             lastToken.raw += token.raw;

--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1844,7 +1844,15 @@
           src = src.substring(token.raw.length);
           prevChar = token.raw.slice(-1);
           keepPrevChar = true;
-          tokens.push(token);
+          var lastToken = tokens[tokens.length - 1];
+
+          if (lastToken && lastToken.type === 'text') {
+            lastToken.raw += token.raw;
+            lastToken.text += token.text;
+          } else {
+            tokens.push(token);
+          }
+
           continue;
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1337,9 +1337,9 @@
       }
     },
     "@rollup/plugin-babel": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.2.2.tgz",
-      "integrity": "sha512-MjmH7GvFT4TW8xFdIeFS3wqIX646y5tACdxkTO+khbHvS3ZcVJL6vkAHLw2wqPmkhwCfWHoNsp15VYNwW6JEJA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.2.3.tgz",
+      "integrity": "sha512-DOMc7nx6y5xFi86AotrFssQqCen6CxYn+zts5KSI879d4n1hggSb4TH3mjVgG17Vc3lZziWWfcXzrEmVdzPMdw==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.10.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8451,9 +8451,9 @@
       }
     },
     "rollup": {
-      "version": "2.38.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.38.0.tgz",
-      "integrity": "sha512-ay9zDiNitZK/LNE/EM2+v5CZ7drkB2xyDljvb1fQJCGnq43ZWRkhxN145oV8GmoW1YNi4sA/1Jdkr2LfawJoXw==",
+      "version": "2.38.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.38.2.tgz",
+      "integrity": "sha512-3Sg65zfgqsnI2LUFsOmhJDvTWXwio+taySq/dsyvel8+GW+AxeW9V6YZG8BpVGQk/TS4uvGLARRH5T3ygDyyNQ==",
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3179,9 +3179,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz",
+      "integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
       "dev": true,
       "optional": true
     },
@@ -8451,12 +8451,12 @@
       }
     },
     "rollup": {
-      "version": "2.38.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.38.2.tgz",
-      "integrity": "sha512-3Sg65zfgqsnI2LUFsOmhJDvTWXwio+taySq/dsyvel8+GW+AxeW9V6YZG8BpVGQk/TS4uvGLARRH5T3ygDyyNQ==",
+      "version": "2.38.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.38.3.tgz",
+      "integrity": "sha512-FVx/XzR2DtCozKNDBjHJCHIgkC12rNg/ruAeoYWjLeeKfSKgwhh+lDLDhuCkuRG/fsup8py8dKBTlHdvUFX32A==",
       "dev": true,
       "requires": {
-        "fsevents": "~2.1.2"
+        "fsevents": "~2.3.1"
       }
     },
     "rollup-plugin-license": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "jasmine": "^3.6.4",
     "markdown-it": "12.0.4",
     "node-fetch": "^2.6.1",
-    "rollup": "^2.38.0",
+    "rollup": "^2.38.2",
     "rollup-plugin-license": "^2.2.0",
     "semantic-release": "^17.3.7",
     "titleize": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "jasmine": "^3.6.4",
     "markdown-it": "12.0.4",
     "node-fetch": "^2.6.1",
-    "rollup": "^2.38.2",
+    "rollup": "^2.38.3",
     "rollup-plugin-license": "^2.2.0",
     "semantic-release": "^17.3.7",
     "titleize": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/core": "^7.12.10",
     "@babel/preset-env": "^7.12.11",
     "@markedjs/html-differ": "^3.0.4",
-    "@rollup/plugin-babel": "^5.2.2",
+    "@rollup/plugin-babel": "^5.2.3",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@semantic-release/commit-analyzer": "^8.0.1",
     "@semantic-release/git": "^9.0.0",

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -452,7 +452,13 @@ module.exports = class Lexer {
         src = src.substring(token.raw.length);
         prevChar = token.raw.slice(-1);
         keepPrevChar = true;
-        tokens.push(token);
+        const lastToken = tokens[tokens.length - 1];
+        if (lastToken && lastToken.type === 'text') {
+          lastToken.raw += token.raw;
+          lastToken.text += token.text;
+        } else {
+          tokens.push(token);
+        }
         continue;
       }
 

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -136,14 +136,15 @@ module.exports = class Lexer {
       }
 
       // code
-      if (token = this.tokenizer.code(src, tokens)) {
+      if (token = this.tokenizer.code(src)) {
         src = src.substring(token.raw.length);
-        if (token.type) {
-          tokens.push(token);
-        } else {
-          lastToken = tokens[tokens.length - 1];
+        lastToken = tokens[tokens.length - 1];
+        // An indented code block cannot interrupt a paragraph.
+        if (lastToken && lastToken.type === 'paragraph') {
           lastToken.raw += '\n' + token.raw;
           lastToken.text += '\n' + token.text;
+        } else {
+          tokens.push(token);
         }
         continue;
       }
@@ -331,7 +332,7 @@ module.exports = class Lexer {
    * Lexing/Compiling
    */
   inlineTokens(src, tokens = [], inLink = false, inRawBlock = false) {
-    let token;
+    let token, lastToken;
 
     // String with links masked to avoid interference with em and strong
     let maskedSrc = src;
@@ -464,7 +465,7 @@ module.exports = class Lexer {
         src = src.substring(token.raw.length);
         prevChar = token.raw.slice(-1);
         keepPrevChar = true;
-        const lastToken = tokens[tokens.length - 1];
+        lastToken = tokens[tokens.length - 1];
         if (lastToken && lastToken.type === 'text') {
           lastToken.raw += token.raw;
           lastToken.text += token.text;

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -79,18 +79,9 @@ module.exports = class Tokenizer {
     }
   }
 
-  code(src, tokens) {
+  code(src) {
     const cap = this.rules.block.code.exec(src);
     if (cap) {
-      const lastToken = tokens[tokens.length - 1];
-      // An indented code block cannot interrupt a paragraph.
-      if (lastToken && lastToken.type === 'paragraph') {
-        return {
-          raw: cap[0],
-          text: cap[0].trimRight()
-        };
-      }
-
       const text = cap[0].replace(/^ {1,4}/gm, '');
       return {
         type: 'code',


### PR DESCRIPTION
**Marked version:** 1.2.9

## Description

- Fixes #1906. Joins together adjacent inline `text` tokens similar to how block text tokens are merged. HTML output doesn't change, but this makes it easier to make a custom renderer since text tokens aren't broken up.

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
