### PR TITLE
fix: rename inconsistent variable in example

### DIFF
--- a/docs/USING_PRO.md
+++ b/docs/USING_PRO.md
@@ -362,7 +362,7 @@ The renderer function has access to the parser in the `this` object, which can b
 **Example:** Add a custom syntax to generate `<dl>` description lists.
 
 ``` js
-const descriptionlist = {
+const descriptionList = {
   name: 'descriptionList',
   level: 'block',                                     // Is this a block-level or inline-level tokenizer?
   start(src) { return src.match(/:[^:\n]/)?.index; }, // Hint to Marked.js to stop and check for a match
@@ -413,7 +413,7 @@ function walkTokens(token) {                        // Post-processing on the co
     token.tokens = this.Lexer.lexInline(token.text)
   }
 }
-marked.use({ extensions: [descriptionlist, description], walkTokens });
+marked.use({ extensions: [descriptionList, description], walkTokens });
 
 // EQUIVALENT TO:
 


### PR DESCRIPTION
<!--

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->

**Marked version:** 4.0.6

<!-- The NPM version or commit hash having the issue -->

**Markdown flavor:** Markdown.pl|CommonMark|GitHub Flavored Markdown|n/a

## Description

- The example in the documentation of [custom extensions](https://marked.js.org/using_pro#extensions) used `marked.use({ extensions: [descriptionList] });` to add the extension provided above while the name of the extension is `descriptionlist`.

<!--

	If no issue exists that you're aware of. The maintainers should be able to figure out if it's a duplicate.

## Expectation

Describe the output you are expecting from marked

## Result

Describe the output you received from marked

## What was attempted

Describe what code combination got you there

-->

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
