### PR TITLE
fix: fix ref links inside table

### DIFF
--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -405,7 +405,7 @@ export class Tokenizer {
         l = item.header.length;
         for (j = 0; j < l; j++) {
           item.header[j].tokens = [];
-          this.lexer.inlineTokens(item.header[j].text, item.header[j].tokens);
+          this.lexer.inline(item.header[j].text, item.header[j].tokens);
         }
 
         // cell child tokens
@@ -414,7 +414,7 @@ export class Tokenizer {
           row = item.rows[j];
           for (k = 0; k < row.length; k++) {
             row[k].tokens = [];
-            this.lexer.inlineTokens(row[k].text, row[k].tokens);
+            this.lexer.inline(row[k].text, row[k].tokens);
           }
         }
 

--- a/test/specs/new/table_reference_link.html
+++ b/test/specs/new/table_reference_link.html
@@ -1,0 +1,12 @@
+<table>
+	<thead>
+		<tr>
+			<th>a</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td><a href="https://www.google.com">d</a></td>
+		</tr>
+	</tbody>
+</table>

--- a/test/specs/new/table_reference_link.md
+++ b/test/specs/new/table_reference_link.md
@@ -1,0 +1,5 @@
+|   a    |
+| ------ |
+| [d][c] |
+
+[c]: https://www.google.com


### PR DESCRIPTION
**Marked version:** 3.0.0 - 4.0.15

**Markdown flavor:** GitHub Flavored Markdown

## Description

Reference links inside tables were broken in v3.0.0

- Fixes #2217 

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
