### PR TITLE
docs: warn about broken inline latex example

### DIFF
--- a/docs/USING_PRO.md
+++ b/docs/USING_PRO.md
@@ -153,6 +153,7 @@ console.log(marked('$ latex code $\n\n` other code `'));
 <p><code>latex code</code></p>
 <p><code>other code</code></p>
 ```
+**NOTE**: This does not fully support latex, see issue [#1948](https://github.com/markedjs/marked/issues/1948).
 
 ### Block level tokenizer methods
 


### PR DESCRIPTION
The docs don't mention how the latex example won't actually work with inline latex, ie. `foo $bar$ baz`.

Not a fix, Just wanted to clarify docs to save debugging time until #1948 is fixed.