### PR TITLE
fix: avoid linefeed errors running tests on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
+* eol=lf
 test/* linguist-vendored
 


### PR DESCRIPTION
Some tests fail on windows due to `\r\n` vs `\n`:
code_compensation_indent
code_consistent_newline
whiltespace_lines (sic)

Updated .gitattributes to preserve the `eol` value.

Files in test/specs/new were refreshed to have new attributes applied prior to testing.  No failures were reported.

**Marked version:**
n/a

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or, 
- [] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).

Updated title to clarify this only applies to running the test suite and not general usage.