### PR TITLE
docs: fix demo initial options not loaded

### DIFF
--- a/docs/demo/worker.js
+++ b/docs/demo/worker.js
@@ -42,6 +42,7 @@ function parse(e) {
         }
       }
       postMessage({
+        id: e.data.id,
         task: e.data.task,
         defaults: defaults
       });
@@ -53,6 +54,7 @@ function parse(e) {
       var parsed = marked.parser(lexed, e.data.options);
       var endTime = new Date();
       postMessage({
+        id: e.data.id,
         task: e.data.task,
         lexed: lexedList,
         parsed: parsed,


### PR DESCRIPTION
**Marked version:** docs

## Description

Fix default options not loaded before initial markdown parsed in demo.

- Fixes #1982

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
