### PR TITLE
Clarify deprecation messages for default parameters

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -250,7 +250,7 @@ export function checkDeprecations(opt, callback) {
   }
 
   if (opt.mangle) {
-    console.warn('marked(): mangle parameter is deprecated since version 5.0.0, should not be used and will be removed in the future. Note the "mangle" parameter is historically enabled by default, but can be manually disabled, or instead use https://www.npmjs.com/package/marked-mangle.');
+    console.warn('marked(): mangle parameter is enabled by default, but is deprecated since version 5.0.0, and will be removed in the future. To clear this warning, install https://www.npmjs.com/package/marked-mangle, or disable by setting `{mangle: false}`.');
   }
 
   if (opt.baseUrl) {
@@ -266,7 +266,7 @@ export function checkDeprecations(opt, callback) {
   }
 
   if (opt.headerIds || opt.headerPrefix) {
-    console.warn('marked(): headerIds and headerPrefix parameters are deprecated since version 5.0.0, should not be used and will be removed in the future. Note the "headerIds" parameter is historically enabled by default, but can be manually disabled, or instead use https://www.npmjs.com/package/marked-gfm-heading-id.');
+    console.warn('marked(): headerIds and headerPrefix parameters enabled by default, but are deprecated since version 5.0.0, and will be removed in the future. To clear this warning, install  https://www.npmjs.com/package/marked-gfm-heading-id, or disable by setting `{headerIds: false}`.');
   }
 }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -250,7 +250,7 @@ export function checkDeprecations(opt, callback) {
   }
 
   if (opt.mangle) {
-    console.warn('marked(): mangle parameter is deprecated since version 5.0.0, should not be used and will be removed in the future. Instead use https://www.npmjs.com/package/marked-mangle.');
+    console.warn('marked(): mangle parameter is deprecated since version 5.0.0, should not be used and will be removed in the future. Note the "mangle" parameter is historically enabled by default, but can be manually disabled, or instead use https://www.npmjs.com/package/marked-mangle.');
   }
 
   if (opt.baseUrl) {
@@ -266,7 +266,7 @@ export function checkDeprecations(opt, callback) {
   }
 
   if (opt.headerIds || opt.headerPrefix) {
-    console.warn('marked(): headerIds and headerPrefix parameters are deprecated since version 5.0.0, should not be used and will be removed in the future. Instead use https://www.npmjs.com/package/marked-gfm-heading-id.');
+    console.warn('marked(): headerIds and headerPrefix parameters are deprecated since version 5.0.0, should not be used and will be removed in the future. Note the "headerIds" parameter is historically enabled by default, but can be manually disabled, or instead use https://www.npmjs.com/package/marked-gfm-heading-id.');
   }
 }
 


### PR DESCRIPTION
<!--

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->

**Marked version: 5.0.1**

<!-- The NPM version or commit hash having the issue -->

**Markdown flavor:** n/a

## Description

- Fixes #2797 

Adds a few clarifying words to the deprecation messages for those parameters that are enabled by default. Users are confused about why they are receiving warnings for parameters they didn't manually set; this help indicate that they are enabled by default and they can also just disable the setting if they don't want to get the extension.

I could see changing "historically" to "currently" (or just removing), if that is more clear wording.

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
