### PR TITLE
fix: fix space removed after checkbox

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -141,11 +141,11 @@ export class _Parser {
                 } else {
                   item.tokens.unshift({
                     type: 'text',
-                    text: checkbox
+                    text: checkbox + ' '
                   } as Tokens.Text);
                 }
               } else {
-                itemBody += checkbox;
+                itemBody += checkbox + ' ';
               }
             }
 

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -39,6 +39,12 @@ describe('task', () => {
 
     expect(html).toBe('<ul>\n<li><input disabled="" type="checkbox"> item</li>\n</ul>\n');
   });
+
+  it('space after loose checkbox', () => {
+    const html = marked('- [ ] item 1\n\n- [ ] item 2');
+
+    expect(html).toBe('<ul>\n<li><p><input disabled="" type="checkbox"> \nitem 1</p>\n</li>\n<li><p><input disabled="" type="checkbox"> \nitem 2</p>\n</li>\n</ul>\n');
+  });
 });
 
 describe('parseInline', () => {

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -33,6 +33,14 @@ describe('inlineLexer', () => {
   });
 });
 
+describe('task', () => {
+  it('space after checkbox', () => {
+    const html = marked('- [ ] item');
+
+    expect(html).toBe('<ul>\n<li><input disabled="" type="checkbox"> item</li>\n</ul>\n');
+  });
+});
+
 describe('parseInline', () => {
   it('should parse inline tokens', () => {
     const md = '**strong** _em_';


### PR DESCRIPTION
**Marked version:** 8.0.0

## Description

Fixes #2970

Add back space after checkbox in task list.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
