### PR TITLE
chore: add .devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,15 @@
 	"name": "marked",
 	// We're using node 14 for development, to keep close to the engine compatibility that marked.js uses.
 	"image": "mcr.microsoft.com/devcontainers/javascript-node:0-14",
-	"postCreateCommand": "npm install"
+	"postCreateCommand": "npm install",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			"extensions": [
+				"dbaeumeur.vscode-eslint"
+			]
+		}
+	}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
 {
-	"name": "Node.js",
+	"name": "marked",
 	// We're using node 14 for development, to keep close to the engine compatibility that marked.js uses.
 	"image": "mcr.microsoft.com/devcontainers/javascript-node:0-14",
 	"postCreateCommand": "npm install"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
+{
+	"name": "Node.js",
+	// We're using node 14 for development, to keep close to the engine compatibility that marked.js uses.
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:0-14",
+	"postCreateCommand": "npm install"
+}


### PR DESCRIPTION
Closes #2699 with the basic node 14 devcontainer. Do note that a dev container for 12 doesn't exist, so if this is preferred, I would have to add a Dockerfile as well.