### PR TITLE
docs: update highlight.js usage

### DIFF
--- a/build-docs.js
+++ b/build-docs.js
@@ -36,11 +36,11 @@ async function build(currentDir, tmpl) {
       const parsed = parse(filename);
       if (parsed.ext === '.md' && isUppercase(parsed.name)) {
         const html = marked(buffer.toString('utf8'), {
-          highlight: (code, lang) => {
-            if (!lang) {
+          highlight: (code, language) => {
+            if (!language) {
               return highlightAuto(code).value;
             }
-            return highlight(lang, code).value;
+            return highlight(code, { language }).value;
           }
         });
         buffer = Buffer.from(tmpl

--- a/docs/USING_ADVANCED.md
+++ b/docs/USING_ADVANCED.md
@@ -17,13 +17,13 @@ marked(markdownString [,options] [,callback])
 const marked = require('marked');
 
 // Set options
-// `highlight` example uses `highlight.js`
+// `highlight` example uses https://highlightjs.org
 marked.setOptions({
   renderer: new marked.Renderer(),
-  highlight: function(code, language) {
+  highlight: function(code, lang) {
     const hljs = require('highlight.js');
-    const validLanguage = hljs.getLanguage(language) ? language : 'plaintext';
-    return hljs.highlight(validLanguage, code).value;
+    const language = hljs.getLanguage(lang) ? lang : 'plaintext';
+    return hljs.highlight(code, { language }).value;
   },
   pedantic: false,
   gfm: true,


### PR DESCRIPTION
## Description

Fixes deprecated usage of highlight.js in the docs, see https://github.com/highlightjs/highlight.js/issues/2277

[Preview Docs →](https://markedjs-git-docs-highlightjs-usage-markedjs.vercel.app/using_advanced)

## Contributor

- [x] no tests required for this PR.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
