### PR TITLE
low level stream / iterator support

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,7 +25,10 @@ https://github.com/markedjs/marked
     }),
     commonjs(),
     babel({
-      presets: [['@babel/preset-env', { loose: true }]]
+      presets: [['@babel/preset-env', {
+        loose: true,
+        exclude: ['transform-regenerator']
+      }]]
     })
   ]
 },
@@ -52,7 +55,10 @@ https://github.com/markedjs/marked
     }),
     commonjs(),
     babel({
-      presets: [['@babel/preset-env', { loose: true }]]
+      presets: [['@babel/preset-env', {
+        loose: true,
+        exclude: ['transform-regenerator']
+      }]]
     })
   ]
 }];

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -16,6 +16,9 @@ export class Renderer {
     const lang = (infostring || '').match(/\S*/)[0];
     if (this.options.highlight) {
       const out = this.options.highlight(code, lang);
+      if (typeof out?.then === 'function') {
+        return out.then(out => `<pre><code>${out}</code></pre>`);
+      }
       if (out != null && out !== code) {
         escaped = true;
         code = out;

--- a/src/marked.js
+++ b/src/marked.js
@@ -54,7 +54,7 @@ export function marked(src, opt, callback) {
           if (opt.walkTokens) {
             marked.walkTokens(tokens, opt.walkTokens);
           }
-          out = Parser.parse(tokens, opt);
+          out = [...Parser.parse(tokens, opt)].join('');
         } catch (e) {
           err = e;
         }
@@ -110,7 +110,7 @@ export function marked(src, opt, callback) {
     if (opt.walkTokens) {
       marked.walkTokens(tokens, opt.walkTokens);
     }
-    return Parser.parse(tokens, opt);
+    return [...Parser.parse(tokens, opt)].join('');
   } catch (e) {
     e.message += '\nPlease report this to https://github.com/markedjs/marked.';
     if (opt.silent) {

--- a/test/bench.js
+++ b/test/bench.js
@@ -112,7 +112,7 @@ export async function runBench(options) {
       const parser = new Parser();
       const writer = new HtmlRenderer();
       return function(text) {
-        return writer.render(parser.parse(text));
+        return writer.render([...parser.parse(text)].join());
       };
     })()));
   } catch (e) {

--- a/test/unit/Parser-spec.js
+++ b/test/unit/Parser-spec.js
@@ -2,8 +2,8 @@ import { Parser } from '../../src/Parser.js';
 
 async function expectHtml({ tokens, options, html, inline }) {
   const parser = new Parser(options);
-  const actual = parser[inline ? 'parseInline' : 'parse'](tokens);
-  await expectAsync(actual).toEqualHtml(html);
+  const actual = parser[inline ? 'parseInline' : 'parse'](tokens, undefined, true);
+  await expectAsync(typeof actual === 'string' ? actual : [...actual].join('')).toEqualHtml(html);
 }
 
 describe('Parser', () => {

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -615,6 +615,31 @@ used extension2 walked</p>
     });
   });
 
+  it('should allow for iterator', () => {
+    const tokens = lexer(`
+# heading
+\`\`\`JSON
+{ "foo": "bar" }
+\`\`\`
+# footer
+    `);
+    use({
+      renderer: {
+        async code(code, lang) {
+          return `<pre><code>foo</code></pre>`;
+        }
+      }
+    });
+    const res = marked.Parser.getIterator(tokens);
+    return Promise.all([...res]).then(results => {
+      const actual = results.join('\n');
+      expect(actual).toBe(
+        '<h1 id="heading">heading</h1>\n\n'
+      + '<pre><code>foo</code></pre>\n'
+      + '<h1 id="footer">footer</h1>\n');
+    });
+  });
+
   it('should allow deleting/editing tokens', () => {
     const styleTags = {
       extensions: [{
@@ -642,7 +667,7 @@ used extension2 walked</p>
         name: 'styled',
         renderer(token) {
           token.type = token.originalType;
-          const text = this.parser.parse([token]);
+          const text = [...this.parser.parse([token])].join('');
           const openingTag = /(<[^\s<>]+)([^\n<>]*>.*)/s.exec(text);
           if (openingTag) {
             return `${openingTag[1]} ${token.style}${openingTag[2]}`;


### PR DESCRIPTION
My approche at potentially tackling a streamer / async render

## Description
Add sync parser that can iterated over all token and yield the response back to the user to allow for some sort of streaming / flushing out the result.

the idea is not to concatenate the hole response into one single string, and instead yield all data as it spits it out

This could later allow for a higher level component to await for something if it where to return a promise

To prevent slowing down the synchronous parsing and slamming in async everywhere (like PR: #458) that would otherwise cause the event loop to trigger unnecessary delays everywhere. i opted to take a different approach in the way that the developer will have to wait for a chunk to resolve if it returns a promise. (similar to how i suggested it at https://github.com/markedjs/marked/issues/458#issuecomment-1081954012)

### Things to consider:
  * This approach dose not mean we have to maintain two parsing classes.
  * if some renderer returns a promise then that will be returned to the streamer as a unresolved promise. 

Fixes [async renderer support #458](https://github.com/markedjs/marked/issues/458)

## Contributor
some few stuff is breaking...

## Committer
In most cases, this should be a different person than the contributor. and it also need to be bench tested against prev version

* [ ]  CI is green (no forced merge required).
* [ ]  Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).