### PR TITLE
Fix lexer and tokenizer to retain line breaks properly

### DIFF
--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -152,12 +152,11 @@ export class Lexer {
       // newline
       if (token = this.tokenizer.space(src)) {
         src = src.substring(token.raw.length);
-        if (token.raw.length === 1 && tokens[tokens.length - 1]) {
-          // if there's a single \n as a spacer, it's terminating the last line, so move it there so that we don't get unecessary paragraph tags
-          tokens[tokens.length - 1].raw = `${tokens[tokens.length - 1].raw}\n`;
-          continue;
-        }
-        if (token.type) {
+        if (token.raw.length === 1 && tokens.length > 0) {
+          // if there's a single \n as a spacer, it's terminating the last line,
+          // so move it there so that we don't get unecessary paragraph tags
+          tokens[tokens.length - 1].raw += '\n';
+        } else {
           tokens.push(token);
         }
         continue;

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -154,8 +154,8 @@ export class Lexer {
         src = src.substring(token.raw.length);
         if (token.raw.length === 1 && tokens[tokens.length - 1]) {
           // if there's a single \n as a spacer, it's terminating the last line, so move it there so that we don't get unecessary paragraph tags
-          tokens[tokens.length - 1].raw = `${tokens[tokens.length - 1].raw}\n`
-          continue
+          tokens[tokens.length - 1].raw = `${tokens[tokens.length - 1].raw}\n`;
+          continue;
         }
         if (token.type) {
           tokens.push(token);

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -152,6 +152,11 @@ export class Lexer {
       // newline
       if (token = this.tokenizer.space(src)) {
         src = src.substring(token.raw.length);
+        if (token.raw.length === 1 && tokens[tokens.length - 1]) {
+          // if there's a single \n as a spacer, it's terminating the last line, so move it there so that we don't get unecessary paragraph tags
+          tokens[tokens.length - 1].raw = `${tokens[tokens.length - 1].raw}\n`
+          continue
+        }
         if (token.type) {
           tokens.push(token);
         }

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -304,8 +304,22 @@ export class Tokenizer {
         this.lexer.state.top = false;
         list.items[i].tokens = this.lexer.blockTokens(list.items[i].text, []);
         const spacers = list.items[i].tokens.filter(t => t.type === 'space');
-        const hasMultipleSpaces = spacers.every(t => t.raw.length > 1);
-        if (!list.loose && spacers.length && hasMultipleSpaces) {
+        const hasMultipleLineBreaks = spacers.every(t => {
+          const chars = t.raw.split('');
+          let lineBreaks = 0;
+          for (let char of chars) {
+            if (char === '\n') {
+              lineBreaks += 1;
+            }
+            if (lineBreaks > 1) {
+              return true
+            }
+          }
+
+          return false
+        });
+
+        if (!list.loose && spacers.length && hasMultipleLineBreaks) {
           // Having a single line break doesn't mean a list is loose. A single line break is terminating the last list item
           list.loose = true;
           list.items[i].loose = true;

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -72,14 +72,11 @@ export class Tokenizer {
 
   space(src) {
     const cap = this.rules.block.newline.exec(src);
-    if (cap) {
-      if (cap[0].length) {
-        return {
-          type: 'space',
-          raw: cap[0]
-        };
-      }
-      return { raw: '\n' };
+    if (cap && cap[0].length > 0) {
+      return {
+        type: 'space',
+        raw: cap[0]
+      };
     }
   }
 

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -73,7 +73,7 @@ export class Tokenizer {
   space(src) {
     const cap = this.rules.block.newline.exec(src);
     if (cap) {
-      if (cap[0].length > 1) {
+      if (cap[0].length) {
         return {
           type: 'space',
           raw: cap[0]
@@ -303,7 +303,10 @@ export class Tokenizer {
       for (i = 0; i < l; i++) {
         this.lexer.state.top = false;
         list.items[i].tokens = this.lexer.blockTokens(list.items[i].text, []);
-        if (!list.loose && list.items[i].tokens.some(t => t.type === 'space')) {
+        const spacers = list.items[i].tokens.filter(t => t.type === 'space');
+        const hasMultipleSpaces = spacers.every(t => t.raw.length > 1);
+        if (!list.loose && spacers.length && hasMultipleSpaces) {
+          // Having a single line break doesn't mean a list is loose. A single line break is terminating the last list item
           list.loose = true;
           list.items[i].loose = true;
         }

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -307,16 +307,16 @@ export class Tokenizer {
         const hasMultipleLineBreaks = spacers.every(t => {
           const chars = t.raw.split('');
           let lineBreaks = 0;
-          for (let char of chars) {
+          for (const char of chars) {
             if (char === '\n') {
               lineBreaks += 1;
             }
             if (lineBreaks > 1) {
-              return true
+              return true;
             }
           }
 
-          return false
+          return false;
         });
 
         if (!list.loose && spacers.length && hasMultipleLineBreaks) {

--- a/test/unit/Lexer-spec.js
+++ b/test/unit/Lexer-spec.js
@@ -579,6 +579,35 @@ paragraph
       });
     });
 
+    it('not loose with spaces', () => {
+      expectTokens({
+        md: `- item 1
+  - item 2
+`,
+        tokens: jasmine.arrayContaining([
+          jasmine.objectContaining({
+            type: 'list',
+            raw: '- item 1\n  - item 2\n',
+            loose: false,
+            items: [
+              jasmine.objectContaining({
+                raw: '- item 1\n  - item 2',
+                tokens: jasmine.arrayContaining([
+                  jasmine.objectContaining({
+                    raw: 'item 1\n'
+                  }),
+                  jasmine.objectContaining({
+                    type: 'list',
+                    raw: '- item 2'
+                  }),
+                ])
+              })
+            ]
+          })
+        ])
+      });
+    });
+
     it('task', () => {
       expectTokens({
         md: `- [ ] item 1

--- a/test/unit/Lexer-spec.js
+++ b/test/unit/Lexer-spec.js
@@ -73,7 +73,8 @@ describe('Lexer', () => {
   describe('headings', () => {
     it('depth', () => {
       expectTokens({
-        md: `# heading 1
+        md: `
+# heading 1
 
 ## heading 2
 
@@ -92,6 +93,10 @@ lheading 2
 ----------
 `,
         tokens: [
+          {
+            type: 'space',
+            raw: '\n'
+          },
           {
             type: 'heading',
             raw: '# heading 1\n\n',
@@ -168,11 +173,15 @@ lheading 2
   describe('table', () => {
     it('pipe table', () => {
       expectTokens({
-        md: `| a | b |
+        md: `
+| a | b |
 |---|---|
 | 1 | 2 |
 `,
         tokens: [{
+          type: 'space',
+          raw: '\n'
+        }, {
           type: 'table',
           align: [null, null],
           raw: '| a | b |\n|---|---|\n| 1 | 2 |\n',
@@ -204,56 +213,63 @@ lheading 2
 
     it('table after para', () => {
       expectTokens({
-        md: `paragraph 1
+        md: `
+paragraph 1
 | a | b |
 |---|---|
 | 1 | 2 |
 `,
-        tokens: [
-          {
-            type: 'paragraph',
-            raw: 'paragraph 1\n',
-            text: 'paragraph 1',
-            tokens: [{ type: 'text', raw: 'paragraph 1', text: 'paragraph 1' }]
-          },
-          {
-            type: 'table',
-            align: [null, null],
-            raw: '| a | b |\n|---|---|\n| 1 | 2 |\n',
-            header: [
+        tokens: [{
+          type: 'space',
+          raw: '\n'
+        }, {
+          type: 'paragraph',
+          raw: 'paragraph 1\n',
+          text: 'paragraph 1',
+          tokens: [{ type: 'text', raw: 'paragraph 1', text: 'paragraph 1' }]
+        },
+        {
+          type: 'table',
+          align: [null, null],
+          raw: '| a | b |\n|---|---|\n| 1 | 2 |\n',
+          header: [
+            {
+              text: 'a',
+              tokens: [{ type: 'text', raw: 'a', text: 'a' }]
+            },
+            {
+              text: 'b',
+              tokens: [{ type: 'text', raw: 'b', text: 'b' }]
+            }
+          ],
+          rows: [
+            [
               {
-                text: 'a',
-                tokens: [{ type: 'text', raw: 'a', text: 'a' }]
+                text: '1',
+                tokens: [{ type: 'text', raw: '1', text: '1' }]
               },
               {
-                text: 'b',
-                tokens: [{ type: 'text', raw: 'b', text: 'b' }]
+                text: '2',
+                tokens: [{ type: 'text', raw: '2', text: '2' }]
               }
-            ],
-            rows: [
-              [
-                {
-                  text: '1',
-                  tokens: [{ type: 'text', raw: '1', text: '1' }]
-                },
-                {
-                  text: '2',
-                  tokens: [{ type: 'text', raw: '2', text: '2' }]
-                }
-              ]
             ]
-          }
+          ]
+        }
         ]
       });
     });
 
     it('align table', () => {
       expectTokens({
-        md: `| a | b | c |
+        md: `
+| a | b | c |
 |:--|:-:|--:|
 | 1 | 2 | 3 |
 `,
         tokens: [{
+          type: 'space',
+          raw: '\n'
+        }, {
           type: 'table',
           align: ['left', 'center', 'right'],
           raw: '| a | b | c |\n|:--|:-:|--:|\n| 1 | 2 | 3 |\n',
@@ -293,37 +309,42 @@ lheading 2
 
     it('no pipe table', () => {
       expectTokens({
-        md: `a | b
+        md: `
+a | b
 --|--
 1 | 2
 `,
-        tokens: [{
-          type: 'table',
-          align: [null, null],
-          raw: 'a | b\n--|--\n1 | 2\n',
-          header: [
-            {
-              text: 'a',
-              tokens: [{ type: 'text', raw: 'a', text: 'a' }]
-            },
-            {
-              text: 'b',
-              tokens: [{ type: 'text', raw: 'b', text: 'b' }]
-            }
-          ],
-          rows: [
-            [
+        tokens: [
+          {
+            type: 'space',
+            raw: '\n'
+          }, {
+            type: 'table',
+            align: [null, null],
+            raw: 'a | b\n--|--\n1 | 2\n',
+            header: [
               {
-                text: '1',
-                tokens: [{ type: 'text', raw: '1', text: '1' }]
+                text: 'a',
+                tokens: [{ type: 'text', raw: 'a', text: 'a' }]
               },
               {
-                text: '2',
-                tokens: [{ type: 'text', raw: '2', text: '2' }]
+                text: 'b',
+                tokens: [{ type: 'text', raw: 'b', text: 'b' }]
               }
+            ],
+            rows: [
+              [
+                {
+                  text: '1',
+                  tokens: [{ type: 'text', raw: '1', text: '1' }]
+                },
+                {
+                  text: '2',
+                  tokens: [{ type: 'text', raw: '2', text: '2' }]
+                }
+              ]
             ]
-          ]
-        }]
+          }]
       });
     });
   });
@@ -342,12 +363,12 @@ lheading 2
       expectTokens({
         md: 'T\nh\n---',
         tokens:
-        jasmine.arrayContaining([
-          jasmine.objectContaining({
-            raw: 'T\nh\n'
-          }),
-          { type: 'hr', raw: '---' }
-        ])
+          jasmine.arrayContaining([
+            jasmine.objectContaining({
+              raw: 'T\nh\n'
+            }),
+            { type: 'hr', raw: '---' }
+          ])
       });
     });
   });
@@ -378,11 +399,15 @@ lheading 2
   describe('list', () => {
     it('unordered', () => {
       expectTokens({
-        md: `- item 1
+        md: `
+- item 1
 - item 2
 `,
         tokens: [
           {
+            type: 'space',
+            raw: '\n'
+          }, {
             type: 'list',
             raw: '- item 1\n- item 2\n',
             ordered: false,
@@ -425,10 +450,15 @@ lheading 2
 
     it('ordered', () => {
       expectTokens({
-        md: `1. item 1
+        md: `
+1. item 1
 2. item 2
 `,
         tokens: jasmine.arrayContaining([
+          jasmine.objectContaining({
+            type: 'space',
+            raw: '\n'
+          }),
           jasmine.objectContaining({
             type: 'list',
             raw: '1. item 1\n2. item 2\n',
@@ -449,10 +479,15 @@ lheading 2
 
     it('ordered with parenthesis', () => {
       expectTokens({
-        md: `1) item 1
+        md: `
+1) item 1
 2) item 2
 `,
         tokens: jasmine.arrayContaining([
+          jasmine.objectContaining({
+            type: 'space',
+            raw: '\n'
+          }),
           jasmine.objectContaining({
             type: 'list',
             raw: '1) item 1\n2) item 2\n',
@@ -473,12 +508,17 @@ lheading 2
 
     it('space after list', () => {
       expectTokens({
-        md: `- item 1
+        md: `
+- item 1
 - item 2
 
 paragraph
 `,
         tokens: [
+          {
+            type: 'space',
+            raw: '\n'
+          },
           {
             type: 'list',
             raw: '- item 1\n- item 2',
@@ -533,10 +573,15 @@ paragraph
 
     it('start', () => {
       expectTokens({
-        md: `2. item 1
+        md: `
+2. item 1
 3. item 2
 `,
         tokens: jasmine.arrayContaining([
+          jasmine.objectContaining({
+            type: 'space',
+            raw: '\n'
+          }),
           jasmine.objectContaining({
             type: 'list',
             raw: '2. item 1\n3. item 2\n',
@@ -557,11 +602,16 @@ paragraph
 
     it('loose', () => {
       expectTokens({
-        md: `- item 1
+        md: `
+- item 1
 
 - item 2
 `,
         tokens: jasmine.arrayContaining([
+          jasmine.objectContaining({
+            type: 'space',
+            raw: '\n'
+          }),
           jasmine.objectContaining({
             type: 'list',
             raw: '- item 1\n\n- item 2\n',
@@ -581,10 +631,15 @@ paragraph
 
     it('not loose with spaces', () => {
       expectTokens({
-        md: `- item 1
+        md: `
+- item 1
   - item 2
 `,
         tokens: jasmine.arrayContaining([
+          jasmine.objectContaining({
+            type: 'space',
+            raw: '\n'
+          }),
           jasmine.objectContaining({
             type: 'list',
             raw: '- item 1\n  - item 2\n',
@@ -610,10 +665,15 @@ paragraph
 
     it('task', () => {
       expectTokens({
-        md: `- [ ] item 1
+        md: `
+- [ ] item 1
 - [x] item 2
 `,
         tokens: jasmine.arrayContaining([
+          jasmine.objectContaining({
+            type: 'space',
+            raw: '\n'
+          }),
           jasmine.objectContaining({
             type: 'list',
             raw: '- [ ] item 1\n- [x] item 2\n',

--- a/test/unit/Lexer-spec.js
+++ b/test/unit/Lexer-spec.js
@@ -344,7 +344,7 @@ lheading 2
         tokens:
         jasmine.arrayContaining([
           jasmine.objectContaining({
-            raw: "T\nh\n"
+            raw: 'T\nh\n'
           }),
           { type: 'hr', raw: '---' }
         ])
@@ -599,7 +599,7 @@ paragraph
                   jasmine.objectContaining({
                     type: 'list',
                     raw: '- item 2'
-                  }),
+                  })
                 ])
               })
             ]

--- a/test/unit/Lexer-spec.js
+++ b/test/unit/Lexer-spec.js
@@ -73,8 +73,7 @@ describe('Lexer', () => {
   describe('headings', () => {
     it('depth', () => {
       expectTokens({
-        md: `
-# heading 1
+        md: `# heading 1
 
 ## heading 2
 
@@ -169,8 +168,7 @@ lheading 2
   describe('table', () => {
     it('pipe table', () => {
       expectTokens({
-        md: `
-| a | b |
+        md: `| a | b |
 |---|---|
 | 1 | 2 |
 `,
@@ -206,8 +204,7 @@ lheading 2
 
     it('table after para', () => {
       expectTokens({
-        md: `
-paragraph 1
+        md: `paragraph 1
 | a | b |
 |---|---|
 | 1 | 2 |
@@ -215,7 +212,7 @@ paragraph 1
         tokens: [
           {
             type: 'paragraph',
-            raw: 'paragraph 1',
+            raw: 'paragraph 1\n',
             text: 'paragraph 1',
             tokens: [{ type: 'text', raw: 'paragraph 1', text: 'paragraph 1' }]
           },
@@ -252,8 +249,7 @@ paragraph 1
 
     it('align table', () => {
       expectTokens({
-        md: `
-| a | b | c |
+        md: `| a | b | c |
 |:--|:-:|--:|
 | 1 | 2 | 3 |
 `,
@@ -297,8 +293,7 @@ paragraph 1
 
     it('no pipe table', () => {
       expectTokens({
-        md: `
-a | b
+        md: `a | b
 --|--
 1 | 2
 `,
@@ -370,14 +365,13 @@ a | b
   describe('list', () => {
     it('unordered', () => {
       expectTokens({
-        md: `
-- item 1
+        md: `- item 1
 - item 2
 `,
         tokens: [
           {
             type: 'list',
-            raw: '- item 1\n- item 2',
+            raw: '- item 1\n- item 2\n',
             ordered: false,
             start: '',
             loose: false,
@@ -418,14 +412,13 @@ a | b
 
     it('ordered', () => {
       expectTokens({
-        md: `
-1. item 1
+        md: `1. item 1
 2. item 2
 `,
         tokens: jasmine.arrayContaining([
           jasmine.objectContaining({
             type: 'list',
-            raw: '1. item 1\n2. item 2',
+            raw: '1. item 1\n2. item 2\n',
             ordered: true,
             start: 1,
             items: [
@@ -443,14 +436,13 @@ a | b
 
     it('ordered with parenthesis', () => {
       expectTokens({
-        md: `
-1) item 1
+        md: `1) item 1
 2) item 2
 `,
         tokens: jasmine.arrayContaining([
           jasmine.objectContaining({
             type: 'list',
-            raw: '1) item 1\n2) item 2',
+            raw: '1) item 1\n2) item 2\n',
             ordered: true,
             start: 1,
             items: [
@@ -468,8 +460,7 @@ a | b
 
     it('space after list', () => {
       expectTokens({
-        md: `
-- item 1
+        md: `- item 1
 - item 2
 
 paragraph
@@ -515,7 +506,7 @@ paragraph
           { type: 'space', raw: '\n\n' },
           {
             type: 'paragraph',
-            raw: 'paragraph',
+            raw: 'paragraph\n',
             text: 'paragraph',
             tokens: [{
               type: 'text',
@@ -529,14 +520,13 @@ paragraph
 
     it('start', () => {
       expectTokens({
-        md: `
-2. item 1
+        md: `2. item 1
 3. item 2
 `,
         tokens: jasmine.arrayContaining([
           jasmine.objectContaining({
             type: 'list',
-            raw: '2. item 1\n3. item 2',
+            raw: '2. item 1\n3. item 2\n',
             ordered: true,
             start: 2,
             items: [
@@ -554,15 +544,14 @@ paragraph
 
     it('loose', () => {
       expectTokens({
-        md: `
-- item 1
+        md: `- item 1
 
 - item 2
 `,
         tokens: jasmine.arrayContaining([
           jasmine.objectContaining({
             type: 'list',
-            raw: '- item 1\n\n- item 2',
+            raw: '- item 1\n\n- item 2\n',
             loose: true,
             items: [
               jasmine.objectContaining({
@@ -579,14 +568,13 @@ paragraph
 
     it('task', () => {
       expectTokens({
-        md: `
-- [ ] item 1
+        md: `- [ ] item 1
 - [x] item 2
 `,
         tokens: jasmine.arrayContaining([
           jasmine.objectContaining({
             type: 'list',
-            raw: '- [ ] item 1\n- [x] item 2',
+            raw: '- [ ] item 1\n- [x] item 2\n',
             items: [
               jasmine.objectContaining({
                 raw: '- [ ] item 1\n',

--- a/test/unit/Lexer-spec.js
+++ b/test/unit/Lexer-spec.js
@@ -337,6 +337,19 @@ lheading 2
         ]
       });
     });
+
+    it('after line break does not consume raw \n', () => {
+      expectTokens({
+        md: 'T\nh\n---',
+        tokens:
+        jasmine.arrayContaining([
+          jasmine.objectContaining({
+            raw: "T\nh\n"
+          }),
+          { type: 'hr', raw: '---' }
+        ])
+      });
+    });
   });
 
   describe('blockquote', () => {

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -994,6 +994,7 @@ br
     });
 
     expect(tokensSeen).toEqual([
+      ['space', ''],
       ['paragraph', 'paragraph'],
       ['text', 'paragraph'],
       ['space', ''],


### PR DESCRIPTION
<!--

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->

**Marked version:**
4.0.8
<!-- The NPM version or commit hash having the issue -->

**Markdown flavor:** n/a

## Description
This PR stops ignoring single `\n` characters and makes sure they're properly represented in the token list for each token type in the lexer.

- Fixes #2340

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
