### PR TITLE
fix: Set commonJS code as `main` in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Christopher Jeffrey",
   "version": "4.0.0",
   "type": "module",
-  "main": "./lib/marked.esm.js",
+  "main": "./lib/marked.cjs",
   "module": "./lib/marked.esm.js",
   "browser": "./lib/marked.cjs",
   "bin": {


### PR DESCRIPTION
Change `main` to point to `./lib/marked.cjs` instead of `./lib/marked.esm.js` for compatibility with 'other' loaders (eg jest) in a non-ES module environment.

This was tested in an ESM repo both directly (node) and under jest with no problems.

**Marked version:**
4.0.0

## Description

- Fixes #2274 

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
