### PR TITLE
Docs: Nowrap on list elements

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -80,11 +80,14 @@ td, th {
 a {
     color: #0366d6;
     text-decoration: none;
-    white-space: nowrap;
 }
 
 a:hover {
     text-decoration: underline;
+}
+
+nav a {
+    white-space: nowrap;
 }
 
 pre {


### PR DESCRIPTION
Simply makes a styling change to the docs to prevent this:

![Screenshot from 2021-10-14 18-38-05](https://user-images.githubusercontent.com/53054099/137418587-c5e5998f-65df-46f7-8442-007534c07b3a.png)
