### PR TITLE
fix: stop table at lines with only whitespace

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -93,7 +93,7 @@ block.normal = merge({}, block);
 block.gfm = merge({}, block.normal, {
   table: '^ *([^\\n ].*\\|.*)\\n' // Header
     + ' {0,3}(?:\\| *)?(:?-+:? *(?:\\| *:?-+:? *)*)\\|?' // Align
-    + '(?:\\n *((?:(?!\\n|hr|heading|blockquote|code|fences|list|html).*(?:\\n|$))*)\\n*|$)' // Cells
+    + '(?:\\n((?:(?! *\\n|hr|heading|blockquote|code|fences|list|html).*(?:\\n|$))*)\\n*|$)' // Cells
 });
 
 block.gfm.table = edit(block.gfm.table)

--- a/test/specs/new/space_after_table.html
+++ b/test/specs/new/space_after_table.html
@@ -14,4 +14,3 @@
 </table>
 
 <p>there should be a single space in the line above</p>
-    

--- a/test/specs/new/space_after_table.html
+++ b/test/specs/new/space_after_table.html
@@ -1,0 +1,17 @@
+<table>
+  <thead>
+    <tr>
+      <th>a</th>
+      <th>b</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>1</td>
+      <td>2</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>there should be a single space in the line above</p>
+    

--- a/test/specs/new/space_after_table.md
+++ b/test/specs/new/space_after_table.md
@@ -1,0 +1,8 @@
+---
+gfm: true
+---
+| a | b |
+|---|---|
+| 1 | 2 |
+ 
+there should be a single space in the line above


### PR DESCRIPTION
**Marked version:** 3.0.1

**Markdown flavor:** GitHub Flavored Markdown

## Description

fix blank line with only whitespace after table

- Fixes #2187

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
