### PR TITLE
Removing smartLists from docs and code

### DIFF
--- a/docs/USING_ADVANCED.md
+++ b/docs/USING_ADVANCED.md
@@ -31,7 +31,6 @@ marked.setOptions({
   gfm: true,
   breaks: false,
   sanitize: false,
-  smartLists: true,
   smartypants: false,
   xhtml: false
 });
@@ -58,7 +57,6 @@ console.log(marked.parse(markdownString));
 |sanitize    |`boolean` |`false`  |v0.2.1   |If true, sanitize the HTML passed into `markdownString` with the `sanitizer` function.<br>**Warning**: This feature is deprecated and it should NOT be used as it cannot be considered secure.<br>Instead use a sanitize library, like [DOMPurify](https://github.com/cure53/DOMPurify) (recommended), [sanitize-html](https://github.com/apostrophecms/sanitize-html) or [insane](https://github.com/bevacqua/insane) on the output HTML! |
 |sanitizer   |`function`|`null`   |v0.3.4   |A function to sanitize the HTML passed into `markdownString`.|
 |silent      |`boolean` |`false`  |v0.2.7   |If true, the parser does not throw any exception.|
-|smartLists  |`boolean` |`false`  |v0.2.8   |If true, use smarter list behavior than those found in `markdown.pl`.|
 |smartypants |`boolean` |`false`  |v0.2.9   |If true, use "smart" typographic punctuation for things like quotes and dashes.|
 |tokenizer    |`object`  |`new Tokenizer()`|v1.0.0|An object containing functions to create tokens from markdown. See [extensibility](/using_pro) for more details.|
 |walkTokens   |`function`  |`null`|v1.1.0|A function which is called for every token. See [extensibility](/using_pro) for more details.|

--- a/docs/USING_PRO.md
+++ b/docs/USING_PRO.md
@@ -15,7 +15,6 @@ marked.use({
   gfm: true,
   breaks: false,
   sanitize: false,
-  smartLists: true,
   smartypants: false,
   xhtml: false
 });

--- a/lib/marked.cjs
+++ b/lib/marked.cjs
@@ -87,7 +87,6 @@ function getDefaults() {
     sanitize: false,
     sanitizer: null,
     silent: false,
-    smartLists: false,
     smartypants: false,
     tokenizer: null,
     walkTokens: null,

--- a/lib/marked.esm.js
+++ b/lib/marked.esm.js
@@ -26,7 +26,6 @@ function getDefaults() {
     sanitize: false,
     sanitizer: null,
     silent: false,
-    smartLists: false,
     smartypants: false,
     tokenizer: null,
     walkTokens: null,

--- a/lib/marked.umd.js
+++ b/lib/marked.umd.js
@@ -89,7 +89,6 @@
       sanitize: false,
       sanitizer: null,
       silent: false,
-      smartLists: false,
       smartypants: false,
       tokenizer: null,
       walkTokens: null,

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -15,7 +15,6 @@ export function getDefaults() {
     sanitize: false,
     sanitizer: null,
     silent: false,
-    smartLists: false,
     smartypants: false,
     tokenizer: null,
     walkTokens: null,

--- a/test/bench.js
+++ b/test/bench.js
@@ -38,8 +38,7 @@ export async function runBench(options) {
     gfm: false,
     breaks: false,
     pedantic: false,
-    sanitize: false,
-    smartLists: false
+    sanitize: false
   });
   if (options.marked) {
     cjsMarked.setOptions(options.marked);
@@ -50,8 +49,7 @@ export async function runBench(options) {
     gfm: false,
     breaks: false,
     pedantic: false,
-    sanitize: false,
-    smartLists: false
+    sanitize: false
   });
   if (options.marked) {
     esmMarked.setOptions(options.marked);
@@ -62,8 +60,7 @@ export async function runBench(options) {
   //   gfm: true,
   //   breaks: false,
   //   pedantic: false,
-  //   sanitize: false,
-  //   smartLists: false
+  //   sanitize: false
   // });
   // if (options.marked) {
   //   esmMarked.setOptions(options.marked);


### PR DESCRIPTION



## Description  

- Fixes #2582

## Removing all smartLists options which were removed in version v3.0

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.


