### PR TITLE
fix: export cjs/esm/umd modules explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
       "import": "./lib/marked.esm.js",
       "default": "./lib/marked.cjs"
     },
+    "./lib/marked.cjs": "./lib/marked.cjs",
+    "./lib/marked.esm": "./lib/marked.esm.js",
+    "./lib/marked.umd": "./lib/marked.umd.js",
     "./bin/marked": "./bin/marked.js",
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
<!--

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->

**Marked version: 4.2.12**

<!-- The NPM version or commit hash having the issue -->

**Markdown flavor:** n/a

## Description

- Fixes #2265 (already marked resolved, but I, and several others, are still seeing variations of this issue)

## Expectation

Including marked in a subpackage should work as expected. 

## Result

I wish I had a more reproducible setup. 

In short, we have a monorepo using [`pnpm`](https://pnpm.io/). I have a package in that repo that uses `marked`. The file in question looks something like: 

```ts
import DOMPurify from 'isomorphic-dompurify';
import { marked } from 'marked';

marked.use({
  renderer: {
    /* ...some options here */
  },
});

export const format = (markdown: string) =>
  DOMPurify.sanitize(marked.parse(markdown, { breaks: true }));
```

That package compiles that to CJS, which ends up looking something like:

```js
"use strict";

Object.defineProperty(exports, "__esModule", {
  value: true
});
exports.format = void 0;

var _isomorphicDompurify = _interopRequireDefault(require("isomorphic-dompurify"));

var _marked = require("marked");

function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

_marked.marked.use({
  renderer: {
    /* ...some options here */
  }
});

const format = markdown => _isomorphicDompurify.default.sanitize(_marked.marked.parse(markdown, {
  breaks: true
}));

exports.format = format;
```

That module then gets imported in another project in the monorepo, which is a [`create-react-app`](https://create-react-app.dev/). I'm trying to upgrade the `react-scripts` in that project, which means I'm also upgrading from Webpack 4 to Webpack 5. That upgrade is going smoothly, except for the above file now throwing the `TypeError: Cannot read properties of undefined (reading 'use')` error.

## What was attempted

If I explicitly export the three generated files, which should be safe to mark as `exports`, I'm able to sidestep this issue in my downstream projects using [`resolve`](https://webpack.js.org/configuration/resolve/#resolvealias): 

```json
    "alias": {
      "marked": "marked/lib/marked.esm.js",
    },
```

Which in effect [applies @emilmuller's wrokaround to Webpack 5](https://github.com/markedjs/marked/issues/2265#issuecomment-1452017721). 

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
