### PR TITLE
configure Babel in esm packaging config

### DIFF
--- a/rollup.config.esm.js
+++ b/rollup.config.esm.js
@@ -1,4 +1,5 @@
 const commonjs = require('@rollup/plugin-commonjs');
+const babel = require('@rollup/plugin-babel').default;
 const license = require('rollup-plugin-license');
 
 module.exports = {
@@ -21,6 +22,9 @@ Copyright (c) 2011-${new Date().getFullYear()}, Christopher Jeffrey. (MIT Licens
 https://github.com/markedjs/marked
 `
     }),
-    commonjs()
+    commonjs(),
+    babel({
+      presets: [['@babel/preset-env', { loose: true }]]
+    })
   ]
 };


### PR DESCRIPTION
Babel is not only needed in UMD packagin, but also in ESM.

I'm notice this commit, [#1572](https://github.com/markedjs/marked/pull/1572),
**Use Babel's loose mode for shorted & more performant code**
I couldn't agree more with that statement,
and also think that use Babel translate javascript to esm module would also have the same benefits

