### PR TITLE
fix: revert #2223

### DIFF
--- a/src/marked.js
+++ b/src/marked.js
@@ -335,12 +335,3 @@ marked.Slugger = Slugger;
 marked.parse = marked;
 
 module.exports = marked;
-module.exports.parse = marked;
-module.exports.Parser = Parser;
-module.exports.parser = Parser.parse;
-module.exports.Renderer = Renderer;
-module.exports.TextRenderer = TextRenderer;
-module.exports.Lexer = Lexer;
-module.exports.lexer = Lexer.lex;
-module.exports.Tokenizer = Tokenizer;
-module.exports.Slugger = Slugger;


### PR DESCRIPTION
It seems like #2223 turned lib/marked.js into a ES Module which would be a breaking change.

This reverts #2223