### PR TITLE
fix: fix entity specs

### DIFF
--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -32,7 +32,7 @@ export class Renderer {
 
     return '<pre><code class="'
       + this.options.langPrefix
-      + escape(lang, true)
+      + escape(lang)
       + '">'
       + (escaped ? code : escape(code, true))
       + '</code></pre>\n';
@@ -170,7 +170,7 @@ export class Renderer {
     if (href === null) {
       return text;
     }
-    let out = '<a href="' + escape(href) + '"';
+    let out = '<a href="' + href + '"';
     if (title) {
       out += ' title="' + title + '"';
     }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -3,7 +3,7 @@
  */
 const escapeTest = /[&<>"']/;
 const escapeReplace = new RegExp(escapeTest.source, 'g');
-const escapeTestNoEncode = /[<>"']|&(?!(#\d{1,7}|#[Xx][a-fA-f0-9]{1,6}|\w+);)/;
+const escapeTestNoEncode = /[<>"']|&(?!(#\d{1,7}|#[Xx][a-fA-F0-9]{1,6}|\w+);)/;
 const escapeReplaceNoEncode = new RegExp(escapeTestNoEncode.source, 'g');
 const escapeReplacements = {
   '&': '&amp;',

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2,9 +2,9 @@
  * Helpers
  */
 const escapeTest = /[&<>"']/;
-const escapeReplace = /[&<>"']/g;
-const escapeTestNoEncode = /[<>"']|&(?!#?\w+;)/;
-const escapeReplaceNoEncode = /[<>"']|&(?!#?\w+;)/g;
+const escapeReplace = new RegExp(escapeTest.source, 'g');
+const escapeTestNoEncode = /[<>"']|&(?!(#\d{1,7}|#[Xx][a-fA-f0-9]{1,6}|\w+);)/;
+const escapeReplaceNoEncode = new RegExp(escapeTestNoEncode.source, 'g');
 const escapeReplacements = {
   '&': '&amp;',
   '<': '&lt;',

--- a/test/specs/commonmark/commonmark.0.30.json
+++ b/test/specs/commonmark/commonmark.0.30.json
@@ -221,8 +221,7 @@
     "example": 28,
     "start_line": 691,
     "end_line": 701,
-    "section": "Entity and numeric character references",
-    "shouldFail": true
+    "section": "Entity and numeric character references"
   },
   {
     "markdown": "&copy\n",
@@ -272,8 +271,7 @@
     "example": 34,
     "start_line": 752,
     "end_line": 759,
-    "section": "Entity and numeric character references",
-    "shouldFail": true
+    "section": "Entity and numeric character references"
   },
   {
     "markdown": "`f&ouml;&ouml;`\n",

--- a/test/specs/gfm/commonmark.0.30.json
+++ b/test/specs/gfm/commonmark.0.30.json
@@ -221,8 +221,7 @@
     "example": 28,
     "start_line": 691,
     "end_line": 701,
-    "section": "Entity and numeric character references",
-    "shouldFail": true
+    "section": "Entity and numeric character references"
   },
   {
     "markdown": "&copy\n",
@@ -272,8 +271,7 @@
     "example": 34,
     "start_line": 752,
     "end_line": 759,
-    "section": "Entity and numeric character references",
-    "shouldFail": true
+    "section": "Entity and numeric character references"
   },
   {
     "markdown": "`f&ouml;&ouml;`\n",


### PR DESCRIPTION
**Marked version:** 4.2.2

## Description

Fix `Entity and numeric character references` specs [#28](https://spec.commonmark.org/0.30/#example-28) and [#34](https://spec.commonmark.org/0.30/#example-34).

In order to fix the last 2 `Entity and numeric character references` specs we would need to convert html entities to percent encoded with this json map: https://html.spec.whatwg.org/entities.json. This would increase the size of marked significantly (almost double 48k -> 84k) and provide very little benefit to the actual output.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
