### PR TITLE
feat: add block param to html renderer

### DIFF
--- a/docs/USING_PRO.md
+++ b/docs/USING_PRO.md
@@ -106,7 +106,7 @@ console.log(marked.parse('# heading+'));
 
 - <code>**code**(*string* code, *string* infostring, *boolean* escaped)</code>
 - <code>**blockquote**(*string* quote)</code>
-- <code>**html**(*string* html)</code>
+- <code>**html**(*string* html, *boolean* block)</code>
 - <code>**heading**(*string* text, *number* level, *string* raw, *Slugger* slugger)</code>
 - <code>**hr**()</code>
 - <code>**list**(*string* body, *boolean* ordered, *number* start)</code>

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -173,8 +173,7 @@ export class Parser {
           continue;
         }
         case 'html': {
-          // TODO parse inline content if parameter markdown=1
-          out += this.renderer.html(token.text);
+          out += this.renderer.html(token.text, token.block);
           continue;
         }
         case 'paragraph': {

--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -45,7 +45,7 @@ export class Renderer {
     return `<blockquote>\n${quote}</blockquote>\n`;
   }
 
-  html(html) {
+  html(html, block) {
     return html;
   }
 

--- a/src/Tokenizer.js
+++ b/src/Tokenizer.js
@@ -362,6 +362,7 @@ export class Tokenizer {
     if (cap) {
       const token = {
         type: 'html',
+        block: true,
         raw: cap[0],
         pre: !this.options.sanitizer
           && (cap[1] === 'pre' || cap[1] === 'script' || cap[1] === 'style'),
@@ -519,6 +520,7 @@ export class Tokenizer {
         raw: cap[0],
         inLink: this.lexer.state.inLink,
         inRawBlock: this.lexer.state.inRawBlock,
+        block: false,
         text: this.options.sanitize
           ? (this.options.sanitizer
             ? this.options.sanitizer(cap[0])

--- a/test/unit/Lexer-spec.js
+++ b/test/unit/Lexer-spec.js
@@ -773,6 +773,7 @@ paragraph
             type: 'html',
             raw: '<div>html</div>',
             pre: false,
+            block: true,
             text: '<div>html</div>'
           }
         ]
@@ -787,6 +788,7 @@ paragraph
             type: 'html',
             raw: '<pre>html</pre>',
             pre: true,
+            block: true,
             text: '<pre>html</pre>'
           }
         ]
@@ -802,6 +804,7 @@ paragraph
             type: 'paragraph',
             raw: '<div>html</div>',
             pre: false,
+            block: true,
             text: '&lt;div&gt;html&lt;/div&gt;',
             tokens: [{
               type: 'text',
@@ -884,9 +887,9 @@ paragraph
         expectInlineTokens({
           md: '<div>html</div>',
           tokens: [
-            { type: 'html', raw: '<div>', inLink: false, inRawBlock: false, text: '<div>' },
+            { type: 'html', raw: '<div>', inLink: false, inRawBlock: false, block: false, text: '<div>' },
             { type: 'text', raw: 'html', text: 'html' },
-            { type: 'html', raw: '</div>', inLink: false, inRawBlock: false, text: '</div>' }
+            { type: 'html', raw: '</div>', inLink: false, inRawBlock: false, block: false, text: '</div>' }
           ]
         });
       });
@@ -896,7 +899,14 @@ paragraph
           md: '<div>html</div>',
           options: { sanitize: true },
           tokens: [
-            { type: 'text', raw: '<div>html</div>', inLink: false, inRawBlock: false, text: '&lt;div&gt;html&lt;/div&gt;' }
+            {
+              type: 'text',
+              raw: '<div>html</div>',
+              inLink: false,
+              inRawBlock: false,
+              block: false,
+              text: '&lt;div&gt;html&lt;/div&gt;'
+            }
           ]
         });
       });


### PR DESCRIPTION
## Description

Add `block` parameter to html tokens and a `block` param to html renderer to allow different renderings for inline and block level html.

- Fixes #1745 

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [x] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
