### PR TITLE
fix: deprecate options

### DIFF
--- a/docs/USING_ADVANCED.md
+++ b/docs/USING_ADVANCED.md
@@ -97,20 +97,27 @@ console.log(inlineHtml); // '<strong>strong</strong> <em>em</em>'
 Unlike `highlight.js` the `pygmentize.js` library uses asynchronous highlighting. This example demonstrates that marked is agnostic when it comes to the highlighter you use.
 
 ```js
-marked.setOptions({
-  highlight: function(code, lang, callback) {
-    require('pygmentize-bundled') ({ lang: lang, format: 'html' }, code, function (err, result) {
-      callback(err, result.toString());
-    });
+import pygmentize from 'pygmentize-bundled';
+
+marked.use({
+  async: true,
+  highlight(code, lang) {
+    return new Promise((resolve, reject) => {
+      pygmentize({ lang: lang, format: 'html' }, code, (err, result) {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(result.toString());
+      });
+    })
   }
 });
 
-marked.parse(markdownString, (err, html) => {
-  console.log(html);
-});
+const html = await marked.parse(markdownString);
 ```
 
-In both examples, `code` is a `string` representing the section of code to pass to the highlighter. In this example, `lang` is a `string` informing the highlighter what programming language to use for the `code` and `callback` is the `function` the asynchronous highlighter will call once complete.
+In both examples, `code` is a `string` representing the section of code to pass to the highlighter. In this example, `lang` is a `string` informing the highlighter what programming language to use for the `code`. The highlight function can return a `Promise` for asynchronous highlighting. Don't forget to set the `async` option to `true` and `await` the output of marked.
 
 <h2 id="workers">Workers</h2>
 

--- a/docs/USING_ADVANCED.md
+++ b/docs/USING_ADVANCED.md
@@ -79,6 +79,7 @@ Marked can be extended using [custom extensions](/using_pro#extensions). This is
 |[Highlight](https://github.com/marked/marked-highlight)|[`marked-highlight`](https://www.npmjs.com/package/marked-highlight)|Highlight code blocks|
 |[Katex Code](https://github.com/UziTech/marked-katex-extension)|[`marked-katex-extension`](https://www.npmjs.com/package/marked-katex-extension)|Render [katex](https://katex.org/) code|
 |[LinkifyIt](https://github.com/UziTech/marked-linkify-it)|[`marked-linkify-it`](https://www.npmjs.com/package/marked-linkify-it)|Use [linkify-it](https://github.com/markdown-it/linkify-it) for urls|
+|[Mangle](https://github.com/markedjs/marked-mangle)|[`marked-mangle`](https://www.npmjs.com/package/marked-mangle)|Mangle mailto links with HTML character references|
 |[Misskey-flavored Markdown](https://akkoma.dev/sfr/marked-mfm)|[`marked-mfm`](https://www.npmjs.com/package/marked-mfm)|Custom extension for [Misskey-flavored Markdown](https://github.com/misskey-dev/mfm.js/blob/develop/docs/syntax.md).|
 
 <h2 id="inline">Inline Markdown</h2>

--- a/docs/USING_ADVANCED.md
+++ b/docs/USING_ADVANCED.md
@@ -65,13 +65,13 @@ Marked can be extended using [custom extensions](/using_pro#extensions). This is
 |[Emoji](https://github.com/UziTech/marked-emoji)|[`marked-emoji`](https://www.npmjs.com/package/marked-emoji)|Add emoji support like on GitHub|
 |[Extended Tables](https://github.com/calculuschild/marked-extended-tables)|[`marked-extended-tables`](https://www.npmjs.com/package/marked-extended-tables)|Extends the standard Github-Flavored tables to support advanced features: Column Spanning, Row Spanning, Multi-row headers|
 |[GFM Heading ID](https://github.com/markedjs/marked-gfm-heading-id)|[`marked-gfm-heading-id`](https://www.npmjs.com/package/marked-gfm-heading-id)|Use [`github-slugger`](https://github.com/Flet/github-slugger) to create the heading IDs and allow a custom prefix.|
-|[Highlight](https://github.com/marked/marked-highlight)|[`marked-highlight`](https://www.npmjs.com/package/marked-highlight)|Highlight code blocks|
+|[Highlight](https://github.com/markedjs/marked-highlight)|[`marked-highlight`](https://www.npmjs.com/package/marked-highlight)|Highlight code blocks|
 |[Katex Code](https://github.com/UziTech/marked-katex-extension)|[`marked-katex-extension`](https://www.npmjs.com/package/marked-katex-extension)|Render [katex](https://katex.org/) code|
 |[LinkifyIt](https://github.com/UziTech/marked-linkify-it)|[`marked-linkify-it`](https://www.npmjs.com/package/marked-linkify-it)|Use [linkify-it](https://github.com/markdown-it/linkify-it) for urls|
 |[Mangle](https://github.com/markedjs/marked-mangle)|[`marked-mangle`](https://www.npmjs.com/package/marked-mangle)|Mangle mailto links with HTML character references|
 |[Misskey-flavored Markdown](https://akkoma.dev/sfr/marked-mfm)|[`marked-mfm`](https://www.npmjs.com/package/marked-mfm)|Custom extension for [Misskey-flavored Markdown](https://github.com/misskey-dev/mfm.js/blob/develop/docs/syntax.md).|
-|[Smartypants](https://github.com/marked/marked-smartypants)|[`marked-smartypants`](https://www.npmjs.com/package/marked-smartypants)|Use [smartypants](https://www.npmjs.com/package/smartypants) to use "smart" typographic punctuation for things like quotes and dashes.|
-|[XHTML](https://github.com/marked/marked-xhtml)|[`marked-xhtml`](https://www.npmjs.com/package/marked-xhtml)|Emit self-closing HTML tags for void elements (&lt;br/&gt;, &lt;img/&gt;, etc.) with a "/" as required by XHTML.|
+|[Smartypants](https://github.com/markedjs/marked-smartypants)|[`marked-smartypants`](https://www.npmjs.com/package/marked-smartypants)|Use [smartypants](https://www.npmjs.com/package/smartypants) to use "smart" typographic punctuation for things like quotes and dashes.|
+|[XHTML](https://github.com/markedjs/marked-xhtml)|[`marked-xhtml`](https://www.npmjs.com/package/marked-xhtml)|Emit self-closing HTML tags for void elements (&lt;br/&gt;, &lt;img/&gt;, etc.) with a "/" as required by XHTML.|
 
 <h2 id="inline">Inline Markdown</h2>
 

--- a/docs/USING_ADVANCED.md
+++ b/docs/USING_ADVANCED.md
@@ -49,7 +49,7 @@ console.log(marked.parse(markdownString));
 |gfm         |`boolean` |`true`   |v0.2.1   |If true, use approved [GitHub Flavored Markdown (GFM) specification](https://github.github.com/gfm/).|
 |headerIds   |`boolean` |`true`   |v0.4.0   |If true, include an `id` attribute when emitting headings (h1, h2, h3, etc).|
 |headerPrefix|`string`  |`''`     |v0.3.0   |A string to prefix the `id` attribute when emitting headings (h1, h2, h3, etc).|
-|highlight   |`function`|`null`   |v0.3.0   |A function to highlight code blocks, see <a href="#highlight">Asynchronous highlighting</a>.|
+|highlight (**deprecated**) |`function`|`null`   |v0.3.0   |Deprecated in v5.0.0 use [`marked-highlight`](https://www.npmjs.com/package/marked-highlight) to add highlighting to code blocks. |
 |langPrefix  |`string`  |`'language-'`|v0.3.0|A string to prefix the className in a `<code>` block. Useful for syntax highlighting.|
 |mangle      |`boolean` |`true`   |v0.3.4   |If true, autolinked email address is escaped with HTML character references.|
 |pedantic    |`boolean` |`false`  |v0.2.1   |If true, conform to the original `markdown.pl` as much as possible. Don't fix original markdown bugs or behavior. Turns off and overrides `gfm`.|
@@ -76,6 +76,7 @@ Marked can be extended using [custom extensions](/using_pro#extensions). This is
 |[Emoji](https://github.com/UziTech/marked-emoji)|[`marked-emoji`](https://www.npmjs.com/package/marked-emoji)|Add emoji support like on GitHub|
 |[Extended Tables](https://github.com/calculuschild/marked-extended-tables)|[`marked-extended-tables`](https://www.npmjs.com/package/marked-extended-tables)|Extends the standard Github-Flavored tables to support advanced features: Column Spanning, Row Spanning, Multi-row headers|
 |[GFM Heading ID](https://github.com/markedjs/marked-gfm-heading-id)|[`marked-gfm-heading-id`](https://www.npmjs.com/package/marked-gfm-heading-id)|Use [`github-slugger`](https://github.com/Flet/github-slugger) to create the heading IDs and allow a custom prefix.|
+|[Highlight](https://github.com/UziTech/marked-highlight)|[`marked-highlight`](https://www.npmjs.com/package/marked-highlight)|Highlight code blocks|
 |[Katex Code](https://github.com/UziTech/marked-katex-extension)|[`marked-katex-extension`](https://www.npmjs.com/package/marked-katex-extension)|Render [katex](https://katex.org/) code|
 |[LinkifyIt](https://github.com/UziTech/marked-linkify-it)|[`marked-linkify-it`](https://www.npmjs.com/package/marked-linkify-it)|Use [linkify-it](https://github.com/markdown-it/linkify-it) for urls|
 |[Misskey-flavored Markdown](https://akkoma.dev/sfr/marked-mfm)|[`marked-mfm`](https://www.npmjs.com/package/marked-mfm)|Custom extension for [Misskey-flavored Markdown](https://github.com/misskey-dev/mfm.js/blob/develop/docs/syntax.md).|
@@ -92,32 +93,9 @@ const inlineHtml = marked.parseInline('**strong** _em_');
 console.log(inlineHtml); // '<strong>strong</strong> <em>em</em>'
 ```
 
-<h2 id="highlight">Asynchronous highlighting</h2>
+<h2 id="highlight">highlighting</h2>
 
-Unlike `highlight.js` the `pygmentize.js` library uses asynchronous highlighting. This example demonstrates that marked is agnostic when it comes to the highlighter you use.
-
-```js
-import pygmentize from 'pygmentize-bundled';
-
-marked.use({
-  async: true,
-  highlight(code, lang) {
-    return new Promise((resolve, reject) => {
-      pygmentize({ lang: lang, format: 'html' }, code, (err, result) {
-        if (err) {
-          reject(err);
-          return;
-        }
-        resolve(result.toString());
-      });
-    })
-  }
-});
-
-const html = await marked.parse(markdownString);
-```
-
-In both examples, `code` is a `string` representing the section of code to pass to the highlighter. In this example, `lang` is a `string` informing the highlighter what programming language to use for the `code`. The highlight function can return a `Promise` for asynchronous highlighting. Don't forget to set the `async` option to `true` and `await` the output of marked.
+Use [`marked-highlight`](https://www.npmjs.com/package/marked-highlight) to highlight code blocks.
 
 <h2 id="workers">Workers</h2>
 

--- a/docs/USING_ADVANCED.md
+++ b/docs/USING_ADVANCED.md
@@ -93,7 +93,7 @@ const inlineHtml = marked.parseInline('**strong** _em_');
 console.log(inlineHtml); // '<strong>strong</strong> <em>em</em>'
 ```
 
-<h2 id="highlight">highlighting</h2>
+<h2 id="highlight">Highlighting</h2>
 
 Use [`marked-highlight`](https://www.npmjs.com/package/marked-highlight) to highlight code blocks.
 

--- a/docs/USING_ADVANCED.md
+++ b/docs/USING_ADVANCED.md
@@ -76,7 +76,7 @@ Marked can be extended using [custom extensions](/using_pro#extensions). This is
 |[Emoji](https://github.com/UziTech/marked-emoji)|[`marked-emoji`](https://www.npmjs.com/package/marked-emoji)|Add emoji support like on GitHub|
 |[Extended Tables](https://github.com/calculuschild/marked-extended-tables)|[`marked-extended-tables`](https://www.npmjs.com/package/marked-extended-tables)|Extends the standard Github-Flavored tables to support advanced features: Column Spanning, Row Spanning, Multi-row headers|
 |[GFM Heading ID](https://github.com/markedjs/marked-gfm-heading-id)|[`marked-gfm-heading-id`](https://www.npmjs.com/package/marked-gfm-heading-id)|Use [`github-slugger`](https://github.com/Flet/github-slugger) to create the heading IDs and allow a custom prefix.|
-|[Highlight](https://github.com/UziTech/marked-highlight)|[`marked-highlight`](https://www.npmjs.com/package/marked-highlight)|Highlight code blocks|
+|[Highlight](https://github.com/marked/marked-highlight)|[`marked-highlight`](https://www.npmjs.com/package/marked-highlight)|Highlight code blocks|
 |[Katex Code](https://github.com/UziTech/marked-katex-extension)|[`marked-katex-extension`](https://www.npmjs.com/package/marked-katex-extension)|Render [katex](https://katex.org/) code|
 |[LinkifyIt](https://github.com/UziTech/marked-linkify-it)|[`marked-linkify-it`](https://www.npmjs.com/package/marked-linkify-it)|Use [linkify-it](https://github.com/markdown-it/linkify-it) for urls|
 |[Misskey-flavored Markdown](https://akkoma.dev/sfr/marked-mfm)|[`marked-mfm`](https://www.npmjs.com/package/marked-mfm)|Custom extension for [Misskey-flavored Markdown](https://github.com/misskey-dev/mfm.js/blob/develop/docs/syntax.md).|

--- a/docs/USING_ADVANCED.md
+++ b/docs/USING_ADVANCED.md
@@ -51,7 +51,7 @@ console.log(marked.parse(markdownString));
 |headerPrefix|`string`  |`''`     |v0.3.0   |A string to prefix the `id` attribute when emitting headings (h1, h2, h3, etc).|
 |highlight (**deprecated**) |`function`|`null`   |v0.3.0   |Deprecated in v5.0.0 use [`marked-highlight`](https://www.npmjs.com/package/marked-highlight) to add highlighting to code blocks. |
 |langPrefix  |`string`  |`'language-'`|v0.3.0|A string to prefix the className in a `<code>` block. Useful for syntax highlighting.|
-|mangle      |`boolean` |`true`   |v0.3.4   |If true, autolinked email address is escaped with HTML character references.|
+|mangle (**deprecated**) |`boolean` |`true`   |v0.3.4   |Deprecated in v5.0.0 use [`marked-mangle`](https://www.npmjs.com/package/marked-mangle) to mangle email addresses.|
 |pedantic    |`boolean` |`false`  |v0.2.1   |If true, conform to the original `markdown.pl` as much as possible. Don't fix original markdown bugs or behavior. Turns off and overrides `gfm`.|
 |renderer    |`object`  |`new Renderer()`|v0.3.0|An object containing functions to render tokens to HTML. See [extensibility](/using_pro) for more details.|
 |sanitize    |`boolean` |`false`  |v0.2.1   |If true, sanitize the HTML passed into `markdownString` with the `sanitizer` function.<br>**Warning**: This feature is deprecated and it should NOT be used as it cannot be considered secure.<br>Instead use a sanitize library, like [DOMPurify](https://github.com/cure53/DOMPurify) (recommended), [sanitize-html](https://github.com/apostrophecms/sanitize-html) or [insane](https://github.com/bevacqua/insane) on the output HTML! |

--- a/docs/USING_ADVANCED.md
+++ b/docs/USING_ADVANCED.md
@@ -2,14 +2,13 @@
 
 ```js
 import { marked } from 'marked';
-marked.parse(markdownString [,options] [,callback])
+marked.parse(markdownString [,options])
 ```
 
-|Argument              |Type         |Notes                                                                                                |
-|:---------------------|:------------|:----------------------------------------------------------------------------------------------------|
-|markdownString        |`string`     |String of markdown source to be compiled.                                                            |
-|<a href="#options">options</a>|`object`|Hash of options. Can also use `marked.setOptions`.                                                |
-|callback              |`function`   |Called when `markdownString` has been parsed. Can be used as second argument if no `options` present.|
+|Argument                      |Type    |Notes                                                           |
+|:-----------------------------|:-------|:---------------------------------------------------------------|
+|markdownString                |`string`|String of markdown source to be compiled.                       |
+|<a href="#options">options</a>|`object`|Hash of options. Can also use `marked.use` to set global options|
 
 ### Alternative using reference
 
@@ -18,21 +17,10 @@ marked.parse(markdownString [,options] [,callback])
 import { marked } from 'marked';
 
 // Set options
-// `highlight` example uses https://highlightjs.org
-marked.setOptions({
-  renderer: new marked.Renderer(),
-  highlight: function(code, lang) {
-    const hljs = require('highlight.js');
-    const language = hljs.getLanguage(lang) ? lang : 'plaintext';
-    return hljs.highlight(code, { language }).value;
-  },
-  langPrefix: 'hljs language-', // highlight.js css expects a top-level 'hljs' class.
+marked.use({
+  async: true,
   pedantic: false,
   gfm: true,
-  breaks: false,
-  sanitize: false,
-  smartypants: false,
-  xhtml: false
 });
 
 // Compile
@@ -44,23 +32,23 @@ console.log(marked.parse(markdownString));
 |Member      |Type      |Default  |Since    |Notes         |
 |:-----------|:---------|:--------|:--------|:-------------|
 |async       |`boolean` |`false`  |4.1.0    |If true, `walkTokens` functions can be async and `marked.parse` will return a promise that resolves when all walk tokens functions resolve.|
-|baseUrl     |`string`  |`null`   |0.3.9    |A prefix url for any relative link. |
 |breaks      |`boolean` |`false`  |v0.2.7   |If true, add `<br>` on a single line break (copies GitHub behavior on comments, but not on rendered markdown files). Requires `gfm` be `true`.|
 |gfm         |`boolean` |`true`   |v0.2.1   |If true, use approved [GitHub Flavored Markdown (GFM) specification](https://github.github.com/gfm/).|
-|headerIds   |`boolean` |`true`   |v0.4.0   |If true, include an `id` attribute when emitting headings (h1, h2, h3, etc).|
-|headerPrefix|`string`  |`''`     |v0.3.0   |A string to prefix the `id` attribute when emitting headings (h1, h2, h3, etc).|
-|highlight (**deprecated**) |`function`|`null`   |v0.3.0   |Deprecated in v5.0.0 use [`marked-highlight`](https://www.npmjs.com/package/marked-highlight) to add highlighting to code blocks. |
-|langPrefix  |`string`  |`'language-'`|v0.3.0|A string to prefix the className in a `<code>` block. Useful for syntax highlighting.|
-|mangle (**deprecated**) |`boolean` |`true`   |v0.3.4   |Deprecated in v5.0.0 use [`marked-mangle`](https://www.npmjs.com/package/marked-mangle) to mangle email addresses.|
 |pedantic    |`boolean` |`false`  |v0.2.1   |If true, conform to the original `markdown.pl` as much as possible. Don't fix original markdown bugs or behavior. Turns off and overrides `gfm`.|
 |renderer    |`object`  |`new Renderer()`|v0.3.0|An object containing functions to render tokens to HTML. See [extensibility](/using_pro) for more details.|
-|sanitize    |`boolean` |`false`  |v0.2.1   |If true, sanitize the HTML passed into `markdownString` with the `sanitizer` function.<br>**Warning**: This feature is deprecated and it should NOT be used as it cannot be considered secure.<br>Instead use a sanitize library, like [DOMPurify](https://github.com/cure53/DOMPurify) (recommended), [sanitize-html](https://github.com/apostrophecms/sanitize-html) or [insane](https://github.com/bevacqua/insane) on the output HTML! |
-|sanitizer   |`function`|`null`   |v0.3.4   |A function to sanitize the HTML passed into `markdownString`.|
-|silent      |`boolean` |`false`  |v0.2.7   |If true, the parser does not throw any exception.|
-|smartypants |`boolean` |`false`  |v0.2.9   |If true, use "smart" typographic punctuation for things like quotes and dashes.|
+|silent      |`boolean` |`false`  |v0.2.7   |If true, the parser does not throw any exception or log any warning. Any error will be returned as a string.|
 |tokenizer    |`object`  |`new Tokenizer()`|v1.0.0|An object containing functions to create tokens from markdown. See [extensibility](/using_pro) for more details.|
 |walkTokens   |`function`  |`null`|v1.1.0|A function which is called for every token. See [extensibility](/using_pro) for more details.|
-|xhtml       |`boolean` |`false`  |v0.3.2   |If true, emit self-closing HTML tags for void elements (&lt;br/&gt;, &lt;img/&gt;, etc.) with a "/" as required by XHTML.|
+|baseUrl (**deprecated**)|`string`  |`null`   |v0.3.9    |Deprecated in v5.0.0 use [`marked-base-url`](https://www.npmjs.com/package/marked-base-url) to prefix url for any relative link. |
+|headerIds (**deprecated**)|`boolean` |`true`   |v0.4.0   |Deprecated in v5.0.0 use [`marked-gfm-heading-id`](https://www.npmjs.com/package/marked-gfm-heading-id) to include an `id` attribute when emitting headings (h1, h2, h3, etc).|
+|headerPrefix (**deprecated**)|`string`  |`''`     |v0.3.0   |Deprecated in v5.0.0 use [`marked-gfm-heading-id`](https://www.npmjs.com/package/marked-gfm-heading-id) to add a string to prefix the `id` attribute when emitting headings (h1, h2, h3, etc).|
+|highlight (**deprecated**)|`function`|`null`   |v0.3.0   |Deprecated in v5.0.0 use [`marked-highlight`](https://www.npmjs.com/package/marked-highlight) to add highlighting to code blocks. |
+|langPrefix  (**deprecated**)|`string`  |`'language-'`|v0.3.0|Deprecated in v5.0.0 use [`marked-highlight`](https://www.npmjs.com/package/marked-highlight) to prefix the className in a `<code>` block. Useful for syntax highlighting.|
+|mangle (**deprecated**)|`boolean` |`true`   |v0.3.4   |Deprecated in v5.0.0 use [`marked-mangle`](https://www.npmjs.com/package/marked-mangle) to mangle email addresses.|
+|sanitize (**deprecated**)|`boolean` |`false`  |v0.2.1   |If true, sanitize the HTML passed into `markdownString` with the `sanitizer` function.<br>**Warning**: This feature is deprecated and it should NOT be used as it cannot be considered secure.<br>Instead use a sanitize library, like [DOMPurify](https://github.com/cure53/DOMPurify) (recommended), [sanitize-html](https://github.com/apostrophecms/sanitize-html) or [insane](https://github.com/bevacqua/insane) on the output HTML! |
+|sanitizer  (**deprecated**)|`function`|`null`   |v0.3.4   |A function to sanitize the HTML passed into `markdownString`.|
+|smartypants (**deprecated**)|`boolean` |`false`  |v0.2.9   |Deprecated in v5.0.0 use [`marked-smartypants`](https://www.npmjs.com/package/marked-smartypants) to use "smart" typographic punctuation for things like quotes and dashes.|
+|xhtml (**deprecated**)|`boolean` |`false`  |v0.3.2   |Deprecated in v5.0.0 use [`marked-xhtml`](https://www.npmjs.com/package/marked-xhtml) to emit self-closing HTML tags for void elements (&lt;br/&gt;, &lt;img/&gt;, etc.) with a "/" as required by XHTML.|
 
 <h2 id="extensions">Known Extensions</h2>
 
@@ -71,6 +59,7 @@ Marked can be extended using [custom extensions](/using_pro#extensions). This is
 |Name|Package Name|Description|
 |:---|:-----------|:----------|
 |[Admonition](https://www.npmjs.com/package/marked-admonition-extension)|[`marked-admonition-extension`](https://www.npmjs.com/package/marked-admonition-extension)| Admonition extension |
+|[Base URL](https://github.com/markedjs/marked-base-url)|[`marked-base-url`](https://www.npmjs.com/package/marked-base-url)|Prefix relative urls with a base URL.|
 |[Bidi](https://github.com/markedjs/marked-bidi)|[`marked-bidi`](https://www.npmjs.com/package/marked-bidi)|Add Bidirectional text support to the HTML|
 |[Custom Heading ID](https://github.com/markedjs/marked-custom-heading-id)|[`marked-custom-heading-id`](https://www.npmjs.com/package/marked-custom-heading-id)|Specify a custom heading id in headings with the [Markdown Extended Syntax](https://www.markdownguide.org/extended-syntax/#heading-ids) `# heading {#custom-id}`|
 |[Emoji](https://github.com/UziTech/marked-emoji)|[`marked-emoji`](https://www.npmjs.com/package/marked-emoji)|Add emoji support like on GitHub|
@@ -81,6 +70,8 @@ Marked can be extended using [custom extensions](/using_pro#extensions). This is
 |[LinkifyIt](https://github.com/UziTech/marked-linkify-it)|[`marked-linkify-it`](https://www.npmjs.com/package/marked-linkify-it)|Use [linkify-it](https://github.com/markdown-it/linkify-it) for urls|
 |[Mangle](https://github.com/markedjs/marked-mangle)|[`marked-mangle`](https://www.npmjs.com/package/marked-mangle)|Mangle mailto links with HTML character references|
 |[Misskey-flavored Markdown](https://akkoma.dev/sfr/marked-mfm)|[`marked-mfm`](https://www.npmjs.com/package/marked-mfm)|Custom extension for [Misskey-flavored Markdown](https://github.com/misskey-dev/mfm.js/blob/develop/docs/syntax.md).|
+|[Smartypants](https://github.com/marked/marked-smartypants)|[`marked-smartypants`](https://www.npmjs.com/package/marked-smartypants)|Use [smartypants](https://www.npmjs.com/package/smartypants) to use "smart" typographic punctuation for things like quotes and dashes.|
+|[XHTML](https://github.com/marked/marked-xhtml)|[`marked-xhtml`](https://www.npmjs.com/package/marked-xhtml)|Emit self-closing HTML tags for void elements (&lt;br/&gt;, &lt;img/&gt;, etc.) with a "/" as required by XHTML.|
 
 <h2 id="inline">Inline Markdown</h2>
 

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -14,28 +14,18 @@ export class Renderer {
 
   code(code, infostring, escaped) {
     const lang = (infostring || '').match(/\S*/)[0];
-    if (this.options.highlight) {
-      const out = this.options.highlight(code, lang);
-      if (out != null && out !== code) {
-        escaped = true;
-        code = out;
-      }
+
+    if (!escaped) {
+      code = escape(code, true);
     }
 
-    code = code.replace(/\n$/, '') + '\n';
+    code = code.replace(/\n$/, '');
 
-    if (!lang) {
-      return '<pre><code>'
-        + (escaped ? code : escape(code, true))
-        + '</code></pre>\n';
-    }
+    const classAttr = lang
+      ? ` class="${this.options.langPrefix}${escape(lang)}"`
+      : '';
 
-    return '<pre><code class="'
-      + this.options.langPrefix
-      + escape(lang)
-      + '">'
-      + (escaped ? code : escape(code, true))
-      + '</code></pre>\n';
+    return `<pre><code${classAttr}>${code}\n</code></pre>\n`;
   }
 
   /**

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -14,18 +14,28 @@ export class Renderer {
 
   code(code, infostring, escaped) {
     const lang = (infostring || '').match(/\S*/)[0];
-
-    if (!escaped) {
-      code = escape(code, true);
+    if (this.options.highlight) {
+      const out = this.options.highlight(code, lang);
+      if (out != null && out !== code) {
+        escaped = true;
+        code = out;
+      }
     }
 
-    code = code.replace(/\n$/, '');
+    code = code.replace(/\n$/, '') + '\n';
 
-    const classAttr = lang
-      ? ` class="${this.options.langPrefix}${escape(lang)}"`
-      : '';
+    if (!lang) {
+      return '<pre><code>'
+        + (escaped ? code : escape(code, true))
+        + '</code></pre>\n';
+    }
 
-    return `<pre><code${classAttr}>${code}\n</code></pre>\n`;
+    return '<pre><code class="'
+      + this.options.langPrefix
+      + escape(lang)
+      + '">'
+      + (escaped ? code : escape(code, true))
+      + '</code></pre>\n';
   }
 
   /**

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -232,9 +232,21 @@ export function findClosingBracket(str, b) {
   return -1;
 }
 
-export function checkSanitizeDeprecation(opt) {
-  if (opt && opt.sanitize && !opt.silent) {
+export function checkDeprecations(opt, callback) {
+  if (!opt || opt.silent) {
+    return;
+  }
+
+  if (callback) {
+    console.warn('marked(): callback is deprecated since version 5.0.0, should not be used and will be removed in the future. Read more here: https://marked.js.org/using_pro#async');
+  }
+
+  if (opt.sanitize) {
     console.warn('marked(): sanitize and sanitizer parameters are deprecated since version 0.7.0, should not be used and will be removed in the future. Read more here: https://marked.js.org/#/USING_ADVANCED.md#options');
+  }
+
+  if (opt.highlight) {
+    console.warn('marked(): highlight parameters are deprecated since version 5.0.0, should not be used and will be removed in the future. Use marked-highlight from https://www.npmjs.com/package/marked-highlight to highlight code blocks.');
   }
 }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -241,16 +241,32 @@ export function checkDeprecations(opt, callback) {
     console.warn('marked(): callback is deprecated since version 5.0.0, should not be used and will be removed in the future. Read more here: https://marked.js.org/using_pro#async');
   }
 
-  if (opt.sanitize) {
+  if (opt.sanitize || opt.sanitizer) {
     console.warn('marked(): sanitize and sanitizer parameters are deprecated since version 0.7.0, should not be used and will be removed in the future. Read more here: https://marked.js.org/#/USING_ADVANCED.md#options');
   }
 
-  if (opt.highlight) {
-    console.warn('marked(): highlight parameter is deprecated since version 5.0.0, should not be used and will be removed in the future. Use marked-highlight from https://www.npmjs.com/package/marked-highlight to highlight code blocks.');
+  if (opt.highlight || opt.langPrefix) {
+    console.warn('marked(): highlight and langPrefix parameters are deprecated since version 5.0.0, should not be used and will be removed in the future. Use marked-highlight from https://www.npmjs.com/package/marked-highlight to highlight code blocks.');
   }
 
   if (opt.mangle) {
     console.warn('marked(): mangle parameter is deprecated since version 5.0.0, should not be used and will be removed in the future. Use marked-mangle from https://www.npmjs.com/package/marked-mangle to mangle emails.');
+  }
+
+  if (opt.baseUrl) {
+    console.warn('marked(): baseUrl parameter is deprecated since version 5.0.0, should not be used and will be removed in the future. Use marked-base-url from https://www.npmjs.com/package/marked-base-url to add a base URL to relative links.');
+  }
+
+  if (opt.smartypants) {
+    console.warn('marked(): smartypants parameter is deprecated since version 5.0.0, should not be used and will be removed in the future. Use marked-smartypants from https://www.npmjs.com/package/marked-smartypants to use "smart" punctuation.');
+  }
+
+  if (opt.xhtml) {
+    console.warn('marked(): xhtml parameter is deprecated since version 5.0.0, should not be used and will be removed in the future. Use marked-xhtml from https://www.npmjs.com/package/marked-xhtml to emit self-closing HTML tags for void elements.');
+  }
+
+  if (opt.headerIds || opt.headerPrefix) {
+    console.warn('marked(): headerIds and headerPrefix parameters are deprecated since version 5.0.0, should not be used and will be removed in the future. Use marked-gfm-heading-id from https://www.npmjs.com/package/marked-gfm-heading-id to add GFM ids to headers.');
   }
 }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -246,27 +246,27 @@ export function checkDeprecations(opt, callback) {
   }
 
   if (opt.highlight || opt.langPrefix) {
-    console.warn('marked(): highlight and langPrefix parameters are deprecated since version 5.0.0, should not be used and will be removed in the future. Use marked-highlight from https://www.npmjs.com/package/marked-highlight to highlight code blocks.');
+    console.warn('marked(): highlight and langPrefix parameters are deprecated since version 5.0.0, should not be used and will be removed in the future. Instead use https://www.npmjs.com/package/marked-highlight.');
   }
 
   if (opt.mangle) {
-    console.warn('marked(): mangle parameter is deprecated since version 5.0.0, should not be used and will be removed in the future. Use marked-mangle from https://www.npmjs.com/package/marked-mangle to mangle emails.');
+    console.warn('marked(): mangle parameter is deprecated since version 5.0.0, should not be used and will be removed in the future. Instead use https://www.npmjs.com/package/marked-mangle.');
   }
 
   if (opt.baseUrl) {
-    console.warn('marked(): baseUrl parameter is deprecated since version 5.0.0, should not be used and will be removed in the future. Use marked-base-url from https://www.npmjs.com/package/marked-base-url to add a base URL to relative links.');
+    console.warn('marked(): baseUrl parameter is deprecated since version 5.0.0, should not be used and will be removed in the future. Instead use https://www.npmjs.com/package/marked-base-url.');
   }
 
   if (opt.smartypants) {
-    console.warn('marked(): smartypants parameter is deprecated since version 5.0.0, should not be used and will be removed in the future. Use marked-smartypants from https://www.npmjs.com/package/marked-smartypants to use "smart" punctuation.');
+    console.warn('marked(): smartypants parameter is deprecated since version 5.0.0, should not be used and will be removed in the future. Instead use https://www.npmjs.com/package/marked-smartypants.');
   }
 
   if (opt.xhtml) {
-    console.warn('marked(): xhtml parameter is deprecated since version 5.0.0, should not be used and will be removed in the future. Use marked-xhtml from https://www.npmjs.com/package/marked-xhtml to emit self-closing HTML tags for void elements.');
+    console.warn('marked(): xhtml parameter is deprecated since version 5.0.0, should not be used and will be removed in the future. Instead use https://www.npmjs.com/package/marked-xhtml.');
   }
 
   if (opt.headerIds || opt.headerPrefix) {
-    console.warn('marked(): headerIds and headerPrefix parameters are deprecated since version 5.0.0, should not be used and will be removed in the future. Use marked-gfm-heading-id from https://www.npmjs.com/package/marked-gfm-heading-id to add GFM ids to headers.');
+    console.warn('marked(): headerIds and headerPrefix parameters are deprecated since version 5.0.0, should not be used and will be removed in the future. Instead use https://www.npmjs.com/package/marked-gfm-heading-id.');
   }
 }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -246,7 +246,11 @@ export function checkDeprecations(opt, callback) {
   }
 
   if (opt.highlight) {
-    console.warn('marked(): highlight parameters are deprecated since version 5.0.0, should not be used and will be removed in the future. Use marked-highlight from https://www.npmjs.com/package/marked-highlight to highlight code blocks.');
+    console.warn('marked(): highlight parameter is deprecated since version 5.0.0, should not be used and will be removed in the future. Use marked-highlight from https://www.npmjs.com/package/marked-highlight to highlight code blocks.');
+  }
+
+  if (opt.mangle) {
+    console.warn('marked(): mangle parameter is deprecated since version 5.0.0, should not be used and will be removed in the future. Use marked-mangle from https://www.npmjs.com/package/marked-mangle to mangle emails.');
   }
 }
 

--- a/src/marked.js
+++ b/src/marked.js
@@ -6,7 +6,7 @@ import { TextRenderer } from './TextRenderer.js';
 import { Slugger } from './Slugger.js';
 import { Hooks } from './Hooks.js';
 import {
-  checkSanitizeDeprecation,
+  checkDeprecations,
   escape
 } from './helpers.js';
 import {
@@ -64,17 +64,13 @@ function parseMarkdown(lexer, parser) {
         + Object.prototype.toString.call(src) + ', string expected'));
     }
 
-    checkSanitizeDeprecation(opt);
+    checkDeprecations(opt, callback);
 
     if (opt.hooks) {
       opt.hooks.options = opt;
     }
 
     if (callback) {
-      if (!opt.silent) {
-        console.warn('marked(): callback is deprecated since version 5.0.0 Read more here: https://marked.js.org/using_advanced#highlight');
-      }
-
       const highlight = opt.highlight;
       let tokens;
 
@@ -153,7 +149,6 @@ function parseMarkdown(lexer, parser) {
       return Promise.resolve(opt.hooks ? opt.hooks.preprocess(src) : src)
         .then(src => lexer(src, opt))
         .then(tokens => opt.walkTokens ? Promise.all(marked.walkTokens(tokens, opt.walkTokens)).then(() => tokens) : tokens)
-        .then(tokens => opt.highlight ? Promise.all(marked.walkTokens(tokens, highlightCode(opt))).then(() => tokens) : tokens)
         .then(tokens => parser(tokens, opt))
         .then(html => opt.hooks ? opt.hooks.postprocess(html) : html)
         .catch(throwError);
@@ -167,9 +162,6 @@ function parseMarkdown(lexer, parser) {
       if (opt.walkTokens) {
         marked.walkTokens(tokens, opt.walkTokens);
       }
-      if (opt.highlight) {
-        marked.walkTokens(tokens, highlightCode(opt));
-      }
       let html = parser(tokens, opt);
       if (opt.hooks) {
         html = opt.hooks.postprocess(html);
@@ -177,31 +169,6 @@ function parseMarkdown(lexer, parser) {
       return html;
     } catch (e) {
       return throwError(e);
-    }
-  };
-}
-
-function highlightCode(opt) {
-  return (token) => {
-    if (token.type !== 'code') {
-      return;
-    }
-
-    const lang = (token.lang || '').match(/\S*/)[0];
-
-    if (opt.async) {
-      return Promise.resolve(opt.highlight(token.text, lang)).then((code) => {
-        if (code !== null && code !== token.text) {
-          token.escaped = true;
-          token.text = code;
-        }
-      });
-    }
-
-    const code = opt.highlight(token.text, lang);
-    if (typeof code === 'string' && code !== token.text) {
-      token.escaped = true;
-      token.text = code;
     }
   };
 }

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -941,6 +941,64 @@ text 1
     });
   });
 
+  it('should highlight codeblocks with async', async() => {
+    highlight.and.callThrough();
+
+    marked.use({
+      async: true,
+      highlight: (code, lang) => new Promise((resolve, reject) => {
+        highlight(code, lang, (err, out) => {
+          if (err) {
+            reject(err);
+          }
+
+          resolve(out);
+        });
+      })
+    });
+
+    const html = await marked(markdown);
+
+    expect(html).toBe(`<pre><code class="language-lang1">async text 1
+</code></pre>
+<blockquote>
+<pre><code class="language-lang2">async text 2
+</code></pre>
+</blockquote>
+<ul>
+<li><pre><code class="language-lang3">async text 3
+</code></pre>
+</li>
+</ul>
+`);
+  });
+
+  it('should highlight codeblocks with async when sync', async() => {
+    highlight.and.callFake((text, lang) => {
+      return `async ${text || ''}`;
+    });
+
+    marked.use({
+      async: true,
+      highlight
+    });
+
+    const html = await marked(markdown);
+
+    expect(html).toBe(`<pre><code class="language-lang1">async text 1
+</code></pre>
+<blockquote>
+<pre><code class="language-lang2">async text 2
+</code></pre>
+</blockquote>
+<ul>
+<li><pre><code class="language-lang3">async text 3
+</code></pre>
+</li>
+</ul>
+`);
+  });
+
   it('should call callback for each error in highlight', (done) => {
     highlight.and.callFake((text, lang, callback) => {
       callback(new Error('highlight error'));

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -943,64 +943,6 @@ text 1
     });
   });
 
-  it('should highlight codeblocks with async', async() => {
-    highlight.and.callThrough();
-
-    marked.use({
-      async: true,
-      highlight: (code, lang) => new Promise((resolve, reject) => {
-        highlight(code, lang, (err, out) => {
-          if (err) {
-            reject(err);
-          }
-
-          resolve(out);
-        });
-      })
-    });
-
-    const html = await marked(markdown);
-
-    expect(html).toBe(`<pre><code class="language-lang1">async text 1
-</code></pre>
-<blockquote>
-<pre><code class="language-lang2">async text 2
-</code></pre>
-</blockquote>
-<ul>
-<li><pre><code class="language-lang3">async text 3
-</code></pre>
-</li>
-</ul>
-`);
-  });
-
-  it('should highlight codeblocks with async when sync', async() => {
-    highlight.and.callFake((text, lang) => {
-      return `async ${text || ''}`;
-    });
-
-    marked.use({
-      async: true,
-      highlight
-    });
-
-    const html = await marked(markdown);
-
-    expect(html).toBe(`<pre><code class="language-lang1">async text 1
-</code></pre>
-<blockquote>
-<pre><code class="language-lang2">async text 2
-</code></pre>
-</blockquote>
-<ul>
-<li><pre><code class="language-lang3">async text 3
-</code></pre>
-</li>
-</ul>
-`);
-  });
-
   it('should call callback for each error in highlight', (done) => {
     highlight.and.callFake((text, lang, callback) => {
       callback(new Error('highlight error'));

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -766,6 +766,7 @@ used extension2 walked</p>
         walked++;
       }
     };
+    use({ silent: true });
     use(extension);
     marked('text', () => {
       expect(walked).toBe(2);
@@ -897,6 +898,7 @@ paragraph
 describe('async highlight', () => {
   let highlight, markdown;
   beforeEach(() => {
+    marked.use({ silent: true });
     highlight = jasmine.createSpy('highlight', (text, lang, callback) => {
       setImmediate(() => {
         callback(null, `async ${text || ''}`);
@@ -1006,10 +1008,9 @@ text 1
 
     let numErrors = 0;
     marked(markdown, { highlight }, (err, html) => {
-      expect(err).toBeTruthy();
-      expect(html).toBeUndefined();
+      expect(html).toContain('An error occurred:');
 
-      if (err) {
+      if (err || html.includes('An error occurred:')) {
         numErrors++;
       }
 


### PR DESCRIPTION
> # 🚨  BREAKING CHANGE 🚨 
> do not submit until we are ready to release v5.0.0

## Description

Deprecate the following options:

| Option | Replacement|
|---------|---------------|
| `highlight`, `langPrefix`, and `callback`| [marked-highlight](https://www.npmjs.com/package/marked-highlight)|
|`mangle`| [marked-mangle](https://www.npmjs.com/package/marked-mangle)|
|`baseUrl`| [marked-base-url](https://www.npmjs.com/package/marked-base-url)|
|`smartypants`| [marked-smartypants](https://www.npmjs.com/package/marked-smartypants)|
|`xhtml`| [marked-xhtml](https://www.npmjs.com/package/marked-xhtml)|
|`headerIds` and `headerPrefix`| [marked-gfm-heading-id](https://www.npmjs.com/package/marked-gfm-heading-id)|

This will be a breaking change so should be done in the next major version.

This only deprecates the options it does not remove them yet. Ideally we will deprecate these in v5.0.0 and remove them in a later major release.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [x] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
