### PR TITLE
Fix every third list item broken

### DIFF
--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -227,37 +227,39 @@ export class Tokenizer {
           endEarly = true;
         }
 
-        const nextBulletRegex = new RegExp(`^ {0,${Math.min(3, indent - 1)}}(?:[*+-]|\\d{1,9}[.)])`);
+        if (!endEarly) {
+          const nextBulletRegex = new RegExp(`^ {0,${Math.min(3, indent - 1)}}(?:[*+-]|\\d{1,9}[.)])`);
 
-        // Check if following lines should be included in List Item
-        while (src && !endEarly) {
-          rawLine = src.split('\n', 1)[0];
-          line = rawLine;
+          // Check if following lines should be included in List Item
+          while (src) {
+            rawLine = src.split('\n', 1)[0];
+            line = rawLine;
 
-          // Re-align to follow commonmark nesting rules
-          if (this.options.pedantic) {
-            line = line.replace(/^ {1,4}(?=( {4})*[^ ])/g, '  ');
+            // Re-align to follow commonmark nesting rules
+            if (this.options.pedantic) {
+              line = line.replace(/^ {1,4}(?=( {4})*[^ ])/g, '  ');
+            }
+
+            // End list item if found start of new bullet
+            if (nextBulletRegex.test(line)) {
+              break;
+            }
+
+            if (line.search(/[^ ]/) >= indent || !line.trim()) { // Dedent if possible
+              itemContents += '\n' + line.slice(indent);
+            } else if (!blankLine) { // Until blank line, item doesn't need indentation
+              itemContents += '\n' + line;
+            } else { // Otherwise, improper indentation ends this item
+              break;
+            }
+
+            if (!blankLine && !line.trim()) { // Check if current line is blank
+              blankLine = true;
+            }
+
+            raw += rawLine + '\n';
+            src = src.substring(rawLine.length + 1);
           }
-
-          // End list item if found start of new bullet
-          if (nextBulletRegex.test(line)) {
-            break;
-          }
-
-          if (line.search(/[^ ]/) >= indent || !line.trim()) { // Dedent if possible
-            itemContents += '\n' + line.slice(indent);
-          } else if (!blankLine) { // Until blank line, item doesn't need indentation
-            itemContents += '\n' + line;
-          } else { // Otherwise, improper indentation ends this item
-            break;
-          }
-
-          if (!blankLine && !line.trim()) { // Check if current line is blank
-            blankLine = true;
-          }
-
-          raw += rawLine + '\n';
-          src = src.substring(rawLine.length + 1);
         }
 
         if (!list.loose) {

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -169,7 +169,7 @@ export class Tokenizer {
     let cap = this.rules.block.list.exec(src);
     if (cap) {
       let raw, istask, ischecked, indent, i, blankLine, endsWithBlankLine,
-        line, nextLine, rawLine, itemContents;
+        line, nextLine, rawLine, itemContents, endEarly;
 
       let bull = cap[1].trim();
       const isordered = bull.length > 1;
@@ -194,6 +194,7 @@ export class Tokenizer {
 
       // Check if current bullet point can start a new List Item
       while (src) {
+        endEarly = false;
         if (!(cap = itemRegex.exec(src))) {
           break;
         }
@@ -223,13 +224,13 @@ export class Tokenizer {
         if (!line && /^ *$/.test(nextLine)) { // Items begin with at most one blank line
           raw += nextLine + '\n';
           src = src.substring(nextLine.length + 1);
-          list.loose = true;
+          endEarly = true;
         }
 
         const nextBulletRegex = new RegExp(`^ {0,${Math.min(3, indent - 1)}}(?:[*+-]|\\d{1,9}[.)])`);
 
         // Check if following lines should be included in List Item
-        while (src && !list.loose) {
+        while (src && !endEarly) {
           rawLine = src.split('\n', 1)[0];
           line = rawLine;
 

--- a/test/specs/new/multiple_sub_lists.html
+++ b/test/specs/new/multiple_sub_lists.html
@@ -1,0 +1,26 @@
+<ol>
+<li><p>list item one</p>
+<ol>
+<li>sublist item one</li>
+<li>sublist item two</li>
+</ol>
+</li>
+<li><p>list item two</p>
+<ol>
+<li>sublist item one</li>
+<li>sublist item two</li>
+</ol>
+</li>
+<li><p>list item three</p>
+<ol>
+<li>sublist item one</li>
+<li>sublist item two</li>
+</ol>
+</li>
+<li><p>list item four</p>
+<ol>
+<li>sublist item one</li>
+<li>sublist item two</li>
+</ol>
+</li>
+</ol>

--- a/test/specs/new/multiple_sub_lists.md
+++ b/test/specs/new/multiple_sub_lists.md
@@ -1,0 +1,15 @@
+1. list item one
+    1. sublist item one
+    2. sublist item two
+
+2. list item two
+    1. sublist item one
+    2. sublist item two
+
+3. list item three
+    1. sublist item one
+    2. sublist item two
+
+4. list item four
+    1. sublist item one
+    2. sublist item two


### PR DESCRIPTION
<!--

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->

**Marked version:**

4.0.6

## Description

Fixes #2314

#2302 mistakenly used `list.loose` as a flag to end list items early if they start with two blank lines. Technically that is a different scenario from being "loose", so legitimate loose lists were also hitting that flag and prematurely ending the list after the second item. This PR just adds a separate flag `endEarly` to handle that case.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
