### PR TITLE
feat: add `--no-clobber` option to CLI

### DIFF
--- a/bin/main.js
+++ b/bin/main.js
@@ -116,7 +116,7 @@ export async function main(nodeProcess) {
           config = argv.shift();
           break;
         case '-n':
-        case '--noclobber':
+        case '--no-clobber':
           noclobber = true;
           break;
         case '-h':

--- a/bin/main.js
+++ b/bin/main.js
@@ -62,6 +62,7 @@ export async function main(nodeProcess) {
     let tokens;
     let config;
     let opt;
+    let noclobber;
 
     function getArg() {
       let arg = argv.shift();
@@ -113,6 +114,10 @@ export async function main(nodeProcess) {
         case '-c':
         case '--config':
           config = argv.shift();
+          break;
+        case '-n':
+        case '--noclobber':
+          noclobber = true;
           break;
         case '-h':
         case '--help':
@@ -216,6 +221,10 @@ export async function main(nodeProcess) {
       : await marked.parse(data, options);
 
     if (output) {
+      if (noclobber && await fileExists(output)) {
+        nodeProcess.stderr.write('marked: output file \'' + output + '\' already exists, disable the \'-n\' / \'--noclobber\' flag to overwrite\n');
+        nodeProcess.exit(1);
+      }
       return await writeFile(output, html);
     }
 

--- a/bin/main.js
+++ b/bin/main.js
@@ -222,7 +222,7 @@ export async function main(nodeProcess) {
 
     if (output) {
       if (noclobber && await fileExists(output)) {
-        nodeProcess.stderr.write('marked: output file \'' + output + '\' already exists, disable the \'-n\' / \'--noclobber\' flag to overwrite\n');
+        nodeProcess.stderr.write('marked: output file \'' + output + '\' already exists, disable the \'-n\' / \'--no-clobber\' flag to overwrite\n');
         nodeProcess.exit(1);
       }
       return await writeFile(output, html);

--- a/man/marked.1.md
+++ b/man/marked.1.md
@@ -2,7 +2,7 @@
 
 ## SYNOPSIS
 
-`marked` [`-o` <output file>] [`-i` <input file>] [`-s` <markdown string>] [`-c` <config file>] [`--help`] [`--version`] [`--tokens`] [`--noclobber`] [`--pedantic`] [`--gfm`] [`--breaks`] [`--no-etc...`] [`--silent`] [filename]
+`marked` [`-o` <output file>] [`-i` <input file>] [`-s` <markdown string>] [`-c` <config file>] [`--help`] [`--version`] [`--tokens`] [`--no-clobber`] [`--pedantic`] [`--gfm`] [`--breaks`] [`--no-etc...`] [`--silent`] [filename]
 
 ## DESCRIPTION
 
@@ -45,7 +45,7 @@ Specify config file to use instead of the default `~/.marked.json` or `~/.marked
 * -t, --tokens
 Output a token list instead of html.
 
-* -n, --noclobber
+* -n, --no-clobber
 Do not overwrite `output` if it exists.
 
 * --pedantic

--- a/man/marked.1.md
+++ b/man/marked.1.md
@@ -2,7 +2,7 @@
 
 ## SYNOPSIS
 
-`marked` [`-o` <output file>] [`-i` <input file>] [`-s` <markdown string>] [`-c` <config file>] [`--help`] [`--version`] [`--tokens`] [`--pedantic`] [`--gfm`] [`--breaks`] [`--no-etc...`] [`--silent`] [filename]
+`marked` [`-o` <output file>] [`-i` <input file>] [`-s` <markdown string>] [`-c` <config file>] [`--help`] [`--version`] [`--tokens`] [`--noclobber`] [`--pedantic`] [`--gfm`] [`--breaks`] [`--no-etc...`] [`--silent`] [filename]
 
 ## DESCRIPTION
 
@@ -44,6 +44,9 @@ Specify config file to use instead of the default `~/.marked.json` or `~/.marked
 
 * -t, --tokens
 Output a token list instead of html.
+
+* -n, --noclobber
+Do not overwrite `output` if it exists.
 
 * --pedantic
 Conform to obscure parts of markdown.pl as much as possible.


### PR DESCRIPTION
**Marked version:** c9ffa649a4671afec2f18fe11777693b9007ee6a

<!-- The NPM version or commit hash having the issue -->

**Markdown flavor:** n/a

## Description

- Fixes #2012
 
If the `--no-clobber` / `-n` option is set, it throws an error if the output file already exists.

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [x] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
