### PR TITLE
fix walkTokens not called on async marked call

### DIFF
--- a/src/marked.js
+++ b/src/marked.js
@@ -51,6 +51,9 @@ function marked(src, opt, callback) {
 
       if (!err) {
         try {
+          if (opt.walkTokens) {
+            marked.walkTokens(tokens, opt.walkTokens);
+          }
           out = Parser.parse(tokens, opt);
         } catch (e) {
           err = e;

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -183,6 +183,20 @@ describe('use extension', () => {
     expect(walked).toBe(2);
   });
 
+  it('should use walkTokens in async', (done) => {
+    let walked = 0;
+    const extension = {
+      walkTokens(token) {
+        walked++;
+      }
+    };
+    marked.use(extension);
+    marked('text', () => {
+      expect(walked).toBe(2);
+      done();
+    });
+  });
+
   it('should use options from extension', () => {
     const extension = {
       headerIds: false


### PR DESCRIPTION
**Marked version:** master

## Description

`walkTokens` option was is not called when calling marked with a callback function.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
