### PR TITLE
fix: Support escapes within emphasis

### DIFF
--- a/src/Lexer.js
+++ b/src/Lexer.js
@@ -350,7 +350,8 @@ export class Lexer {
 
     // Mask out escaped em & strong delimiters
     while ((match = this.tokenizer.rules.inline.escapedEmSt.exec(maskedSrc)) != null) {
-      maskedSrc = maskedSrc.slice(0, match.index) + '++' + maskedSrc.slice(this.tokenizer.rules.inline.escapedEmSt.lastIndex);
+      maskedSrc = maskedSrc.slice(0, match.index + match[0].length - 2) + '++' + maskedSrc.slice(this.tokenizer.rules.inline.escapedEmSt.lastIndex);
+      this.tokenizer.rules.inline.escapedEmSt.lastIndex--;
     }
 
     while (src) {

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -629,22 +629,24 @@ export class Tokenizer {
         // Remove extra characters. *a*** -> *a*
         rLength = Math.min(rLength, rLength + delimTotal + midDelimTotal);
 
+        const raw = src.slice(0, lLength + match.index + (match[0].length - rDelim.length) + rLength);
+
         // Create `em` if smallest delimiter has odd char count. *a***
         if (Math.min(lLength, rLength) % 2) {
-          const text = src.slice(1, lLength + match.index + rLength);
+          const text = raw.slice(1, -1);
           return {
             type: 'em',
-            raw: src.slice(0, lLength + match.index + rLength + 1),
+            raw,
             text,
             tokens: this.lexer.inlineTokens(text)
           };
         }
 
         // Create 'strong' if smallest delimiter has even char count. **a***
-        const text = src.slice(2, lLength + match.index + rLength - 1);
+        const text = raw.slice(2, -2);
         return {
           type: 'strong',
-          raw: src.slice(0, lLength + match.index + rLength + 1),
+          raw,
           text,
           tokens: this.lexer.inlineTokens(text)
         };

--- a/src/rules.js
+++ b/src/rules.js
@@ -168,7 +168,7 @@ export const inline = {
   emStrong: {
     lDelim: /^(?:\*+(?:([punct_])|[^\s*]))|^_+(?:([punct*])|([^\s_]))/,
     //        (1) and (2) can only be a Right Delimiter. (3) and (4) can only be Left.  (5) and (6) can be either Left or Right.
-    //          () Skip orphan inside strong  () Consume to delim (1) #***                (2) a***#, a***                   (3) #***a, ***a                 (4) ***#              (5) #***#                 (6) a***a
+    //          () Skip orphan inside strong                                      () Consume to delim     (1) #***                (2) a***#, a***                             (3) #***a, ***a                 (4) ***#              (5) #***#                 (6) a***a
     rDelimAst: /^(?:[^_*\\]|\\.)*?\_\_(?:[^_*\\]|\\.)*?\*(?:[^_*\\]|\\.)*?(?=\_\_)|(?:[^*\\]|\\.)+(?=[^*])|[punct_](\*+)(?=[\s]|$)|(?:[^punct*_\s\\]|\\.)(\*+)(?=[punct_\s]|$)|[punct_\s](\*+)(?=[^punct*_\s])|[\s](\*+)(?=[punct_])|[punct_](\*+)(?=[punct_])|(?:[^punct*_\s\\]|\\.)(\*+)(?=[^punct*_\s])/,
     rDelimUnd: /^(?:[^_*\\]|\\.)*?\*\*(?:[^_*\\]|\\.)*?\_(?:[^_*\\]|\\.)*?(?=\*\*)|(?:[^_\\]|\\.)+(?=[^_])|[punct*](\_+)(?=[\s]|$)|(?:[^punct*_\s\\]|\\.)(\_+)(?=[punct*\s]|$)|[punct*\s](\_+)(?=[^punct*_\s])|[\s](\_+)(?=[punct*])|[punct*](\_+)(?=[punct*])/ // ^- Not allowed for _
   },

--- a/src/rules.js
+++ b/src/rules.js
@@ -169,8 +169,8 @@ export const inline = {
     lDelim: /^(?:\*+(?:([punct_])|[^\s*]))|^_+(?:([punct*])|([^\s_]))/,
     //        (1) and (2) can only be a Right Delimiter. (3) and (4) can only be Left.  (5) and (6) can be either Left or Right.
     //          () Skip orphan inside strong  () Consume to delim (1) #***                (2) a***#, a***                   (3) #***a, ***a                 (4) ***#              (5) #***#                 (6) a***a
-    rDelimAst: /^[^_*]*?\_\_[^_*]*?\*[^_*]*?(?=\_\_)|[^*]+(?=[^*])|[punct_](\*+)(?=[\s]|$)|[^punct*_\s](\*+)(?=[punct_\s]|$)|[punct_\s](\*+)(?=[^punct*_\s])|[\s](\*+)(?=[punct_])|[punct_](\*+)(?=[punct_])|[^punct*_\s](\*+)(?=[^punct*_\s])/,
-    rDelimUnd: /^[^_*]*?\*\*[^_*]*?\_[^_*]*?(?=\*\*)|[^_]+(?=[^_])|[punct*](\_+)(?=[\s]|$)|[^punct*_\s](\_+)(?=[punct*\s]|$)|[punct*\s](\_+)(?=[^punct*_\s])|[\s](\_+)(?=[punct*])|[punct*](\_+)(?=[punct*])/ // ^- Not allowed for _
+    rDelimAst: /^(?:[^_*\\]|\\.)*?\_\_(?:[^_*\\]|\\.)*?\*(?:[^_*\\]|\\.)*?(?=\_\_)|(?:[^*\\]|\\.)+(?=[^*])|[punct_](\*+)(?=[\s]|$)|(?:[^punct*_\s\\]|\\.)(\*+)(?=[punct_\s]|$)|[punct_\s](\*+)(?=[^punct*_\s])|[\s](\*+)(?=[punct_])|[punct_](\*+)(?=[punct_])|(?:[^punct*_\s\\]|\\.)(\*+)(?=[^punct*_\s])/,
+    rDelimUnd: /^(?:[^_*\\]|\\.)*?\*\*(?:[^_*\\]|\\.)*?\_(?:[^_*\\]|\\.)*?(?=\*\*)|(?:[^_\\]|\\.)+(?=[^_])|[punct*](\_+)(?=[\s]|$)|(?:[^punct*_\s\\]|\\.)(\_+)(?=[punct*\s]|$)|[punct*\s](\_+)(?=[^punct*_\s])|[\s](\_+)(?=[punct*])|[punct*](\_+)(?=[punct*])/ // ^- Not allowed for _
   },
   code: /^(`+)([^`]|[^`][\s\S]*?[^`])\1(?!`)/,
   br: /^( {2,}|\\)\n(?!\s*$)/,

--- a/src/rules.js
+++ b/src/rules.js
@@ -186,7 +186,9 @@ inline.punctuation = edit(inline.punctuation).replace(/punctuation/g, inline._pu
 
 // sequences em should skip over [title](link), `code`, <html>
 inline.blockSkip = /\[[^\]]*?\]\([^\)]*?\)|`[^`]*?`|<[^>]*?>/g;
-inline.escapedEmSt = /\\\*|\\_/g;
+// lookbehind is not available on Safari as of version 16
+// inline.escapedEmSt = /(?<=(?:^|[^\\)(?:\\[^])*)\\[*_]/g;
+inline.escapedEmSt = /(?:^|[^\\])(?:\\[^])*\\[*_]/g;
 
 inline._comment = edit(block._comment).replace('(?:-->|$)', '-->').getRegex();
 

--- a/src/rules.js
+++ b/src/rules.js
@@ -188,7 +188,7 @@ inline.punctuation = edit(inline.punctuation).replace(/punctuation/g, inline._pu
 inline.blockSkip = /\[[^\]]*?\]\([^\)]*?\)|`[^`]*?`|<[^>]*?>/g;
 // lookbehind is not available on Safari as of version 16
 // inline.escapedEmSt = /(?<=(?:^|[^\\)(?:\\[^])*)\\[*_]/g;
-inline.escapedEmSt = /(?:^|[^\\])(?:\\[^])*\\[*_]/g;
+inline.escapedEmSt = /(?:^|[^\\])(?:\\\\)*\\[*_]/g;
 
 inline._comment = edit(block._comment).replace('(?:-->|$)', '-->').getRegex();
 

--- a/test/specs/new/escape_within_emphasis.html
+++ b/test/specs/new/escape_within_emphasis.html
@@ -1,0 +1,5 @@
+<p><strong>strong text[</strong>]</p>
+
+<p><strong>strong text\[</strong>]</p>
+
+<p><em>em[pha](sis)</em></p>

--- a/test/specs/new/escape_within_emphasis.html
+++ b/test/specs/new/escape_within_emphasis.html
@@ -3,3 +3,5 @@
 <p><strong>strong text\[</strong>]</p>
 
 <p><em>em[pha](sis)</em></p>
+
+<p><em>\</em></p>

--- a/test/specs/new/escape_within_emphasis.md
+++ b/test/specs/new/escape_within_emphasis.md
@@ -3,3 +3,5 @@
 **strong text\\\[**\]
 
 _em\[pha\]\(sis\)_
+
+_\\_

--- a/test/specs/new/escape_within_emphasis.md
+++ b/test/specs/new/escape_within_emphasis.md
@@ -1,0 +1,5 @@
+**strong text\[**\]
+
+**strong text\\\[**\]
+
+_em\[pha\]\(sis\)_

--- a/test/unit/Lexer-spec.js
+++ b/test/unit/Lexer-spec.js
@@ -776,6 +776,41 @@ paragraph
         });
       });
 
+      it('escaped punctuation inside emphasis', () => {
+        expectInlineTokens({
+          md: '**strong text\\[**\\]',
+          tokens: [
+            {
+              type: 'strong',
+              raw: '**strong text\\[**',
+              text: 'strong text\\[',
+              tokens: [
+                { type: 'text', raw: 'strong text', text: 'strong text' },
+                { type: 'escape', raw: '\\[', text: '[' }
+              ]
+            },
+            { type: 'escape', raw: '\\]', text: ']' }
+          ]
+        });
+        expectInlineTokens({
+          md: '_em\\<pha\\>sis_',
+          tokens: [
+            {
+              type: 'em',
+              raw: '_em\\<pha\\>sis_',
+              text: 'em\\<pha\\>sis',
+              tokens: [
+                { type: 'text', raw: 'em', text: 'em' },
+                { type: 'escape', raw: '\\<', text: '&lt;' },
+                { type: 'text', raw: 'pha', text: 'pha' },
+                { type: 'escape', raw: '\\>', text: '&gt;' },
+                { type: 'text', raw: 'sis', text: 'sis' }
+              ]
+            }
+          ]
+        });
+      });
+
       it('html', () => {
         expectInlineTokens({
           md: '<div>html</div>',


### PR DESCRIPTION
...particularly right at the end.

Fixes #2280

This resolves the issue at hand, but further improvements will be necessary to bring things fully into alignment with https://spec.commonmark.org/0.30/#emphasis-and-strong-emphasis .

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
