### PR TITLE
Add a `type` property to the `def` tokenizer's return object  - again

### DIFF
--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -347,6 +347,7 @@ module.exports = class Tokenizer {
       if (cap[3]) cap[3] = cap[3].substring(1, cap[3].length - 1);
       const tag = cap[1].toLowerCase().replace(/\s+/g, ' ');
       return {
+        type: 'def',
         tag,
         raw: cap[0],
         href: cap[2],


### PR DESCRIPTION
Hmm I think I modified the wrong file (`lib/marked.js`) in the previous PR (see https://github.com/markedjs/marked/pull/2001) , this should be the right one ! Sorry for that.



**Marked version:**

2.0.2

**Markdown flavor:** Markdown.pl|CommonMark|GitHub Flavored Markdown|n/a

## Description

- Fixes https://github.com/markedjs/marked/issues/2000


## Expectation

Markdown nodes all have a `type` property to ease working with the markdown tree.

## Result

`def` nodes do not have a `type` property. 

## What was attempted

Using `walkTokens` in typescript, I have the need to discriminate between nodes; the https://www.npmjs.com/package/@types/marked package doesn't define a `type` member for the `Def` interface, seemingly because there is not one here either.


## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
