### PR TITLE
[WIP] extensible Parser: separate methods for token types

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -244,6 +244,10 @@ function repeatString(pattern, count) {
   return result + pattern;
 }
 
+function isFun(val) {
+  return typeof val === 'function';
+}
+
 module.exports = {
   escape,
   unescape,
@@ -256,5 +260,6 @@ module.exports = {
   rtrim,
   findClosingBracket,
   checkSanitizeDeprecation,
-  repeatString
+  repeatString,
+  isFun
 };

--- a/src/marked.js
+++ b/src/marked.js
@@ -233,7 +233,7 @@ marked.parseInline = function(src, opt) {
     if (opt.walkTokens) {
       marked.walkTokens(tokens, opt.walkTokens);
     }
-    return Parser.parseInline(tokens, opt);
+    return Parser.parse(tokens, opt);
   } catch (e) {
     e.message += '\nPlease report this to https://github.com/markedjs/marked.';
     if (opt.silent) {


### PR DESCRIPTION
This branch is **not yet ready for merge**; see known regressions below.

Logic for different token types has been moved from switch cases to methods. The main parse loop now simply looks up the method by token type, falling back on `default()`.

Token types are now an open set, rather than a closed set. New token types can be supported by subclassing Parser and adding corresponding methods, or by overriding `default()`.

Consolidated the parsing logic for "top" and "inline" tokens. Removed `parser.parseInline`. The top-level function `parseInline` uses `lexer.lexInline` to generate an appropriate AST; additional restrictions at the parser level appear redundant.

More flexible approach to "contextual" parsing logic, such as using a different renderer or indicating "loose" mode. Now every parse method takes an additional parameter: a "context", which contains a renderer and possibly other settings. By default, such context objects are allocated lazily and no more than once per Parser. The method signatures make it possible to use context inheritance, where child contexts inherit from parent contexts, overriding only some of their properties. This is not used by default, but can be useful for advanced cases such as one described in #2033.

Benchmarks indicate no significant performance regressions or improvements. Differences appear to be within noise levels.

Known regressions that must be fixed before merging the MR:

  * No support for coalescing adjacent `text` nodes.
  * List "loose" mode, with paragraph wrapping, is now a placeholder with incorrect logic.
  * Fewer tests pass, presumably as a result of ↑.

Addresses [#2033](https://github.com/markedjs/marked/issues/2033).

---

Requesting feedback on:

  * Good ways to recover the "text coalesce" functionality, where adjacent text nodes would be joined by `\n`.
  * Good ways to recover the feature where in loose-mode lists text would sometimes be wrapped into paragraphs.
  * Possibly anything else I've overlooked.

The reason for the above regression is that the main parse loop has been split, is no longer "aware" of token types, and has no special cases. I really want to keep it this way.