### PR TITLE
chore: update dingus

### DIFF
--- a/api/dingus.js
+++ b/api/dingus.js
@@ -1,8 +1,10 @@
-const marked = require('../');
+import { marked } from '../src/marked.js';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
 const version = require('../package.json').version;
 const name = 'Marked';
 
-module.exports = (req, res) => {
+export default function dingus(req, res) {
   if (req.method !== 'GET') {
     return res.status(405).json({
       error: {
@@ -14,4 +16,4 @@ module.exports = (req, res) => {
   const { text = '' } = req.query;
   const html = marked(text);
   res.json({ name, version, html });
-};
+}


### PR DESCRIPTION
## Description

Update dingus to es module.

https://marked.js.org/api/dingus?text=Hello%20World fails with error:

```
ERROR	ReferenceError: require is not defined in ES module scope, you can use import instead
This file is being treated as an ES module because it has a '.js' file extension and '/var/task/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
```

test at https://marked-website-git-fork-uzitech-api-markedjs.vercel.app/api/dingus?text=Hello%20World

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
