### PR TITLE
Make No Empty Line Required Before GFM Tables

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -30,7 +30,7 @@ export const block = {
   lheading: /^([^\n]+)\n {0,3}(=+|-+) *(?:\n+|$)/,
   // regex template, placeholders will be replaced according to different paragraph
   // interruption rules of commonmark and the original markdown spec:
-  _paragraph: /^([^\n]+(?:\n(?!hr|heading|lheading|blockquote|fences|list|html| +\n)[^\n]+)*)/,
+  _paragraph: /^([^\n]+(?:\n(?!hr|heading|lheading|blockquote|fences|list|html|table| +\n)[^\n]+)*)/,
   text: /^[^\n]+/
 };
 
@@ -69,6 +69,7 @@ block.paragraph = edit(block._paragraph)
   .replace('hr', block.hr)
   .replace('heading', ' {0,3}#{1,6} ')
   .replace('|lheading', '') // setex headings don't interrupt commonmark paragraphs
+  .replace('|table', '')
   .replace('blockquote', ' {0,3}>')
   .replace('fences', ' {0,3}(?:`{3,}(?=[^`\\n]*\\n)|~{3,})[^\\n]*\\n')
   .replace('list', ' {0,3}(?:[*+-]|1[.)]) ') // only lists starting from 1 can interrupt
@@ -107,6 +108,17 @@ block.gfm.table = edit(block.gfm.table)
   .replace('tag', block._tag) // tables can be interrupted by type (6) html blocks
   .getRegex();
 
+block.gfm.paragraph = edit(block._paragraph)
+  .replace('hr', block.hr)
+  .replace('heading', ' {0,3}#{1,6} ')
+  .replace('|lheading', '') // setex headings don't interrupt commonmark paragraphs
+  .replace('table', block.gfm.table) // interrupt paragraphs with table
+  .replace('blockquote', ' {0,3}>')
+  .replace('fences', ' {0,3}(?:`{3,}(?=[^`\\n]*\\n)|~{3,})[^\\n]*\\n')
+  .replace('list', ' {0,3}(?:[*+-]|1[.)]) ') // only lists starting from 1 can interrupt
+  .replace('html', '</?(?:tag)(?: +|\\n|/?>)|<(?:script|pre|style|textarea|!--)')
+  .replace('tag', block._tag) // pars can be interrupted by type (6) html blocks
+  .getRegex();
 /**
  * Pedantic grammar (original John Gruber's loose markdown specification)
  */

--- a/test/specs/gfm/gfm.0.29.json
+++ b/test/specs/gfm/gfm.0.29.json
@@ -48,18 +48,6 @@
     "example": 205
   },
   {
-    "section": "[extension] Tables",
-    "html": "<p>paragraph 1</p><table>\n<thead>\n<tr>\n<th>abc</th>\n<th>def</th>\n</tr>\n</thead>\n</table>",
-    "markdown": "paragraph 1\n| abc | def |\n| --- | --- |",
-    "example": 206
-  },
-  {
-    "section": "[extension] Tables",
-    "html": "<p>paragraph with <code>inline code</code></p><table>\n<thead>\n<tr>\n<th>abc</th>\n<th>def</th>\n</tr>\n</thead>\n</table>",
-    "markdown": "paragraph with `inline code`\n| abc | def |\n| --- | --- |",
-    "example": 207
-  },
-  {
     "section": "[extension] Task list items",
     "html": "<ul>\n<li><input disabled=\"\" type=\"checkbox\"> foo</li>\n<li><input checked=\"\" disabled=\"\" type=\"checkbox\"> bar</li>\n</ul>",
     "markdown": "- [ ] foo\n- [x] bar",

--- a/test/specs/gfm/gfm.0.29.json
+++ b/test/specs/gfm/gfm.0.29.json
@@ -48,6 +48,18 @@
     "example": 205
   },
   {
+    "section": "[extension] Tables",
+    "html": "<p>paragraph 1</p><table>\n<thead>\n<tr>\n<th>abc</th>\n<th>def</th>\n</tr>\n</thead>\n</table>",
+    "markdown": "paragraph 1\n| abc | def |\n| --- | --- |",
+    "example": 206
+  },
+  {
+    "section": "[extension] Tables",
+    "html": "<p>paragraph with <code>inline code</code></p><table>\n<thead>\n<tr>\n<th>abc</th>\n<th>def</th>\n</tr>\n</thead>\n</table>",
+    "markdown": "paragraph with `inline code`\n| abc | def |\n| --- | --- |",
+    "example": 207
+  },
+  {
     "section": "[extension] Task list items",
     "html": "<ul>\n<li><input disabled=\"\" type=\"checkbox\"> foo</li>\n<li><input checked=\"\" disabled=\"\" type=\"checkbox\"> bar</li>\n</ul>",
     "markdown": "- [ ] foo\n- [x] bar",

--- a/test/specs/new/table_following_text.html
+++ b/test/specs/new/table_following_text.html
@@ -1,0 +1,38 @@
+<p>hello world</p>
+<table>
+    <thead>
+    <tr>
+        <th>abc</th>
+        <th>def</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>bar</td>
+        <td>foo</td>
+    </tr>
+    <tr>
+        <td>baz</td>
+        <td>boo</td>
+    </tr>
+    </tbody>
+</table>
+<p>hello world with empty line</p>
+<table>
+    <thead>
+    <tr>
+        <th>abc</th>
+        <th>def</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>bar</td>
+        <td>foo</td>
+    </tr>
+    <tr>
+        <td>baz</td>
+        <td>boo</td>
+    </tr>
+    </tbody>
+</table>

--- a/test/specs/new/table_following_text.md
+++ b/test/specs/new/table_following_text.md
@@ -1,0 +1,15 @@
+---
+gfm: true
+---
+hello world
+| abc | def |
+| --- | --- |
+| bar | foo |
+| baz | boo |
+
+hello world with empty line
+
+| abc | def |
+| --- | --- |
+| bar | foo |
+| baz | boo |

--- a/test/unit/Lexer-spec.js
+++ b/test/unit/Lexer-spec.js
@@ -204,6 +204,52 @@ lheading 2
       });
     });
 
+    it('table after para', () => {
+      expectTokens({
+        md: `
+paragraph 1
+| a | b |
+|---|---|
+| 1 | 2 |
+`,
+        tokens: [
+          {
+            type: 'paragraph',
+            raw: 'paragraph 1',
+            text: 'paragraph 1',
+            tokens: [{ type: 'text', raw: 'paragraph 1', text: 'paragraph 1' }]
+          },
+          {
+            type: 'table',
+            align: [null, null],
+            raw: '| a | b |\n|---|---|\n| 1 | 2 |\n',
+            header: [
+              {
+                text: 'a',
+                tokens: [{ type: 'text', raw: 'a', text: 'a' }]
+              },
+              {
+                text: 'b',
+                tokens: [{ type: 'text', raw: 'b', text: 'b' }]
+              }
+            ],
+            rows: [
+              [
+                {
+                  text: '1',
+                  tokens: [{ type: 'text', raw: '1', text: '1' }]
+                },
+                {
+                  text: '2',
+                  tokens: [{ type: 'text', raw: '2', text: '2' }]
+                }
+              ]
+            ]
+          }
+        ]
+      });
+    });
+
     it('align table', () => {
       expectTokens({
         md: `


### PR DESCRIPTION
<!--

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->
Uses `table` pattern to interrupt `paragraph`. So an empty line won't be required for GFM tables.
Test cases added for this change.

**Marked version:** 4.0.4

<!-- The NPM version or commit hash having the issue -->

**Markdown flavor:** GitHub Flavored Markdown

## Description

- Fixes #1733 

<!--

	If no issue exists that you're aware of. The maintainers should be able to figure out if it's a duplicate.

## Expectation

Describe the output you are expecting from marked

## Result

Describe the output you received from marked

## What was attempted

Describe what code combination got you there

-->

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
