### PR TITLE
Suppress deprecation warnings for default values

### DIFF
--- a/src/marked.js
+++ b/src/marked.js
@@ -64,7 +64,7 @@ function parseMarkdown(lexer, parser) {
         + Object.prototype.toString.call(src) + ', string expected'));
     }
 
-    checkDeprecations(opt, callback);
+    checkDeprecations(origOpt, callback);
 
     if (opt.hooks) {
       opt.hooks.options = opt;


### PR DESCRIPTION
<!--

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->

**Marked version:**

5.0.0

**Markdown flavor:** n/a

## Description

- Fixes #2793

## Expectation

When no optionss are passed to `marked()`, no deprecation warnings should be shown

## Result

`marked` shows several deprecation warnings for unused options.

## What was attempted

Taking a quick look, I noticed that a modified `opt` object that is populated with marked defaults was being passed to the `checkDeprecations` function, instead of the original `opt` object.  Using the original `opt` object suppresses unnecessary deprecation warnings.

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
