### PR TITLE
Remove nptable tokenizer

### DIFF
--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -176,13 +176,6 @@ module.exports = class Lexer {
         continue;
       }
 
-      // table no leading pipe (gfm)
-      if (token = this.tokenizer.nptable(src)) {
-        src = src.substring(token.raw.length);
-        tokens.push(token);
-        continue;
-      }
-
       // hr
       if (token = this.tokenizer.hr(src)) {
         src = src.substring(token.raw.length);

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -134,42 +134,6 @@ module.exports = class Tokenizer {
     }
   }
 
-  nptable(src) {
-    const cap = this.rules.block.nptable.exec(src);
-    if (cap) {
-      const item = {
-        type: 'table',
-        header: splitCells(cap[1].replace(/^ *| *\| *$/g, '')),
-        align: cap[2].replace(/^ *|\| *$/g, '').split(/ *\| */),
-        cells: cap[3] ? cap[3].replace(/\n$/, '').split('\n') : [],
-        raw: cap[0]
-      };
-
-      if (item.header.length === item.align.length) {
-        let l = item.align.length;
-        let i;
-        for (i = 0; i < l; i++) {
-          if (/^ *-+: *$/.test(item.align[i])) {
-            item.align[i] = 'right';
-          } else if (/^ *:-+: *$/.test(item.align[i])) {
-            item.align[i] = 'center';
-          } else if (/^ *:-+ *$/.test(item.align[i])) {
-            item.align[i] = 'left';
-          } else {
-            item.align[i] = null;
-          }
-        }
-
-        l = item.cells.length;
-        for (i = 0; i < l; i++) {
-          item.cells[i] = splitCells(item.cells[i], item.header.length);
-        }
-
-        return item;
-      }
-    }
-  }
-
   hr(src) {
     const cap = this.rules.block.hr.exec(src);
     if (cap) {
@@ -357,7 +321,8 @@ module.exports = class Tokenizer {
   }
 
   table(src) {
-    const cap = this.rules.block.table.exec(src);
+    const cap = this.rules.block.table.exec(src)
+             || this.rules.block.nptable.exec(src);
     if (cap) {
       const item = {
         type: 'table',
@@ -385,9 +350,7 @@ module.exports = class Tokenizer {
 
         l = item.cells.length;
         for (i = 0; i < l; i++) {
-          item.cells[i] = splitCells(
-            item.cells[i].replace(/^ *\| *| *\| *$/g, ''),
-            item.header.length);
+          item.cells[i] = splitCells(item.cells[i], item.header.length);
         }
 
         return item;

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -321,8 +321,7 @@ module.exports = class Tokenizer {
   }
 
   table(src) {
-    const cap = this.rules.block.table.exec(src)
-             || this.rules.block.nptable.exec(src);
+    const cap = this.rules.block.table.exec(src);
     if (cap) {
       const item = {
         type: 'table',

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -160,6 +160,10 @@ function splitCells(tableRow, count) {
     cells = row.split(/ \|/);
   let i = 0;
 
+  // First/last cell in a row cannot be empty if it has no leading/trailing pipe
+  if (!cells[0].trim()) { cells.shift(); }
+  if (!cells[cells.length - 1].trim()) { cells.pop(); }
+
   if (cells.length > count) {
     cells.splice(count);
   } else {

--- a/src/rules.js
+++ b/src/rules.js
@@ -26,7 +26,6 @@ const block = {
     + '|</(?!script|pre|style|textarea)[a-z][\\w-]*\\s*>(?=[ \\t]*(?:\\n|$))[\\s\\S]*?(?:(?:\\n *)+\\n|$)' // (7) closing tag
     + ')',
   def: /^ {0,3}\[(label)\]: *\n? *<?([^\s>]+)>?(?:(?: +\n? *| *\n *)(title))? *(?:\n+|$)/,
-  nptable: noopTest,
   table: noopTest,
   lheading: /^([^\n]+)\n {0,3}(=+|-+) *(?:\n+|$)/,
   // regex template, placeholders will be replaced according to different paragraph
@@ -97,24 +96,10 @@ block.normal = merge({}, block);
  */
 
 block.gfm = merge({}, block.normal, {
-  nptable: '^ *([^|\\n ].*\\|.*)\\n' // Header
-    + ' {0,3}([-:]+ *\\|[-| :]*)' // Align
-    + '(?:\\n((?:(?!\\n|hr|heading|blockquote|code|fences|list|html).*(?:\\n|$))*)\\n*|$)', // Cells
-  table: '^ *\\|(.+)\\n' // Header
-    + ' {0,3}\\|?( *[-:]+[-| :]*)' // Align
+  table: '^ *([^\\n ].*\\|.*)\\n' // Header
+    + ' {0,3}(?:\\| *)?(:?-+:? *(?:\\| *:?-+:? *)*)\\|?' // Align
     + '(?:\\n *((?:(?!\\n|hr|heading|blockquote|code|fences|list|html).*(?:\\n|$))*)\\n*|$)' // Cells
 });
-
-block.gfm.nptable = edit(block.gfm.nptable)
-  .replace('hr', block.hr)
-  .replace('heading', ' {0,3}#{1,6} ')
-  .replace('blockquote', ' {0,3}>')
-  .replace('code', ' {4}[^\\n]')
-  .replace('fences', ' {0,3}(?:`{3,}(?=[^`\\n]*\\n)|~{3,})[^\\n]*\\n')
-  .replace('list', ' {0,3}(?:[*+-]|1[.)]) ') // only lists starting from 1 can interrupt
-  .replace('html', '</?(?:tag)(?: +|\\n|/?>)|<(?:script|pre|style|textarea|!--)')
-  .replace('tag', block._tag) // tables can be interrupted by type (6) html blocks
-  .getRegex();
 
 block.gfm.table = edit(block.gfm.table)
   .replace('hr', block.hr)

--- a/test/specs/new/table_cells.html
+++ b/test/specs/new/table_cells.html
@@ -16,7 +16,7 @@
 
 <table><thead><tr><th>1</th><th>2</th></tr></thead><tbody><tr><td>1|\</td><td>2|\</td></tr></tbody></table>
 
-<table><thead><tr><th>1</th><th>2</th></tr></thead><tbody><tr><td></td><td>2</td></tr></tbody></table>
+<table><thead><tr><th>1</th><th>2</th></tr></thead><tbody><tr><td>2</td><td></td></tr></tbody></table>
 
 <table><thead><tr><th>1</th><th>2</th></tr></thead><tbody><tr><td>1</td><td>2|</td></tr></tbody></table>
 


### PR DESCRIPTION
`nptable` tokenizer is 95% identical to `table`, except for handling a weird edge case.  This PR moves that special case to be handled in splitCells() to reduce code redundancy and improve speed (one less tokenizer to cycle through).

Also corrects one `new` test that did not follow the correct behavior compared to actual Github behavior: If a row of cells is missing the leading\trailing pipe, then the leading\trailing cell cannot be empty.

(this is also just some cleanup in prep for #2124, since moving things into the Tokenizer was resulting in large duplicated blocks in each both `table` and `nptable`)

```
 A | B
-- | --
   | 2
```

Results in:
   
 A | B
-- | --
   | 2
   
   
### Current Master Benchmark
```
es5 marked completed in 4795ms and passed 86.66%
es6 marked completed in 4803ms and passed 86.66%
es5 marked (gfm) completed in 5162ms and passed 86.04%
es6 marked (gfm) completed in 5227ms and passed 86.04%
es5 marked (pedantic) completed in 4980ms and passed 70.86%
es6 marked (pedantic) completed in 5040ms and passed 70.86%
```

### This PR Benchmark
```
es5 marked completed in 4673ms and passed 86.66%
es6 marked completed in 4777ms and passed 86.66%
es5 marked (gfm) completed in 4850ms and passed 86.04%
es6 marked (gfm) completed in 4985ms and passed 86.04%
es5 marked (pedantic) completed in 4774ms and passed 70.86%
es6 marked (pedantic) completed in 4922ms and passed 70.86%
```

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ]  no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
