### PR TITLE
feat: export bin/marked

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
       "import": "./lib/marked.esm.js",
       "default": "./lib/marked.cjs"
     },
+    "./bin/marked": "./bin/marked.js",
     "./package.json": "./package.json"
   },
   "repository": "git://github.com/markedjs/marked.git",


### PR DESCRIPTION
This allows tools like marked-man to extend marked and still use its cli.
