### PR TITLE
fix: Add support for Node 16

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         # lowest verison here should also be in `engines` field
-        node_version: [18, 'lts/*', '*']
+        node_version: [16, 18, 'lts/*', '*']
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code

--- a/package.json
+++ b/package.json
@@ -89,6 +89,6 @@
     "minify": "uglifyjs lib/marked.umd.js -cm  --comments /Copyright/ -o marked.min.js"
   },
   "engines": {
-    "node": ">= 18"
+    "node": ">= 16"
   }
 }


### PR DESCRIPTION
<!--

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->

**Marked version:** `master`

<!-- The NPM version or commit hash having the issue -->

**Markdown flavor:** n/a

## Description

- Fixes https://github.com/markedjs/marked/pull/2767#issuecomment-1534262376

Node 16 is still supported until September and there's no code in `marked` that doesn't work on Node 16, so it's unnecessarily aggressive to disallow it.

## Expectation

Should be able to run marked on Node 16

## Result

`engines` field gets in the way prior to this PR

<!--

	If no issue exists that you're aware of. The maintainers should be able to figure out if it's a duplicate.

## What was attempted

Describe what code combination got you there

-->

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [X] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
