### PR TITLE
fix: walkTokens uses marked as this

### DIFF
--- a/docs/USING_PRO.md
+++ b/docs/USING_PRO.md
@@ -406,19 +406,21 @@ const description = {
     return `\n<dt>${this.parser.parseInline(token.dt)}</dt><dd>${this.parser.parseInline(token.dd)}</dd>`;
   },
   childTokens: ['dt', 'dd'],                 // Any child tokens to be visited by walkTokens
-  walkTokens(token) {                        // Post-processing on the completed token tree
-    if (token.type === 'strong') {
-      token.text += ' walked';
-    }
-  }
 };
 
-marked.use({ extensions: [descriptionlist, description] });
+function walkTokens(token) {                        // Post-processing on the completed token tree
+  if (token.type === 'strong') {
+    token.text += ' walked';
+    token.tokens = this.Lexer.lexInline(token.text)
+  }
+}
+marked.use({ extensions: [descriptionlist, description], walkTokens });
 
-\\ EQUIVALENT TO:
+// EQUIVALENT TO:
 
-marked.use({extensions: [descriptionList] });
-marked.use({extensions: [description]     });
+marked.use({ extensions: [descriptionList] });
+marked.use({ extensions: [description]     });
+marked.use({ walkTokens })
 
 console.log(marked('A Description List:\n'
                  + ':   Topic 1   :  Description 1\n'

--- a/src/marked.js
+++ b/src/marked.js
@@ -235,10 +235,10 @@ marked.use = function(...args) {
     // ==-- Parse WalkTokens extensions --== //
     if (pack.walkTokens) {
       const walkTokens = marked.defaults.walkTokens;
-      opts.walkTokens = (token) => {
+      opts.walkTokens = function(token) {
         pack.walkTokens.call(this, token);
         if (walkTokens) {
-          walkTokens(token);
+          walkTokens.call(this, token);
         }
       };
     }
@@ -257,7 +257,7 @@ marked.use = function(...args) {
 
 marked.walkTokens = function(tokens, callback) {
   for (const token of tokens) {
-    callback(token);
+    callback.call(marked, token);
     switch (token.type) {
       case 'table': {
         for (const cell of token.header) {

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -1046,4 +1046,16 @@ br
       ['text', 'br']
     ]);
   });
+
+  it('should asign marked to `this`', () => {
+    marked.use({
+      walkTokens(token) {
+        if (token.type === 'em') {
+          token.text += ' walked';
+          token.tokens = this.Lexer.lexInline(token.text);
+        }
+      }
+    });
+    expect(marked('*text*').trim()).toBe('<p><em>text walked</em></p>');
+  });
 });


### PR DESCRIPTION
<!--

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->

**Marked version:** 3.0.7

<!-- The NPM version or commit hash having the issue -->

## Description

`walkTokens` should have `this` be the marked object so it can be used in the function.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
