### PR TITLE
fix: ignore async: false when async: true is set by an extension

### DIFF
--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -230,6 +230,16 @@ export class Marked {
 
       const origOpt = { ...optOrCallback };
       const opt = { ...this.defaults, ...origOpt };
+
+      // Show warning if an extension set async to true but the parse was called with async: false
+      if (this.defaults.async === true && origOpt.async === false) {
+        if (!opt.silent) {
+          console.warn('marked(): The async option was set to true by an extension. The async: false option sent to parse will be ignored.');
+        }
+
+        opt.async = true;
+      }
+
       const throwError = this.#onError(!!opt.silent, !!opt.async, callback);
 
       // throw error in case of non string input

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -577,6 +577,20 @@ used extension2 walked</p>
     expect(defaults.async).toBeFalse();
   });
 
+  it('should return Promise if async', () => {
+    expect(marked('test', { async: true })).toBeInstanceOf(Promise);
+  });
+
+  it('should return string if not async', () => {
+    expect(typeof marked('test', { async: false })).toBe('string');
+  });
+
+  it('should return Promise if async is set by extension', () => {
+    use({ async: true });
+
+    expect(marked('test', { async: false })).toBeInstanceOf(Promise);
+  });
+
   it('should allow deleting/editing tokens', () => {
     const styleTags = {
       extensions: [{


### PR DESCRIPTION
**Marked version:** 6.0.0

## Description

When `async: true` is set by an extension we need to make sure `marked.parse` returns a promise to await the extension. If the user passes `async: false` to the `marked.parse` function as a second argument we want to warn them that marked will ignore that option and continue to return a Promise.

- Fixes #2919 

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
