### PR TITLE
chore(docs): Use `langPrefix` in `highlight.js` example.

### DIFF
--- a/docs/USING_ADVANCED.md
+++ b/docs/USING_ADVANCED.md
@@ -25,6 +25,7 @@ marked.setOptions({
     const language = hljs.getLanguage(lang) ? lang : 'plaintext';
     return hljs.highlight(code, { language }).value;
   },
+  langPrefix: 'hljs language-', // highlight.js css expects a top-level 'hljs' class.
   pedantic: false,
   gfm: true,
   breaks: false,


### PR DESCRIPTION
To properly integrate [highlight.js](https://github.com/highlightjs/highlight.js/) when using `marked.setOptions`, you need to leverage `langPrefix` to add an additional `hljs` class to the top-level `<code>` element which will be rendered.

Closes #2171
