### PR TITLE
Add check in splitCells to prevent calling trim on undefined

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -162,7 +162,7 @@ export function splitCells(tableRow, count) {
 
   // First/last cell in a row cannot be empty if it has no leading/trailing pipe
   if (!cells[0].trim()) { cells.shift(); }
-  if (!cells[cells.length - 1].trim()) { cells.pop(); }
+  if (cells.length > 0 && !cells[cells.length - 1].trim()) { cells.pop(); }
 
   if (cells.length > count) {
     cells.splice(count);

--- a/test/specs/new/nbsp_following_tables.html
+++ b/test/specs/new/nbsp_following_tables.html
@@ -1,0 +1,22 @@
+<table>
+  <thead>
+    <tr>
+      <th>abc</th>
+      <th>def</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>bar</td>
+      <td>foo</td>
+    </tr>
+    <tr>
+      <td>baz</td>
+      <td>boo</td>
+    </tr>
+    <tr>
+      <td></td>
+      <td></td>
+    </tr>
+  </tbody>
+</table>

--- a/test/specs/new/nbsp_following_tables.md
+++ b/test/specs/new/nbsp_following_tables.md
@@ -1,0 +1,5 @@
+| abc | def |
+| --- | --- |
+| bar | foo |
+| baz | boo |
+ 


### PR DESCRIPTION
**Marked version:** 4.0.11
**Markdown flavor:** GitHub Flavored Markdown

## Description

Fixes #2371 

## Expectation

With this change I expect the example given in the issue to not cause a JavaScript error.

## Result

The test case no longer throws an error and instead renders the table properly.

## What was attempted

This PR adds a simple check to the `splitCells` helper function that validates that the `cells` array isn't empty before calling `cells[cells.length - 1].trim()`. This prevents the error "Cannot read properties of undefined (reading 'trim')" from being thrown.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
