### PR TITLE
Adding Tools using Marked in docs

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -119,7 +119,7 @@ We actively support the usability of Marked in super-fast markdown transformatio
 | [zero-md](https://zerodevx.github.io/zero-md/)             | [Active](https://github.com/zerodevx/zero-md)                      |
 | [texme](https://github.com/susam/texme)                    | [Active](https://www.jsdelivr.com/package/npm/texme)               |
 | [StrapDown.js](https://naereen.github.io/StrapDown.js/)    | [Active](https://naereen.github.io/StrapDown.js/)                  |
-| [The Homebrewery](https://homebrewery.naturalcrit.com/)    | [Active](https://github.com/naturalcrit/homebrewery)                  |
+| [The Homebrewery](https://homebrewery.naturalcrit.com/)    | [Active](https://github.com/naturalcrit/homebrewery)               |
 
 <h2 id="security">Security</h2>
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -110,6 +110,17 @@ We actively support the features of the following [Markdown flavors](https://git
 
 By supporting the above Markdown flavors, it's possible that Marked can help you use other flavors as well; however, these are not actively supported by the community.
 
+<h2 id="specifications">List of Tools Using Marked</h2>
+
+We actively support the usability of Marked in super-fast markdown transformation, some of Tools using `Marked` for single-page creations are 
+
+| Tools                                                      | Status                                                             |
+| :--------------------------------------------------------- | :----------------------------------------------------------------- |
+| [zero-md](https://zerodevx.github.io/zero-md/)             | [Active](https://github.com/zerodevx/zero-md)                      |
+| [texme](https://github.com/susam/texme)                    | [Active](https://www.jsdelivr.com/package/npm/texme)               |
+| [StrapDown.js](https://naereen.github.io/StrapDown.js/)    | [Active](https://naereen.github.io/StrapDown.js/)                  |
+| [The Homebrewery](https://homebrewery.naturalcrit.com/)    | [Active](https://github.com/naturalcrit/homebrewery)                  |
+
 <h2 id="security">Security</h2>
 
 The only completely secure system is the one that doesn't exist in the first place. Having said that, we take the security of Marked very seriously.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -114,12 +114,12 @@ By supporting the above Markdown flavors, it's possible that Marked can help you
 
 We actively support the usability of Marked in super-fast markdown transformation, some of Tools using `Marked` for single-page creations are 
 
-| Tools                                                      | Status                                                             |
-| :--------------------------------------------------------- | :----------------------------------------------------------------- |
-| [zero-md](https://zerodevx.github.io/zero-md/)             | [Active](https://github.com/zerodevx/zero-md)                      |
-| [texme](https://github.com/susam/texme)                    | [Active](https://www.jsdelivr.com/package/npm/texme)               |
-| [StrapDown.js](https://naereen.github.io/StrapDown.js/)    | [Active](https://naereen.github.io/StrapDown.js/)                  |
-| [The Homebrewery](https://homebrewery.naturalcrit.com/)    | [Active](https://github.com/naturalcrit/homebrewery)               |
+| Tools                                                               |                  Description                                               |
+| :-----------------------------------------------------------------  | :------------------------------------------------------------------------  |
+| [zero-md](https://zerodevx.github.io/zero-md/)                      | A native markdown-to-html web component to load and display an external MD file.It uses Marked for super-fast markdown transformation. |
+| [TeXMe](https://github.com/susam/texme)                             | TeXMe is a lightweight JavaScript utility to create self-rendering Markdown + LaTeX documents.             |
+| [StrapDown.js](https://naereen.github.io/StrapDown.js/)             | StrapDown.js is an awesome on-the-fly Markdown to HTML text processor.                |
+| [Homebrewery](https://homebrewery.naturalcrit.com/)             | The Homebrewery is a tool for making authentic looking D&D content using Markdown. It is distributed under the terms of the MIT.             |
 
 <h2 id="security">Security</h2>
 


### PR DESCRIPTION
Adds new section for Tools using Marked

**Marked version:**

<!-- The NPM version or commit hash having the issue -->

**Markdown flavor:** Markdown.pl|CommonMark|GitHub Flavored Markdown|n/a

## Description

- Fixes #2337



## What was attempted

Adding Tools table in docs,
- These tools are single-page creation tools using Marked.


## Result
![image](https://user-images.githubusercontent.com/89572392/193622030-8a12c6f4-3abc-40c8-bb9d-cb44fb922d07.png)


Added this.



## Contributor

- [x] no tests are required for this PR.

