### PR TITLE
fix: fix gfm urls after link

### DIFF
--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -13,7 +13,7 @@ function outputLink(cap, link, raw, lexer) {
 
   if (cap[0].charAt(0) !== '!') {
     lexer.state.inLink = true;
-    return {
+    const token = {
       type: 'link',
       raw,
       href,
@@ -21,6 +21,8 @@ function outputLink(cap, link, raw, lexer) {
       text,
       tokens: lexer.inlineTokens(text, [])
     };
+    lexer.state.inLink = false;
+    return token;
   } else {
     return {
       type: 'image',

--- a/test/specs/new/autolink_after_link.html
+++ b/test/specs/new/autolink_after_link.html
@@ -1,0 +1,3 @@
+<p><a href="https://github.com">Github</a></p>
+
+<p><a href="https://github.com">https://github.com</a></p>

--- a/test/specs/new/autolink_after_link.md
+++ b/test/specs/new/autolink_after_link.md
@@ -1,0 +1,6 @@
+---
+gfm: true
+---
+[Github](https://github.com)
+
+https://github.com


### PR DESCRIPTION
**Marked version:** 3.0.0

<!-- The NPM version or commit hash having the issue -->

**Markdown flavor:** GitHub Flavored Markdown

## Description

`inLink` state is not reset after creating a link token so GFM auto-urls are not being tokenized as links.

- Fixes #2180 

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
