### PR TITLE
fix: use paragraph token in blockquote in list

### DIFF
--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -149,11 +149,14 @@ export class Tokenizer {
     const cap = this.rules.block.blockquote.exec(src);
     if (cap) {
       const text = cap[0].replace(/^ *>[ \t]?/gm, '');
-
+      const top = this.lexer.state.top;
+      this.lexer.state.top = true;
+      const tokens = this.lexer.blockTokens(text);
+      this.lexer.state.top = top;
       return {
         type: 'blockquote',
         raw: cap[0],
-        tokens: this.lexer.blockTokens(text, []),
+        tokens,
         text
       };
     }

--- a/test/unit/Lexer-spec.js
+++ b/test/unit/Lexer-spec.js
@@ -381,6 +381,48 @@ a | b
         ]
       });
     });
+
+    it('paragraph token in list', () => {
+      expectTokens({
+        md: '- > blockquote',
+        tokens: [
+          {
+            type: 'list',
+            raw: '- > blockquote',
+            ordered: false,
+            start: '',
+            loose: false,
+            items: [
+              {
+                type: 'list_item',
+                raw: '- > blockquote',
+                task: false,
+                checked: undefined,
+                loose: false,
+                text: '> blockquote',
+                tokens: [
+                  {
+                    type: 'blockquote',
+                    raw: '> blockquote',
+                    tokens: [
+                      {
+                        type: 'paragraph',
+                        raw: 'blockquote',
+                        text: 'blockquote',
+                        tokens: [
+                          { type: 'text', raw: 'blockquote', text: 'blockquote' }
+                        ]
+                      }
+                    ],
+                    text: 'blockquote'
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      });
+    });
   });
 
   describe('list', () => {


### PR DESCRIPTION
**Marked version:** 4.2.3

## Description

blockquote content should be parsed as if it is top level markdown. This currently breaks in lists that are not loose.

- Fixes #2670 

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
