### PR TITLE
drop node 10 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # lowest verison here should also be in `engines` field
-        node_version: [10, 12, 'lts/*', 'node']
+        node_version: [12, 'lts/*', 'node']
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code

--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
     "preversion": "npm run build && (git diff --quiet || git commit -am build)"
   },
   "engines": {
-    "node": ">= 10"
+    "node": ">= 12"
   }
 }


### PR DESCRIPTION
## Description

Drop support for node 10 in v3

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
