### PR TITLE
fix: fix multiline setext headings

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -27,7 +27,7 @@ export const block = {
     + ')',
   def: /^ {0,3}\[(label)\]: *(?:\n *)?<?([^\s>]+)>?(?:(?: +(?:\n *)?| *\n *)(title))? *(?:\n+|$)/,
   table: noopTest,
-  lheading: /^([^\n]+)\n {0,3}(=+|-+) *(?:\n+|$)/,
+  lheading: /^((?:.|\n(?!\n))+?)\n {0,3}(=+|-+) *(?:\n+|$)/,
   // regex template, placeholders will be replaced according to different paragraph
   // interruption rules of commonmark and the original markdown spec:
   _paragraph: /^([^\n]+(?:\n(?!hr|heading|lheading|blockquote|fences|list|html|table| +\n)[^\n]+)*)/,
@@ -137,6 +137,7 @@ block.pedantic = merge({}, block.normal, {
   def: /^ *\[([^\]]+)\]: *<?([^\s>]+)>?(?: +(["(][^\n]+[")]))? *(?:\n+|$)/,
   heading: /^(#{1,6})(.*)(?:\n+|$)/,
   fences: noopTest, // fences not supported
+  lheading: /^(.+?)\n {0,3}(=+|-+) *(?:\n+|$)/,
   paragraph: edit(block.normal._paragraph)
     .replace('hr', block.hr)
     .replace('heading', ' *#{1,6} *[^\n]')

--- a/test/specs/commonmark/commonmark.0.30.json
+++ b/test/specs/commonmark/commonmark.0.30.json
@@ -649,8 +649,7 @@
     "example": 81,
     "start_line": 1365,
     "end_line": 1372,
-    "section": "Setext headings",
-    "shouldFail": true
+    "section": "Setext headings"
   },
   {
     "markdown": "  Foo *bar\nbaz*\t\n====\n",
@@ -658,8 +657,7 @@
     "example": 82,
     "start_line": 1379,
     "end_line": 1386,
-    "section": "Setext headings",
-    "shouldFail": true
+    "section": "Setext headings"
   },
   {
     "markdown": "Foo\n-------------------------\n\nFoo\n=\n",
@@ -747,7 +745,8 @@
     "example": 93,
     "start_line": 1531,
     "end_line": 1541,
-    "section": "Setext headings"
+    "section": "Setext headings",
+    "shouldFail": true
   },
   {
     "markdown": "- Foo\n---\n",
@@ -763,8 +762,7 @@
     "example": 95,
     "start_line": 1559,
     "end_line": 1566,
-    "section": "Setext headings",
-    "shouldFail": true
+    "section": "Setext headings"
   },
   {
     "markdown": "---\nFoo\n---\nBar\n---\nBaz\n",

--- a/test/specs/gfm/commonmark.0.30.json
+++ b/test/specs/gfm/commonmark.0.30.json
@@ -649,8 +649,7 @@
     "example": 81,
     "start_line": 1365,
     "end_line": 1372,
-    "section": "Setext headings",
-    "shouldFail": true
+    "section": "Setext headings"
   },
   {
     "markdown": "  Foo *bar\nbaz*\t\n====\n",
@@ -658,8 +657,7 @@
     "example": 82,
     "start_line": 1379,
     "end_line": 1386,
-    "section": "Setext headings",
-    "shouldFail": true
+    "section": "Setext headings"
   },
   {
     "markdown": "Foo\n-------------------------\n\nFoo\n=\n",
@@ -747,7 +745,8 @@
     "example": 93,
     "start_line": 1531,
     "end_line": 1541,
-    "section": "Setext headings"
+    "section": "Setext headings",
+    "shouldFail": true
   },
   {
     "markdown": "- Foo\n---\n",
@@ -763,8 +762,7 @@
     "example": 95,
     "start_line": 1559,
     "end_line": 1566,
-    "section": "Setext headings",
-    "shouldFail": true
+    "section": "Setext headings"
   },
   {
     "markdown": "---\nFoo\n---\nBar\n---\nBaz\n",

--- a/test/unit/Lexer-spec.js
+++ b/test/unit/Lexer-spec.js
@@ -358,19 +358,6 @@ a | b
         ]
       });
     });
-
-    it('after line break does not consume raw \n', () => {
-      expectTokens({
-        md: 'T\nh\n---',
-        tokens:
-          jasmine.arrayContaining([
-            jasmine.objectContaining({
-              raw: 'T\nh\n'
-            }),
-            { type: 'hr', raw: '---' }
-          ])
-      });
-    });
   });
 
   describe('blockquote', () => {


### PR DESCRIPTION
**Marked version:** 4.2.2

## Description

Allow multiline setext headings. This fixes 3 `Setext headings` spec tests but breaks one test that was only passing because we didn't allow multiline setext headings.

The last setext heading test will actually have to be fixed in the blockquote tokenizer.

There was also one unit test that was wrong so I just deleted it. There are other tests that prevent the same regression.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
