### PR TITLE
doc: use marked-man to generate man page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,10 @@ clean:
 bench:
 	@node test --bench
 
-man/marked.1.txt:
+man/marked.1.txt: man/marked.1
 	groff -man -Tascii man/marked.1 | col -b > man/marked.1.txt
+
+man/marked.1: man/marked.md
+	npx marked-man $< > $@
 
 .PHONY: clean all

--- a/man/marked.1
+++ b/man/marked.1
@@ -1,92 +1,118 @@
-.ds q \N'34'
-.TH marked 1
-
-.SH NAME
-marked \- a javascript markdown parser
-
+.TH "MARKED" "1" "November 2022" "4.2.2"
+.SH "NAME"
+\fBmarked\fR \- a javascript markdown parser
 .SH SYNOPSIS
-.B marked
-[\-o \fI<output>\fP] [\-i \fI<input>\fP] [\-s \fI<string>\fP] [\-\-help]
-[\-\-tokens] [\-\-pedantic] [\-\-gfm]
-[\-\-breaks] [\-\-sanitize]
-[\-\-smart\-lists] [\-\-lang\-prefix \fI<prefix>\fP]
-[\-\-no\-etc...] [\-\-silent] [\fIfilename\fP]
-
+.P
+\fBmarked\fP [\fB\-o\fP <output>] [\fB\-i\fP <input>] [\fB\-s\fP <string>] [\fB\-\-help\fP] [\fB\-\-tokens\fP] [\fB\-\-pedantic\fP] [\fB\-\-gfm\fP] [\fB\-\-breaks\fP] [\fB\-\-sanitize\fP] [\fB\-\-smart\-lists\fP] [\fB\-\-lang\-prefix\fP <prefix>] [\fB\-\-no\-etc\.\.\.\fP] [\fB\-\-silent\fP] [filename]
 .SH DESCRIPTION
-.B marked
-is a full-featured javascript markdown parser, built for speed.
-It also includes multiple GFM features.
-
+.P
+marked is a full\-featured javascript markdown parser, built for speed\.
+.br
+It also includes multiple GFM features\.
 .SH EXAMPLES
-.TP
-cat in.md | marked > out.html
-.TP
+.RS 2
+.nf
+cat in\.md | marked > out\.html
+.fi
+.RE
+.RS 2
+.nf
 echo "hello *world*" | marked
-.TP
-marked \-o out.html \-i in.md \-\-gfm
-.TP
-marked \-\-output="hello world.html" \-i in.md \-\-no-breaks
-
+.fi
+.RE
+.RS 2
+.nf
+marked \-o out\.html \-i in\.md \-\-gfm
+.fi
+.RE
+.RS 2
+.nf
+marked \-\-output="hello world\.html" \-i in\.md \-\-no\-breaks
+.fi
+.RE
 .SH OPTIONS
-.TP
-.BI \-o,\ \-\-output\ [\fIoutput\fP]
-Specify file output. If none is specified, write to stdout.
-.TP
-.BI \-i,\ \-\-input\ [\fIinput\fP]
-Specify file input, otherwise use last argument as input file.
-If no input file is specified, read from stdin.
-.TP
-.BI \-s,\ \-\-string\ [\fIstring\fP]
-Specify string input instead of a file.
-.TP
-.BI \-t,\ \-\-tokens
-Output a token stream instead of html.
-.TP
-.BI \-\-pedantic
-Conform to obscure parts of markdown.pl as much as possible.
-Don't fix original markdown bugs.
-.TP
-.BI \-\-gfm
-Enable github flavored markdown.
-.TP
-.BI \-\-breaks
-Enable GFM line breaks. Only works with the gfm option.
-.TP
-.BI \-\-sanitize
-Sanitize output. Ignore any HTML input.
-.TP
-.BI \-\-smart\-lists
-Use smarter list behavior than the original markdown.
-.TP
-.BI \-\-lang\-prefix\ [\fIprefix\fP]
-Set the prefix for code block classes.
-.TP
-.BI \-\-mangle
-Mangle email addresses.
-.TP
-.BI \-\-no\-sanitize,\ \-no-etc...
-The inverse of any of the marked options above.
-.TP
-.BI \-\-silent
-Silence error output.
-.TP
-.BI \-h,\ \-\-help
-Display help information.
 
+.RS 1
+.IP \(bu 2
+\-o, \-\-output [output]
+.br
+Specify file output\. If none is specified, write to stdout\.
+.IP \(bu 2
+\-i, \-\-input [input]
+.br
+Specify file input, otherwise use last argument as input file\.
+.br
+If no input file is specified, read from stdin\.
+.IP \(bu 2
+\-s, \-\-string [string]
+.br
+Specify string input instead of a file\.
+.IP \(bu 2
+\-t, \-\-tokens
+.br
+Output a token stream instead of html\.
+.IP \(bu 2
+\-\-pedantic
+.br
+Conform to obscure parts of markdown\.pl as much as possible\.
+.br
+Don't fix original markdown bugs\.
+.IP \(bu 2
+\-\-gfm
+.br
+Enable github flavored markdown\.
+.IP \(bu 2
+\-\-breaks
+.br
+Enable GFM line breaks\. Only works with the gfm option\.
+.IP \(bu 2
+\-\-sanitize
+.br
+Sanitize output\. Ignore any HTML input\.
+.IP \(bu 2
+\-\-smart\-lists
+.br
+Use smarter list behavior than the original markdown\.
+.IP \(bu 2
+\-\-lang\-prefix [prefix]
+.br
+Set the prefix for code block classes\.
+.IP \(bu 2
+\-\-mangle
+.br
+Mangle email addresses\.
+.IP \(bu 2
+\-\-no\-sanitize, \-no\-etc\.\.\.
+.br
+The inverse of any of the marked options above\.
+.IP \(bu 2
+\-\-silent
+.br
+Silence error output\.
+.IP \(bu 2
+\-h, \-\-help
+.br
+Display help information\.
+
+.RE
 .SH CONFIGURATION
-For configuring and running programmatically.
-
-.B Example
-
-    import { marked } from 'marked';
-    marked('*foo*', { gfm: true });
-
+.P
+For configuring and running programmatically\.
+.P
+Example
+.RS 2
+.nf
+import { marked } from 'marked';
+marked('*foo*', { gfm: true });
+.fi
+.RE
 .SH BUGS
-Please report any bugs to https://github.com/markedjs/marked.
-
+.P
+Please report any bugs to https://github.com/markedjs/marked
 .SH LICENSE
-Copyright (c) 2011-2014, Christopher Jeffrey (MIT License).
+.P
+Copyright (c) 2011\-2014, Christopher Jeffrey (MIT License)\.
+.SH SEE ALSO
+.P
+markdown(1), nodejs(1)
 
-.SH "SEE ALSO"
-.BR markdown(1),
-.BR node.js(1)

--- a/man/marked.1.txt
+++ b/man/marked.1.txt
@@ -1,4 +1,6 @@
-marked(1)		    General Commands Manual		     marked(1)
+MARKED(1)		    General Commands Manual		     MARKED(1)
+
+
 
 NAME
        marked - a javascript markdown parser
@@ -8,79 +10,79 @@ SYNOPSIS
        [--pedantic]   [--gfm]	 [--breaks]    [--sanitize]    [--smart-lists]
        [--lang-prefix <prefix>] [--no-etc...] [--silent] [filename]
 
-
 DESCRIPTION
        marked is a full-featured javascript markdown parser, built for speed.
        It also includes multiple GFM features.
 
 EXAMPLES
-       cat in.md | marked > out.html
-
-       echo "hello *world*" | marked
-
-       marked -o out.html -i in.md --gfm
-
-       marked --output="hello world.html" -i in.md --no-breaks
+	 cat in.md | marked > out.html
+	 echo "hello *world*" | marked
+	 marked -o out.html -i in.md --gfm
+	 marked --output="hello world.html" -i in.md --no-breaks
 
 OPTIONS
-       -o, --output [output]
-	      Specify file output. If none is specified, write to stdout.
+	o -o, --output [output]
+	  Specify file output. If none is specified, write to stdout.
 
-       -i, --input [input]
-	      Specify file input, otherwise use last argument as input file.
-	      If no input file is specified, read from stdin.
+	o -i, --input [input]
+	  Specify file input, otherwise use last argument as input file.
+	  If no input file is specified, read from stdin.
 
-       -s, --string [string]
-	      Specify string input instead of a file.
+	o -s, --string [string]
+	  Specify string input instead of a file.
 
-       -t, --tokens
-	      Output a token stream instead of html.
+	o -t, --tokens
+	  Output a token stream instead of html.
 
-       --pedantic
-	      Conform to obscure parts of markdown.pl as much as possible.
-	      Don't fix original markdown bugs.
+	o --pedantic
+	  Conform to obscure parts of markdown.pl as much as possible.
+	  Don't fix original markdown bugs.
 
-       --gfm  Enable github flavored markdown.
+	o --gfm
+	  Enable github flavored markdown.
 
-       --breaks
-	      Enable GFM line breaks. Only works with the gfm option.
+	o --breaks
+	  Enable GFM line breaks. Only works with the gfm option.
 
-       --sanitize
-	      Sanitize output. Ignore any HTML input.
+	o --sanitize
+	  Sanitize output. Ignore any HTML input.
 
-       --smart-lists
-	      Use smarter list behavior than the original markdown.
+	o --smart-lists
+	  Use smarter list behavior than the original markdown.
 
-       --lang-prefix [prefix]
-	      Set the prefix for code block classes.
+	o --lang-prefix [prefix]
+	  Set the prefix for code block classes.
 
-       --mangle
-	      Mangle email addresses.
+	o --mangle
+	  Mangle email addresses.
 
-       --no-sanitize, -no-etc...
-	      The inverse of any of the marked options above.
+	o --no-sanitize, -no-etc...
+	  The inverse of any of the marked options above.
 
-       --silent
-	      Silence error output.
+	o --silent
+	  Silence error output.
 
-       -h, --help
-	      Display help information.
+	o -h, --help
+	  Display help information.
+
 
 CONFIGURATION
        For configuring and running programmatically.
 
        Example
-
-	   import { marked } from 'marked';
-	   marked('*foo*', { gfm: true });
+	 import { marked } from 'marked';
+	 marked('*foo*', { gfm: true });
 
 BUGS
-       Please report any bugs to https://github.com/markedjs/marked.
+       Please report any bugs to https://github.com/markedjs/marked
 
 LICENSE
        Copyright (c) 2011-2014, Christopher Jeffrey (MIT License).
 
 SEE ALSO
-       markdown(1), node.js(1)
+       markdown(1), nodejs(1)
 
-								     marked(1)
+
+
+
+4.2.2				 November 2022			     MARKED(1)

--- a/man/marked.md
+++ b/man/marked.md
@@ -1,0 +1,97 @@
+# marked(1) -- a javascript markdown parser
+
+## SYNOPSIS
+
+`marked` [`-o` <output>] [`-i` <input>] [`-s` <string>] [`--help`] [`--tokens`] [`--pedantic`] [`--gfm`] [`--breaks`] [`--sanitize`] [`--smart-lists`] [`--lang-prefix` <prefix>] [`--no-etc...`] [`--silent`] [filename]
+
+## DESCRIPTION
+
+marked is a full-featured javascript markdown parser, built for speed.
+It also includes multiple GFM features.
+
+## EXAMPLES
+
+```sh
+cat in.md | marked > out.html
+```
+
+```sh
+echo "hello *world*" | marked
+```
+
+```sh
+marked -o out.html -i in.md --gfm
+```
+
+```sh
+marked --output="hello world.html" -i in.md --no-breaks
+```
+
+## OPTIONS
+
+* -o, --output [output]
+Specify file output. If none is specified, write to stdout.
+
+* -i, --input [input]
+Specify file input, otherwise use last argument as input file.
+If no input file is specified, read from stdin.
+
+* -s, --string [string]
+Specify string input instead of a file.
+
+* -t, --tokens
+Output a token stream instead of html.
+
+* --pedantic
+Conform to obscure parts of markdown.pl as much as possible.
+Don't fix original markdown bugs.
+
+* --gfm
+Enable github flavored markdown.
+
+* --breaks
+Enable GFM line breaks. Only works with the gfm option.
+
+* --sanitize
+Sanitize output. Ignore any HTML input.
+
+* --smart-lists
+Use smarter list behavior than the original markdown.
+
+* --lang-prefix [prefix]
+Set the prefix for code block classes.
+
+* --mangle
+Mangle email addresses.
+
+* --no-sanitize, -no-etc...
+The inverse of any of the marked options above.
+
+* --silent
+Silence error output.
+
+* -h, --help
+Display help information.
+
+## CONFIGURATION
+
+For configuring and running programmatically.
+
+Example
+
+```js
+import { marked } from 'marked';
+marked('*foo*', { gfm: true });
+```
+
+## BUGS
+
+Please report any bugs to <https://github.com/markedjs/marked>.
+
+## LICENSE
+
+Copyright (c) 2011-2014, Christopher Jeffrey (MIT License).
+
+## SEE ALSO
+
+markdown(1), nodejs(1)

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "highlight.js": "^11.6.0",
     "jasmine": "^4.5.0",
     "markdown-it": "13.0.1",
+    "marked-man": "^1.2.0",
     "node-fetch": "^3.2.10",
     "rollup": "^2.79.1",
     "rollup-plugin-license": "^3.0.1",


### PR DESCRIPTION
Hi,

please find a proof of concept in this PR.

I think it'd be better to just remove man/marked.1* from the git repository and add them to .gitignore, since now they are generated from marked-man.
