### PR TITLE
Introducing the wiki raito rendering engine among utilities

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -128,6 +128,7 @@ We actively support the usability of Marked in super-fast markdown transformatio
 | [zero-md](https://zerodevx.github.io/zero-md/)                      | A native markdown-to-html web component to load and display an external MD file.It uses Marked for super-fast markdown transformation. |
 | [texme](https://github.com/susam/texme)                             | TeXMe is a lightweight JavaScript utility to create self-rendering Markdown + LaTeX documents.             |
 | [StrapDown.js](https://naereen.github.io/StrapDown.js/)             | StrapDown.js is an awesome on-the-fly Markdown to HTML text processor.                |
+| [raito](https://raito.arnaud.at/)             | Mini Markdown Wiki/CMS in 8kb of JavaScript.                |
 | [Homebrewery](https://homebrewery.naturalcrit.com/)             | The Homebrewery is a tool for making authentic looking D&D content using Markdown. It is distributed under the terms of the MIT.             |
 
 <h2 id="security">Security</h2>


### PR DESCRIPTION
Introducing **the ULTRALIGHT SIMPLISTIC raito rendering utility**, among utilities that use markup.js, as a powered wiki engine, which competes strongly against other engines such as github wiki and mediawiki itself

## Description

Including the **raito** into the utilities that uses marked.js project, it has powered features such as:

* **include macro**, can be use to reuse common pages without rewrite same parts into other pages, this is a mayor feautre from wikimedia and redmine wiki engines, still do not supported inside github wiki or gitlab wikis
* **static site generator**, can be used as a fast generation web, just by editing the index.html css style, such can be changed to bootstrap just by minimal tune

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.
