### PR TITLE
fix: fix escape characters in links

### DIFF
--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -99,11 +99,12 @@ export class Tokenizer {
     if (cap) {
       const raw = cap[0];
       const text = indentCodeCompensation(raw, cap[3] || '');
+      const lang = (cap[2] ? cap[2].trim() : cap[2]).replace(this.rules.inline._escapes, '$1');
 
       return {
         type: 'code',
         raw,
-        lang: cap[2] ? cap[2].trim() : cap[2],
+        lang,
         text
       };
     }
@@ -582,7 +583,10 @@ export class Tokenizer {
           text
         };
       }
-      return outputLink(cap, link, cap[0], this.lexer);
+      return outputLink(cap, {
+        href: link.href.replace(this.rules.inline._escapes, '$1'),
+        title: link.title ? link.title.replace(this.rules.inline._escapes, '$1') : link.title
+      }, cap[0], this.lexer);
     }
   }
 

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -372,8 +372,8 @@ export class Tokenizer {
         type: 'def',
         tag,
         raw: cap[0],
-        href: cap[2],
-        title: cap[3]
+        href: cap[2] ? cap[2].replace(this.rules.inline._escapes, '$1') : cap[2],
+        title: cap[3] ? cap[3].replace(this.rules.inline._escapes, '$1') : cap[3]
       };
     }
   }
@@ -583,10 +583,7 @@ export class Tokenizer {
           text
         };
       }
-      return outputLink(cap, {
-        href: link.href.replace(this.rules.inline._escapes, '$1'),
-        title: link.title ? link.title.replace(this.rules.inline._escapes, '$1') : link.title
-      }, cap[0], this.lexer);
+      return outputLink(cap, link, cap[0], this.lexer);
     }
   }
 

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -99,12 +99,11 @@ export class Tokenizer {
     if (cap) {
       const raw = cap[0];
       const text = indentCodeCompensation(raw, cap[3] || '');
-      const lang = (cap[2] ? cap[2].trim() : cap[2]).replace(this.rules.inline._escapes, '$1');
 
       return {
         type: 'code',
         raw,
-        lang,
+        lang: cap[2] ? cap[2].trim().replace(this.rules.inline._escapes, '$1') : cap[2],
         text
       };
     }

--- a/test/specs/commonmark/commonmark.0.30.json
+++ b/test/specs/commonmark/commonmark.0.30.json
@@ -181,8 +181,7 @@
     "example": 23,
     "start_line": 605,
     "end_line": 611,
-    "section": "Backslash escapes",
-    "shouldFail": true
+    "section": "Backslash escapes"
   },
   {
     "markdown": "``` foo\\+bar\nfoo\n```\n",
@@ -190,8 +189,7 @@
     "example": 24,
     "start_line": 614,
     "end_line": 621,
-    "section": "Backslash escapes",
-    "shouldFail": true
+    "section": "Backslash escapes"
   },
   {
     "markdown": "&nbsp; &amp; &copy; &AElig; &Dcaron;\n&frac34; &HilbertSpace; &DifferentialD;\n&ClockwiseContourIntegral; &ngE;\n",
@@ -1624,8 +1622,7 @@
     "example": 202,
     "start_line": 3307,
     "end_line": 3313,
-    "section": "Link reference definitions",
-    "shouldFail": true
+    "section": "Link reference definitions"
   },
   {
     "markdown": "[foo]\n\n[foo]: url\n",

--- a/test/specs/gfm/commonmark.0.30.json
+++ b/test/specs/gfm/commonmark.0.30.json
@@ -181,8 +181,7 @@
     "example": 23,
     "start_line": 605,
     "end_line": 611,
-    "section": "Backslash escapes",
-    "shouldFail": true
+    "section": "Backslash escapes"
   },
   {
     "markdown": "``` foo\\+bar\nfoo\n```\n",
@@ -190,8 +189,7 @@
     "example": 24,
     "start_line": 614,
     "end_line": 621,
-    "section": "Backslash escapes",
-    "shouldFail": true
+    "section": "Backslash escapes"
   },
   {
     "markdown": "&nbsp; &amp; &copy; &AElig; &Dcaron;\n&frac34; &HilbertSpace; &DifferentialD;\n&ClockwiseContourIntegral; &ngE;\n",
@@ -1624,8 +1622,7 @@
     "example": 202,
     "start_line": 3307,
     "end_line": 3313,
-    "section": "Link reference definitions",
-    "shouldFail": true
+    "section": "Link reference definitions"
   },
   {
     "markdown": "[foo]\n\n[foo]: url\n",


### PR DESCRIPTION
**Marked version:** 4.1.1

## Description

Fixes [backslash escapes](https://spec.commonmark.org/0.30/#backslash-escapes) for common mark specs [`#23`](https://spec.commonmark.org/0.30/#example-23), [`#24`](https://spec.commonmark.org/0.30/#example-24), and [`#202`](https://spec.commonmark.org/0.30/#example-202)

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
