### PR TITLE
fix: only warn if langPrefix is changed

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -245,7 +245,7 @@ export function checkDeprecations(opt, callback) {
     console.warn('marked(): sanitize and sanitizer parameters are deprecated since version 0.7.0, should not be used and will be removed in the future. Read more here: https://marked.js.org/#/USING_ADVANCED.md#options');
   }
 
-  if (opt.highlight || opt.langPrefix) {
+  if (opt.highlight || opt.langPrefix !== 'language-') {
     console.warn('marked(): highlight and langPrefix parameters are deprecated since version 5.0.0, should not be used and will be removed in the future. Instead use https://www.npmjs.com/package/marked-highlight.');
   }
 


### PR DESCRIPTION
**Marked version:** 5.0.0

## Description

This removes the warning for langPrefix unless it is changed.

The default warnings can be silenced by setting the following options:

```js
marked.use({
  mangle: false,
  headerIds: false
});
```

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
