### PR TITLE
fix: fix sourcemaps and circular dependencies

### DIFF
--- a/src/MarkedOptions.ts
+++ b/src/MarkedOptions.ts
@@ -1,8 +1,8 @@
 import type { Token, Tokens, TokensList } from './Tokens.ts';
-import { _Parser } from './Parser.ts';
-import { _Lexer } from './Lexer.ts';
-import { _Renderer } from './Renderer.ts';
-import { _Tokenizer } from './Tokenizer.ts';
+import type { _Parser } from './Parser.ts';
+import type { _Lexer } from './Lexer.ts';
+import type { _Renderer } from './Renderer.ts';
+import type { _Tokenizer } from './Tokenizer.ts';
 
 export interface SluggerOptions {
   /** Generates the next unique slug without updating the internal accumulator. */

--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -4,7 +4,7 @@ import {
   escape
 } from './helpers.ts';
 import type { MarkedOptions } from './MarkedOptions.ts';
-import { Slugger } from './marked.ts';
+import type { _Slugger } from './Slugger.ts';
 
 /**
  * Renderer
@@ -49,7 +49,7 @@ export class _Renderer {
     return html;
   }
 
-  heading(text: string, level: number, raw: string, slugger: Slugger): string {
+  heading(text: string, level: number, raw: string, slugger: _Slugger): string {
     if (this.options.headerIds) {
       const id = this.options.headerPrefix + slugger.slug(raw);
       return `<h${level} id="${id}">${text}</h${level}>\n`;

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -5,7 +5,7 @@ import {
   escape,
   findClosingBracket
 } from './helpers.ts';
-import { _Lexer } from './Lexer.ts';
+import type { _Lexer } from './Lexer.ts';
 import type { Links, Tokens } from './Tokens.ts';
 import type { MarkedOptions } from './MarkedOptions.ts';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "allowSyntheticDefaultImports": true,
     "moduleResolution": "NodeNext",
     "noImplicitAny": false,
-    "allowImportingTsExtensions": true
+    "allowImportingTsExtensions": true,
+    "sourceMap": false
   },
   "include": [
     "src/*.ts"


### PR DESCRIPTION
**Marked version:** 7.0.1

## Description

Fix sourcemaps and circular dependencies

sourcemap aren't adding sourceContent in release
https://stackoverflow.com/questions/63218218/rollup-is-not-generating-typescript-sourcemap

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
