### PR TITLE
fix: remove unknown from walkTokens return types

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,7 @@ jobs:
         run: npm run test:lint
 
   Build:
+    name: Build and Test Types
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -61,6 +62,8 @@ jobs:
         run: npm ci
       - name: Build 🗜️
         run: npm run build
+      - name: Run Types Tests 👩🏽‍💻
+        run: npm run test:types
 
   Release:
     permissions:

--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -14,6 +14,7 @@ import type { MarkedExtension, MarkedOptions } from './MarkedOptions.ts';
 import type { Token, Tokens, TokensList } from './Tokens.ts';
 
 export type ResultCallback = (error: Error | null, parseResult?: string) => undefined | void;
+export type MaybePromise = void | Promise<void>;
 
 type UnknownFunction = (...args: unknown[]) => unknown;
 type GenericRendererFunction = (...args: unknown[]) => string | false;
@@ -42,8 +43,8 @@ export class Marked {
   /**
    * Run callback for every token
    */
-  walkTokens <T = void>(tokens: Token[] | TokensList, callback: (token: Token) => T | T[]) {
-    let values: T[] = [];
+  walkTokens(tokens: Token[] | TokensList, callback: (token: Token) => MaybePromise | MaybePromise[]) {
+    let values: MaybePromise[] = [];
     for (const token of tokens) {
       values = values.concat(callback.call(this, token));
       switch (token.type) {
@@ -215,7 +216,7 @@ export class Marked {
         const walkTokens = this.defaults.walkTokens;
         const packWalktokens = pack.walkTokens;
         opts.walkTokens = function(token) {
-          let values: Array<Promise<void> | void | unknown> = [];
+          let values: MaybePromise[] = [];
           values.push(packWalktokens.call(this, token));
           if (walkTokens) {
             values = values.concat(walkTokens.call(this, token));

--- a/src/MarkedOptions.ts
+++ b/src/MarkedOptions.ts
@@ -173,7 +173,7 @@ export interface MarkedExtension {
    * Each token is passed by reference so updates are persisted when passed to the parser.
    * The return value of the function is ignored.
    */
-  walkTokens?: ((token: Token) => void | unknown | Promise<void>) | undefined | null;
+  walkTokens?: ((token: Token) => void | Promise<void>) | undefined | null;
   /**
    * Generate closing slash for self-closing tags (<br/> instead of <br>)
    * @deprecated Deprecated in v5.0.0 use marked-xhtml to emit self-closing HTML tags for void elements (<br/>, <img/>, etc.) with a "/" as required by XHTML.
@@ -213,5 +213,5 @@ export interface MarkedOptions extends Omit<MarkedExtension, 'renderer' | 'token
   /**
    * walkTokens function returns array of values for Promise.all
    */
-  walkTokens?: null | ((token: Token) => void | (unknown | Promise<void>)[]);
+  walkTokens?: null | ((token: Token) => void | Promise<void> | (void | Promise<void>)[]);
 }

--- a/src/marked.ts
+++ b/src/marked.ts
@@ -13,7 +13,7 @@ import {
 } from './defaults.ts';
 import type { MarkedExtension, MarkedOptions } from './MarkedOptions.ts';
 import type { Token, TokensList } from './Tokens.ts';
-import type { ResultCallback } from './Instance.ts';
+import type { ResultCallback, MaybePromise } from './Instance.ts';
 
 const markedInstance = new Marked();
 
@@ -94,7 +94,7 @@ marked.use = function(...args: MarkedExtension[]) {
  * Run callback for every token
  */
 
-marked.walkTokens = function <T = void>(tokens: Token[] | TokensList, callback: (token: Token) => T | T[]) {
+marked.walkTokens = function(tokens: Token[] | TokensList, callback: (token: Token) => MaybePromise | MaybePromise[]) {
   return markedInstance.walkTokens(tokens, callback);
 };
 


### PR DESCRIPTION
**Marked version:** v7.0.4

## Description

Remove `unknown` from walkTokens return types

- Fixes https://github.com/markedjs/marked/pull/2893#pullrequestreview-1595805674

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
