### PR TITLE
chore(git): mark `lib/*` as generated in `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 * eol=lf
 test/* linguist-vendored
-
+lib/*  linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 * eol=lf
-test/* linguist-vendored
-lib/*  linguist-generated
+test/*         linguist-vendored
+lib/*          linguist-generated
+marked.min.js  linguist-generated


### PR DESCRIPTION
## Description

This PR adds `lib/*` and `marked.min.js` to the  `.gitattributes` file in order to suppress them in diffs.

See https://github.com/github-linguist/linguist/blob/master/docs/overrides.md


## Contributor

- [x] no tests required for this PR.

## Committer

In most cases, this should be a different person than the contributor.

- [x] CI is green (no forced merge required).
- [x] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
