### PR TITLE
Adding Tools using Marked in docs

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -110,6 +110,16 @@ We actively support the features of the following [Markdown flavors](https://git
 
 By supporting the above Markdown flavors, it's possible that Marked can help you use other flavors as well; however, these are not actively supported by the community.
 
+<h2 id="specifications">List of Tools Using Marked</h2>
+
+We actively support the usability of Marked in super-fast markdown transformation, some of Tools using `Marked` for single-page creations are 
+
+| Tools                                                      | Version | Status                                                             |
+| :--------------------------------------------------------- | :------ | :----------------------------------------------------------------- |
+| [zero-md](https://zerodevx.github.io/zero-md/)             | 2.3.6   | [Active](https://github.com/zerodevx/zero-md)                      |
+| [texme](https://github.com/susam/texme)                    | 1.2.0   | [Active](https://www.jsdelivr.com/package/npm/texme)               |
+| [StrapDown.js](https://naereen.github.io/StrapDown.js/)    | 1.1.1   | [Active](https://naereen.github.io/StrapDown.js/)                  |
+
 <h2 id="security">Security</h2>
 
 The only completely secure system is the one that doesn't exist in the first place. Having said that, we take the security of Marked very seriously.


### PR DESCRIPTION
For Issue #2337
 - Please review it.

**Marked version:**

<!-- The NPM version or commit hash having the issue -->

**Markdown flavor:** Markdown.pl|CommonMark|GitHub Flavored Markdown|n/a

## Description

- Fixes #2337



## What was attempted

Adding Tools table in docs,
- These tools are single-page creation tools using Marked.


## Result
![image](https://user-images.githubusercontent.com/89572392/193450535-eb89c311-12ba-4725-86f3-405c6ca68f06.png)

Added this.



## Contributor

- [x] no tests are required for this PR.

