### PR TITLE
fix: fix link reference definitions specs

### DIFF
--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -365,14 +365,15 @@ export class Tokenizer {
   def(src) {
     const cap = this.rules.block.def.exec(src);
     if (cap) {
-      if (cap[3]) cap[3] = cap[3].substring(1, cap[3].length - 1);
       const tag = cap[1].toLowerCase().replace(/\s+/g, ' ');
+      const href = cap[2] ? cap[2].replace(/^<(.*)>$/, '$1').replace(this.rules.inline._escapes, '$1') : '';
+      const title = cap[3] ? cap[3].substring(1, cap[3].length - 1).replace(this.rules.inline._escapes, '$1') : cap[3];
       return {
         type: 'def',
         tag,
         raw: cap[0],
-        href: cap[2] ? cap[2].replace(this.rules.inline._escapes, '$1') : cap[2],
-        title: cap[3] ? cap[3].replace(this.rules.inline._escapes, '$1') : cap[3]
+        href,
+        title
       };
     }
   }
@@ -574,7 +575,7 @@ export class Tokenizer {
         || (cap = this.rules.inline.nolink.exec(src))) {
       let link = (cap[2] || cap[1]).replace(/\s+/g, ' ');
       link = links[link.toLowerCase()];
-      if (!link || !link.href) {
+      if (!link) {
         const text = cap[0].charAt(0);
         return {
           type: 'text',

--- a/src/rules.js
+++ b/src/rules.js
@@ -25,7 +25,7 @@ export const block = {
     + '|<(?!script|pre|style|textarea)([a-z][\\w-]*)(?:attribute)*? */?>(?=[ \\t]*(?:\\n|$))[\\s\\S]*?(?:(?:\\n *)+\\n|$)' // (7) open tag
     + '|</(?!script|pre|style|textarea)[a-z][\\w-]*\\s*>(?=[ \\t]*(?:\\n|$))[\\s\\S]*?(?:(?:\\n *)+\\n|$)' // (7) closing tag
     + ')',
-  def: /^ {0,3}\[(label)\]: *(?:\n *)?<?([^\s>]+)>?(?:(?: +(?:\n *)?| *\n *)(title))? *(?:\n+|$)/,
+  def: /^ {0,3}\[(label)\]: *(?:\n *)?([^<\s][^\s]*|<.*?>)(?:(?: +(?:\n *)?| *\n *)(title))? *(?:\n+|$)/,
   table: noopTest,
   lheading: /^([^\n]+)\n {0,3}(=+|-+) *(?:\n+|$)/,
   // regex template, placeholders will be replaced according to different paragraph

--- a/test/specs/commonmark/commonmark.0.30.json
+++ b/test/specs/commonmark/commonmark.0.30.json
@@ -1564,8 +1564,7 @@
     "example": 195,
     "start_line": 3212,
     "end_line": 3220,
-    "section": "Link reference definitions",
-    "shouldFail": true
+    "section": "Link reference definitions"
   },
   {
     "markdown": "[foo]: /url '\ntitle\nline1\nline2\n'\n\n[foo]\n",
@@ -1605,8 +1604,7 @@
     "example": 200,
     "start_line": 3283,
     "end_line": 3289,
-    "section": "Link reference definitions",
-    "shouldFail": true
+    "section": "Link reference definitions"
   },
   {
     "markdown": "[foo]: <bar>(baz)\n\n[foo]\n",

--- a/test/specs/gfm/commonmark.0.30.json
+++ b/test/specs/gfm/commonmark.0.30.json
@@ -1564,8 +1564,7 @@
     "example": 195,
     "start_line": 3212,
     "end_line": 3220,
-    "section": "Link reference definitions",
-    "shouldFail": true
+    "section": "Link reference definitions"
   },
   {
     "markdown": "[foo]: /url '\ntitle\nline1\nline2\n'\n\n[foo]\n",
@@ -1605,8 +1604,7 @@
     "example": 200,
     "start_line": 3283,
     "end_line": 3289,
-    "section": "Link reference definitions",
-    "shouldFail": true
+    "section": "Link reference definitions"
   },
   {
     "markdown": "[foo]: <bar>(baz)\n\n[foo]\n",


### PR DESCRIPTION
**Marked version:** 4.2.2

## Description

Fix `Link reference definitions` spec tests [#195](https://spec.commonmark.org/0.30/#example-195) and [#200](https://spec.commonmark.org/0.30/#example-200)

`Link reference definitions` spec tests will be at 100% :tada:

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
