### PR TITLE
docs: add cli extension docs

### DIFF
--- a/docs/USING_ADVANCED.md
+++ b/docs/USING_ADVANCED.md
@@ -195,7 +195,7 @@ You can use extensions in the CLI by creating a new CLI that imports marked and 
 import { marked } from 'marked';
 import customHeadingId from 'marked-custom-heading-id';
 
-marked.use(customHeadingId);
+marked.use(customHeadingId());
 
 import 'marked/bin/marked';
 ```

--- a/docs/USING_ADVANCED.md
+++ b/docs/USING_ADVANCED.md
@@ -184,3 +184,23 @@ markedWorker.onmessage = (e) => {
 
 markedWorker.postMessage(markdownString);
 ```
+<h2 id="cli-extensions">CLI Extensions</h2>
+
+You can use extensions in the CLI by creating a new CLI that imports marked and the marked binary.
+
+```js
+// file: myMarked
+#!/usr/bin/node
+
+import { marked } from 'marked';
+import customHeadingId from 'marked-custom-heading-id';
+
+marked.use(customHeadingId);
+
+import 'marked/bin/marked';
+```
+
+```sh
+$ ./myMarked -s "# heading {#custom-id}"
+<h1 id="custom-id">heading</h1>
+```

--- a/docs/_document.html
+++ b/docs/_document.html
@@ -43,6 +43,7 @@
                             <li><a href="/using_advanced#inline">Inline Markdown</a></li>
                             <li><a href="/using_advanced#highlight">Highlighting</a></li>
                             <li><a href="/using_advanced#workers">Workers</a></li>
+                            <li><a href="/using_advanced#cli-extensions">CLI Extensions</a></li>
                         </ul>
                     </li>
                     <li>


### PR DESCRIPTION
## Description

Add documentation for #2629 

[preview](https://marked-website-git-fork-uzitech-cli-extension-docs-markedjs.vercel.app/using_advanced#cli-extensions)

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
