### PR TITLE
add async parser

### DIFF
--- a/docs/USING_ADVANCED.md
+++ b/docs/USING_ADVANCED.md
@@ -44,6 +44,7 @@ console.log(marked.parse(markdownString));
 
 |Member      |Type      |Default  |Since    |Notes         |
 |:-----------|:---------|:--------|:--------|:-------------|
+|async     |`boolean`  |`false`   |4.1.0    |Use the asynchronous parser to call renderer functions.|
 |baseUrl     |`string`  |`null`   |0.3.9    |A prefix url for any relative link. |
 |breaks      |`boolean` |`false`  |v0.2.7   |If true, add `<br>` on a single line break (copies GitHub behavior on comments, but not on rendered markdown files). Requires `gfm` be `true`.|
 |gfm         |`boolean` |`true`   |v0.2.1   |If true, use approved [GitHub Flavored Markdown (GFM) specification](https://github.github.com/gfm/).|

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "marked",
       "version": "4.0.12",
       "license": "MIT",
       "bin": {
@@ -12,6 +13,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.17.5",
+        "@babel/plugin-transform-runtime": "^7.17.0",
         "@babel/preset-env": "^7.16.11",
         "@markedjs/html-differ": "^4.0.0",
         "@rollup/plugin-babel": "^5.3.1",
@@ -1341,6 +1343,26 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-runtime": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.17.0.tgz",
+      "integrity": "sha512-fr7zPWnKXNc1xoHfrIU9mN/4XKX4VLZ45Q+oMhfsYIaHvg7mHgmhfOy/ckRWqDK7XF3QDigRpkh5DKq6+clE8A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "babel-plugin-polyfill-corejs2": "^0.3.0",
+        "babel-plugin-polyfill-corejs3": "^0.5.0",
+        "babel-plugin-polyfill-regenerator": "^0.3.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.16.7.tgz",
@@ -1878,15 +1900,23 @@
       }
     },
     "node_modules/@octokit/request/node_modules/node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/@octokit/rest": {
@@ -11052,6 +11082,20 @@
         "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.17.0.tgz",
+      "integrity": "sha512-fr7zPWnKXNc1xoHfrIU9mN/4XKX4VLZ45Q+oMhfsYIaHvg7mHgmhfOy/ckRWqDK7XF3QDigRpkh5DKq6+clE8A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "babel-plugin-polyfill-corejs2": "^0.3.0",
+        "babel-plugin-polyfill-corejs3": "^0.5.0",
+        "babel-plugin-polyfill-regenerator": "^0.3.0",
+        "semver": "^6.3.0"
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.16.7.tgz",
@@ -11472,9 +11516,9 @@
       },
       "dependencies": {
         "node-fetch": {
-          "version": "2.6.6",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-          "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
           "dev": true,
           "requires": {
             "whatwg-url": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   ],
   "devDependencies": {
     "@babel/core": "^7.17.5",
+    "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/preset-env": "^7.16.11",
     "@markedjs/html-differ": "^4.0.0",
     "@rollup/plugin-babel": "^5.3.1",

--- a/rollup.config.esm.js
+++ b/rollup.config.esm.js
@@ -1,5 +1,6 @@
 const commonjs = require('@rollup/plugin-commonjs');
 const license = require('rollup-plugin-license');
+const babel = require('@rollup/plugin-babel').default;
 
 module.exports = {
   input: 'src/marked.js',
@@ -21,6 +22,13 @@ Copyright (c) 2011-${new Date().getFullYear()}, Christopher Jeffrey. (MIT Licens
 https://github.com/markedjs/marked
 `
     }),
-    commonjs()
+    commonjs(),
+    babel({
+      babelHelpers: 'runtime',
+      presets: [['@babel/preset-env']],
+      plugins: [
+        '@babel/plugin-transform-runtime'
+      ]
+    })
   ]
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,6 +25,7 @@ https://github.com/markedjs/marked
     }),
     commonjs(),
     babel({
+      babelHelpers: 'bundled',
       presets: [['@babel/preset-env', { loose: true }]]
     })
   ]
@@ -52,6 +53,7 @@ https://github.com/markedjs/marked
     }),
     commonjs(),
     babel({
+      babelHelpers: 'bundled',
       presets: [['@babel/preset-env', { loose: true }]]
     })
   ]

--- a/src/AsyncParser.js
+++ b/src/AsyncParser.js
@@ -1,0 +1,286 @@
+import { Renderer } from './Renderer.js';
+import { TextRenderer } from './TextRenderer.js';
+import { Slugger } from './Slugger.js';
+import { defaults } from './defaults.js';
+import {
+  unescape
+} from './helpers.js';
+
+/**
+ * Parsing & Compiling
+ */
+export class AsyncParser {
+  constructor(options) {
+    this.options = options || defaults;
+    this.options.renderer = this.options.renderer || new Renderer();
+    this.renderer = this.options.renderer;
+    this.renderer.options = this.options;
+    this.textRenderer = new TextRenderer();
+    this.slugger = new Slugger();
+  }
+
+  /**
+   * Static Parse Method
+   */
+  static async parse(tokens, options) {
+    const parser = new AsyncParser(options);
+    return parser.parse(tokens);
+  }
+
+  /**
+   * Static Parse Inline Method
+   */
+  static async parseInline(tokens, options) {
+    const parser = new AsyncParser(options);
+    return parser.parseInline(tokens);
+  }
+
+  /**
+   * Parse Loop
+   */
+  async parse(tokens, top = true) {
+    let out = '',
+      i,
+      j,
+      k,
+      l2,
+      l3,
+      row,
+      cell,
+      header,
+      body,
+      token,
+      ordered,
+      start,
+      loose,
+      itemBody,
+      item,
+      checked,
+      task,
+      checkbox,
+      ret;
+
+    const l = tokens.length;
+    for (i = 0; i < l; i++) {
+      token = tokens[i];
+
+      // Run any renderer extensions
+      if (this.options.extensions && this.options.extensions.renderers && this.options.extensions.renderers[token.type]) {
+        ret = await this.options.extensions.renderers[token.type].call({ parser: this }, token);
+        if (ret !== false || !['space', 'hr', 'heading', 'code', 'table', 'blockquote', 'list', 'html', 'paragraph', 'text'].includes(token.type)) {
+          out += ret || '';
+          continue;
+        }
+      }
+
+      switch (token.type) {
+        case 'space': {
+          continue;
+        }
+        case 'hr': {
+          out += await await this.renderer.hr();
+          continue;
+        }
+        case 'heading': {
+          out += await this.renderer.heading(
+            await this.parseInline(token.tokens),
+            token.depth,
+            unescape(await this.parseInline(token.tokens, this.textRenderer)),
+            this.slugger);
+          continue;
+        }
+        case 'code': {
+          out += await this.renderer.asyncCode(token.text,
+            token.lang,
+            token.escaped);
+          continue;
+        }
+        case 'table': {
+          header = '';
+
+          // header
+          cell = '';
+          l2 = token.header.length;
+          for (j = 0; j < l2; j++) {
+            cell += await this.renderer.tablecell(
+              await this.parseInline(token.header[j].tokens),
+              { header: true, align: token.align[j] }
+            );
+          }
+          header += await this.renderer.tablerow(cell);
+
+          body = '';
+          l2 = token.rows.length;
+          for (j = 0; j < l2; j++) {
+            row = token.rows[j];
+
+            cell = '';
+            l3 = row.length;
+            for (k = 0; k < l3; k++) {
+              cell += await this.renderer.tablecell(
+                await this.parseInline(row[k].tokens),
+                { header: false, align: token.align[k] }
+              );
+            }
+
+            body += await this.renderer.tablerow(cell);
+          }
+          out += await this.renderer.table(header, body);
+          continue;
+        }
+        case 'blockquote': {
+          body = await this.parse(token.tokens);
+          out += await this.renderer.blockquote(body);
+          continue;
+        }
+        case 'list': {
+          ordered = token.ordered;
+          start = token.start;
+          loose = token.loose;
+          l2 = token.items.length;
+
+          body = '';
+          for (j = 0; j < l2; j++) {
+            item = token.items[j];
+            checked = item.checked;
+            task = item.task;
+
+            itemBody = '';
+            if (item.task) {
+              checkbox = await this.renderer.checkbox(checked);
+              if (loose) {
+                if (item.tokens.length > 0 && item.tokens[0].type === 'paragraph') {
+                  item.tokens[0].text = checkbox + ' ' + item.tokens[0].text;
+                  if (item.tokens[0].tokens && item.tokens[0].tokens.length > 0 && item.tokens[0].tokens[0].type === 'text') {
+                    item.tokens[0].tokens[0].text = checkbox + ' ' + item.tokens[0].tokens[0].text;
+                  }
+                } else {
+                  item.tokens.unshift({
+                    type: 'text',
+                    text: checkbox
+                  });
+                }
+              } else {
+                itemBody += checkbox;
+              }
+            }
+
+            itemBody += await this.parse(item.tokens, loose);
+            body += await this.renderer.listitem(itemBody, task, checked);
+          }
+
+          out += await this.renderer.list(body, ordered, start);
+          continue;
+        }
+        case 'html': {
+          // TODO parse inline content if parameter markdown=1
+          out += await this.renderer.html(token.text);
+          continue;
+        }
+        case 'paragraph': {
+          out += await this.renderer.paragraph(await this.parseInline(token.tokens));
+          continue;
+        }
+        case 'text': {
+          body = token.tokens ? await this.parseInline(token.tokens) : token.text;
+          while (i + 1 < l && tokens[i + 1].type === 'text') {
+            token = tokens[++i];
+            body += '\n' + (token.tokens ? await this.parseInline(token.tokens) : token.text);
+          }
+          out += top ? await this.renderer.paragraph(body) : body;
+          continue;
+        }
+
+        default: {
+          const errMsg = 'Token with "' + token.type + '" type was not found.';
+          if (this.options.silent) {
+            console.error(errMsg);
+            return;
+          } else {
+            throw new Error(errMsg);
+          }
+        }
+      }
+    }
+
+    return out;
+  }
+
+  /**
+   * Parse Inline Tokens
+   */
+  async parseInline(tokens, renderer) {
+    renderer = renderer || this.renderer;
+    let out = '',
+      i,
+      token,
+      ret;
+
+    const l = tokens.length;
+    for (i = 0; i < l; i++) {
+      token = tokens[i];
+
+      // Run any renderer extensions
+      if (this.options.extensions && this.options.extensions.renderers && this.options.extensions.renderers[token.type]) {
+        ret = await this.options.extensions.renderers[token.type].call({ parser: this }, token);
+        if (ret !== false || !['escape', 'html', 'link', 'image', 'strong', 'em', 'codespan', 'br', 'del', 'text'].includes(token.type)) {
+          out += ret || '';
+          continue;
+        }
+      }
+
+      switch (token.type) {
+        case 'escape': {
+          out += renderer.text(token.text);
+          break;
+        }
+        case 'html': {
+          out += renderer.html(token.text);
+          break;
+        }
+        case 'link': {
+          out += renderer.link(token.href, token.title, await this.parseInline(token.tokens, renderer));
+          break;
+        }
+        case 'image': {
+          out += renderer.image(token.href, token.title, token.text);
+          break;
+        }
+        case 'strong': {
+          out += renderer.strong(await this.parseInline(token.tokens, renderer));
+          break;
+        }
+        case 'em': {
+          out += renderer.em(await this.parseInline(token.tokens, renderer));
+          break;
+        }
+        case 'codespan': {
+          out += renderer.codespan(token.text);
+          break;
+        }
+        case 'br': {
+          out += renderer.br();
+          break;
+        }
+        case 'del': {
+          out += renderer.del(await this.parseInline(token.tokens, renderer));
+          break;
+        }
+        case 'text': {
+          out += renderer.text(token.text);
+          break;
+        }
+        default: {
+          const errMsg = 'Token with "' + token.type + '" type was not found.';
+          if (this.options.silent) {
+            console.error(errMsg);
+            return;
+          } else {
+            throw new Error(errMsg);
+          }
+        }
+      }
+    }
+    return out;
+  }
+}

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -38,6 +38,32 @@ export class Renderer {
       + '</code></pre>\n';
   }
 
+  async asyncCode(code, infostring, escaped) {
+    const lang = (infostring || '').match(/\S*/)[0];
+    if (this.options.highlight) {
+      const out = await this.options.highlight(code, lang);
+      if (out != null && out !== code) {
+        escaped = true;
+        code = out;
+      }
+    }
+
+    code = code.replace(/\n$/, '') + '\n';
+
+    if (!lang) {
+      return '<pre><code>'
+        + (escaped ? code : escape(code, true))
+        + '</code></pre>\n';
+    }
+
+    return '<pre><code class="'
+      + this.options.langPrefix
+      + escape(lang, true)
+      + '">'
+      + (escaped ? code : escape(code, true))
+      + '</code></pre>\n';
+  }
+
   blockquote(quote) {
     return '<blockquote>\n' + quote + '</blockquote>\n';
   }

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,5 +1,6 @@
 export function getDefaults() {
   return {
+    async: false,
     baseUrl: null,
     breaks: false,
     extensions: null,

--- a/src/marked.js
+++ b/src/marked.js
@@ -1,5 +1,6 @@
 import { Lexer } from './Lexer.js';
 import { Parser } from './Parser.js';
+import { AsyncParser } from './AsyncParser.js';
 import { Tokenizer } from './Tokenizer.js';
 import { Renderer } from './Renderer.js';
 import { TextRenderer } from './TextRenderer.js';
@@ -46,13 +47,16 @@ export function marked(src, opt, callback) {
       return callback(e);
     }
 
-    const done = function(err) {
+    function done(err) {
       let out;
 
       if (!err) {
         try {
           if (opt.walkTokens) {
             marked.walkTokens(tokens, opt.walkTokens);
+          }
+          if (opt.async) {
+            out = AsyncParser.parse(tokens, opt);
           }
           out = Parser.parse(tokens, opt);
         } catch (e) {
@@ -65,7 +69,7 @@ export function marked(src, opt, callback) {
       return err
         ? callback(err)
         : callback(null, out);
-    };
+    }
 
     if (!highlight || highlight.length < 3) {
       return done();
@@ -109,6 +113,9 @@ export function marked(src, opt, callback) {
     const tokens = Lexer.lex(src, opt);
     if (opt.walkTokens) {
       marked.walkTokens(tokens, opt.walkTokens);
+    }
+    if (opt.async) {
+      return AsyncParser.parse(tokens, opt);
     }
     return Parser.parse(tokens, opt);
   } catch (e) {
@@ -308,6 +315,9 @@ marked.parseInline = function(src, opt) {
     if (opt.walkTokens) {
       marked.walkTokens(tokens, opt.walkTokens);
     }
+    if (opt.async) {
+      return AsyncParser.parseInline(tokens, opt);
+    }
     return Parser.parseInline(tokens, opt);
   } catch (e) {
     e.message += '\nPlease report this to https://github.com/markedjs/marked.';
@@ -325,6 +335,8 @@ marked.parseInline = function(src, opt) {
  */
 marked.Parser = Parser;
 marked.parser = Parser.parse;
+marked.AsyncParser = AsyncParser;
+marked.asyncParser = AsyncParser.parse;
 marked.Renderer = Renderer;
 marked.TextRenderer = TextRenderer;
 marked.Lexer = Lexer;
@@ -340,10 +352,12 @@ export const walkTokens = marked.walkTokens;
 export const parseInline = marked.parseInline;
 export const parse = marked;
 export const parser = Parser.parse;
+export const asyncParser = AsyncParser.parse;
 export const lexer = Lexer.lex;
 export { defaults, getDefaults } from './defaults.js';
 export { Lexer } from './Lexer.js';
 export { Parser } from './Parser.js';
+export { AsyncParser } from './AsyncParser.js';
 export { Tokenizer } from './Tokenizer.js';
 export { Renderer } from './Renderer.js';
 export { TextRenderer } from './TextRenderer.js';

--- a/src/marked.js
+++ b/src/marked.js
@@ -66,9 +66,19 @@ export function marked(src, opt, callback) {
 
       opt.highlight = highlight;
 
-      return err
-        ? callback(err)
-        : callback(null, out);
+      if (err) {
+        return callback(err);
+      }
+
+      if (opt.async) {
+        return Promise.resolve(out).then((html) => {
+          callback(null, html);
+        }, (asyncErr) => {
+          callback(asyncErr);
+        });
+      }
+
+      return callback(null, out);
     }
 
     if (!highlight || highlight.length < 3) {

--- a/test/helpers/helpers.js
+++ b/test/helpers/helpers.js
@@ -10,7 +10,7 @@ beforeEach(() => {
       return {
         compare: async(spec, expected) => {
           const result = {};
-          const actual = marked(spec.markdown, spec.options);
+          const actual = await marked(spec.markdown, spec.options);
           result.pass = await isEqual(expected, actual);
 
           if (result.pass) {
@@ -42,7 +42,7 @@ beforeEach(() => {
     toRenderExact: () => ({
       compare: async(spec, expected) => {
         const result = {};
-        const actual = marked(spec.markdown, spec.options);
+        const actual = await marked(spec.markdown, spec.options);
 
         result.pass = strictEqual(expected, actual) === undefined;
 

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -1,4 +1,4 @@
-import { marked, Renderer, Slugger, lexer, parseInline, use, getDefaults, walkTokens as _walkTokens } from '../../src/marked.js';
+import { marked, Renderer, Slugger, lexer, parseInline, use, getDefaults, walkTokens } from '../../src/marked.js';
 
 describe('Test heading ID functionality', () => {
   it('should add id attribute by default', () => {
@@ -989,7 +989,7 @@ br
 `;
     const tokens = lexer(markdown, { ...getDefaults(), breaks: true });
     const tokensSeen = [];
-    _walkTokens(tokens, (token) => {
+    walkTokens(tokens, (token) => {
       tokensSeen.push([token.type, (token.raw || '').replace(/\n/g, '')]);
     });
 
@@ -1058,5 +1058,21 @@ br
       }
     });
     expect(marked('*text*').trim()).toBe('<p><em>text walked</em></p>');
+  });
+});
+
+describe('async renderer', () => {
+  it('should render asynchronously', async() => {
+    const extension = {
+      async: true,
+      renderer: {
+        async paragraph(text) {
+          return 'extension';
+        }
+      }
+    };
+    use(extension);
+    const html = await marked('text');
+    expect(html).toBe('extension');
   });
 });


### PR DESCRIPTION
**Marked version:** 4.0.12

## Description

Add async parser that can be accessed with the `async: true` option.

This allows using async renderer methods:

```js
const renderer = {
  async image(href, title, text) {
    // do something asynchronous
  }
}
marked.use({renderer, async: true});
const html = await marked(markdown);
```

To prevent slowing down the synchronous parsing I cloned the `Parser` class to create an `AsyncParser` class that mimics `Parser` in every way but returns a promise for the `.parse` and `.parseInline` methods as well as awaiting the results of every renderer method.

---

### Things to consider:

- AsyncParser is about half the speed of the regular parser because it awaits every renderer call.
- Can we prevent duplicate code in parsers?
  - This approach has the major downside of having to maintain two parsing classes. If we change one we will have to remember to change the other. I did mitigate the risks of forgetting a fix to one by running all spec tests through both.
- Should we also make the tokenizer async?
- Should we also make walkTokens async?

---

- Fixes #458 

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression
- [x] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
