### PR TITLE
fix: loose list items are loose

### DIFF
--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -315,25 +315,32 @@ export class Tokenizer {
       for (i = 0; i < l; i++) {
         this.lexer.state.top = false;
         list.items[i].tokens = this.lexer.blockTokens(list.items[i].text, []);
-        const spacers = list.items[i].tokens.filter(t => t.type === 'space');
-        const hasMultipleLineBreaks = spacers.every(t => {
-          const chars = t.raw.split('');
-          let lineBreaks = 0;
-          for (const char of chars) {
-            if (char === '\n') {
-              lineBreaks += 1;
-            }
-            if (lineBreaks > 1) {
-              return true;
-            }
-          }
 
-          return false;
-        });
+        if (!list.loose) {
+          // Check if list should be loose
+          const spacers = list.items[i].tokens.filter(t => t.type === 'space');
+          const hasMultipleLineBreaks = spacers.length && spacers.every(t => {
+            const chars = t.raw.split('');
+            let lineBreaks = 0;
+            for (const char of chars) {
+              if (char === '\n') {
+                lineBreaks += 1;
+              }
+              if (lineBreaks > 1) {
+                return true;
+              }
+            }
 
-        if (!list.loose && spacers.length && hasMultipleLineBreaks) {
-          // Having a single line break doesn't mean a list is loose. A single line break is terminating the last list item
-          list.loose = true;
+            return false;
+          });
+
+          list.loose = !!hasMultipleLineBreaks;
+        }
+      }
+
+      // Set all items to loose if list is loose
+      if (list.loose) {
+        for (i = 0; i < l; i++) {
           list.items[i].loose = true;
         }
       }

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -319,22 +319,9 @@ export class Tokenizer {
         if (!list.loose) {
           // Check if list should be loose
           const spacers = list.items[i].tokens.filter(t => t.type === 'space');
-          const hasMultipleLineBreaks = spacers.length && spacers.every(t => {
-            const chars = t.raw.split('');
-            let lineBreaks = 0;
-            for (const char of chars) {
-              if (char === '\n') {
-                lineBreaks += 1;
-              }
-              if (lineBreaks > 1) {
-                return true;
-              }
-            }
+          const hasMultipleLineBreaks = spacers.length > 0 && spacers.every(t => /\n.*\n/.test(t.raw));
 
-            return false;
-          });
-
-          list.loose = !!hasMultipleLineBreaks;
+          list.loose = hasMultipleLineBreaks;
         }
       }
 

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -319,7 +319,7 @@ export class Tokenizer {
         if (!list.loose) {
           // Check if list should be loose
           const spacers = list.items[i].tokens.filter(t => t.type === 'space');
-          const hasMultipleLineBreaks = spacers.length > 0 && spacers.every(t => /\n.*\n/.test(t.raw));
+          const hasMultipleLineBreaks = spacers.length > 0 && spacers.some(t => /\n.*\n/.test(t.raw));
 
           list.loose = hasMultipleLineBreaks;
         }

--- a/test/specs/new/list_loose.html
+++ b/test/specs/new/list_loose.html
@@ -1,0 +1,9 @@
+<ul>
+  <li>
+    <p>item 1</p>
+  </li>
+  <li>
+    <p>item 2</p>
+    <p>still item 2</p>
+  </li>
+</ul>

--- a/test/specs/new/list_loose.md
+++ b/test/specs/new/list_loose.md
@@ -1,0 +1,5 @@
+- item 1
+-
+  item 2
+
+  still item 2

--- a/test/unit/Lexer-spec.js
+++ b/test/unit/Lexer-spec.js
@@ -605,10 +605,49 @@ paragraph
             loose: true,
             items: [
               jasmine.objectContaining({
-                raw: '- item 1\n\n'
+                raw: '- item 1\n\n',
+                loose: true
               }),
               jasmine.objectContaining({
-                raw: '- item 2'
+                raw: '- item 2',
+                loose: true
+              })
+            ]
+          })
+        ])
+      });
+    });
+
+    it('end loose', () => {
+      expectTokens({
+        md: `
+- item 1
+- item 2
+
+  item 2a
+- item 3
+`,
+        tokens: jasmine.arrayContaining([
+          jasmine.objectContaining({
+            type: 'space',
+            raw: '\n'
+          }),
+          jasmine.objectContaining({
+            type: 'list',
+            raw: '- item 1\n- item 2\n\n  item 2a\n- item 3\n',
+            loose: true,
+            items: [
+              jasmine.objectContaining({
+                raw: '- item 1\n',
+                loose: true
+              }),
+              jasmine.objectContaining({
+                raw: '- item 2\n\n  item 2a\n',
+                loose: true
+              }),
+              jasmine.objectContaining({
+                raw: '- item 3',
+                loose: true
               })
             ]
           })
@@ -634,6 +673,7 @@ paragraph
             items: [
               jasmine.objectContaining({
                 raw: '- item 1\n  - item 2',
+                loose: false,
                 tokens: jasmine.arrayContaining([
                   jasmine.objectContaining({
                     raw: 'item 1\n'


### PR DESCRIPTION
**Marked version:** 4.2.3

## Description

Currently list items' `loose` property is not set correctly for `loose` lists ([demo](https://marked.js.org/demo/?outputType=lexer&text=-%20item%201%0A-%20item%202%0A%0A-%20item%203&version=4.2.3))

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
