### PR TITLE
fix: make second parameter optional on lexer.inline

### DIFF
--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -318,6 +318,7 @@ export class Lexer {
 
   inline(src, tokens = []) {
     this.inlineQueue.push({ src, tokens });
+    return tokens;
   }
 
   /**

--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -316,7 +316,7 @@ export class Lexer {
     return tokens;
   }
 
-  inline(src, tokens) {
+  inline(src, tokens = []) {
     this.inlineQueue.push({ src, tokens });
   }
 

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -433,11 +433,10 @@ describe('use extension', () => {
             const token = {
               type: 'walkableDescription',
               raw: match[0],
-              dt: [],
+              dt: this.lexer.inline(match[1].trim()),
               dd: [],
               tokens: []
             };
-            this.lexer.inline(match[1].trim(), token.dt);
             this.lexer.inline(match[2].trim(), token.dd);
             this.lexer.inline('unwalked', token.tokens);
             return token;


### PR DESCRIPTION
**Marked version:** v4.0.18

<!-- The NPM version or commit hash having the issue -->

## Description

Allow second parameter for `lexer.inline` to be optional. See https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/61664#discussioncomment-3376571

<!--

	If no issue exists that you're aware of. The maintainers should be able to figure out if it's a duplicate.

## Expectation

Describe the output you are expecting from marked

## Result

Describe the output you received from marked

## What was attempted

Describe what code combination got you there

-->

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
