### PR TITLE
fix: make legacy fields in `package.json` valid

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "author": "Christopher Jeffrey",
   "version": "4.2.12",
   "type": "module",
-  "main": "./lib/marked.cjs",
-  "module": "./lib/marked.esm.js",
+  "main": "./lib/marked.esm.js",
   "browser": "./lib/marked.umd.js",
   "bin": {
     "marked": "bin/marked.js"


### PR DESCRIPTION
<!--

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->

**Marked version:** 4.2.12

**Markdown flavor:** n/a

## Description

- Fixes https://github.com/markedjs/marked/issues/2265 (this issue is closed, but you can see people still complaining in the comments)

<!--

	If no issue exists that you're aware of. The maintainers should be able to figure out if it's a duplicate.

## Expectation

If you have `"type": "module"` then the `main` field should contain ESM

## Result

`marked` has `"type": "module"` and the main field contains CJS, which is why people are complaining it's broken and also why the "fix script" mentioned in this comment works: https://github.com/markedjs/marked/issues/2265#issuecomment-1102839322

It still works for most people because modern versions of Node and bundlers will look at `exports` and ignore `main`. But if you're running an older version of some piece of software in your stack you will get an error

## What was attempted

Followed the Node.js spec

-->

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [X] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
