### PR TITLE
fix: always return promise if async

### DIFF
--- a/docs/USING_PRO.md
+++ b/docs/USING_PRO.md
@@ -255,7 +255,7 @@ smartypants('"this ... string"')
 
 <h2 id="walk-tokens">Walk Tokens : <code>walkTokens</code></h2>
 
-The walkTokens function gets called with every token. Child tokens are called before moving on to sibling tokens. Each token is passed by reference so updates are persisted when passed to the parser. The return value of the function is ignored but awaited if running marked in [`async`](#async) mode.
+The walkTokens function gets called with every token. Child tokens are called before moving on to sibling tokens. Each token is passed by reference so updates are persisted when passed to the parser. When [`async`](#async) mode is enabled, the return value is awaited. Otherwise the return value is ignored. 
 
 `marked.use()` can be called multiple times with different `walkTokens` functions. Each function will be called in order, starting with the function that was assigned *last*.
 

--- a/docs/USING_PRO.md
+++ b/docs/USING_PRO.md
@@ -255,7 +255,7 @@ smartypants('"this ... string"')
 
 <h2 id="walk-tokens">Walk Tokens : <code>walkTokens</code></h2>
 
-The walkTokens function gets called with every token. Child tokens are called before moving on to sibling tokens. Each token is passed by reference so updates are persisted when passed to the parser. The return value of the function is ignored.
+The walkTokens function gets called with every token. Child tokens are called before moving on to sibling tokens. Each token is passed by reference so updates are persisted when passed to the parser. The return value of the function is ignored but awaited if running marked in [`async`](#async) mode.
 
 `marked.use()` can be called multiple times with different `walkTokens` functions. Each function will be called in order, starting with the function that was assigned *last*.
 

--- a/src/marked.js
+++ b/src/marked.js
@@ -112,9 +112,12 @@ export function marked(src, opt, callback) {
         + escape(e.message + '', true)
         + '</pre>';
       if (opt.async) {
-        return Promise.reject(msg);
+        return Promise.resolve(msg);
       }
       return msg;
+    }
+    if (opt.async) {
+      return Promise.reject(e);
     }
     throw e;
   }

--- a/src/marked.js
+++ b/src/marked.js
@@ -108,28 +108,35 @@ export function marked(src, opt, callback) {
   function onError(e) {
     e.message += '\nPlease report this to https://github.com/markedjs/marked.';
     if (opt.silent) {
-      return '<p>An error occurred:</p><pre>'
+      const msg = '<p>An error occurred:</p><pre>'
         + escape(e.message + '', true)
         + '</pre>';
+      if (opt.async) {
+        return Promise.reject(msg);
+      }
+      return msg;
     }
     throw e;
   }
 
   try {
+    if (opt.async) {
+      let promise = Promise.resolve(Lexer.lex(src, opt));
+      if (opt.walkTokens) {
+        promise = promise.then((tokens) =>
+          Promise.all(marked.walkTokens(tokens, opt.walkTokens)).then(() => tokens)
+        );
+      }
+      return promise.then((tokens) => Parser.parse(tokens, opt)).catch(onError);
+    }
+
     const tokens = Lexer.lex(src, opt);
     if (opt.walkTokens) {
-      if (opt.async) {
-        return Promise.all(marked.walkTokens(tokens, opt.walkTokens))
-          .then(() => {
-            return Parser.parse(tokens, opt);
-          })
-          .catch(onError);
-      }
       marked.walkTokens(tokens, opt.walkTokens);
     }
     return Parser.parse(tokens, opt);
   } catch (e) {
-    onError(e);
+    return onError(e);
   }
 }
 

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -1112,4 +1112,14 @@ br
     const html = await promise;
     expect(html.trim()).toBe('<p><em>text walked</em></p>');
   });
+
+  it('should return promise if async', async() => {
+    marked.use({
+      async: true
+    });
+    const promise = marked('*text*');
+    expect(promise).toBeInstanceOf(Promise);
+    const html = await promise;
+    expect(html.trim()).toBe('<p><em>text</em></p>');
+  });
 });


### PR DESCRIPTION
**Marked version:** 4.2.12

## Description

Always return a promise if `async` option is `true`.

- Fixes #2721 

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
