### PR TITLE
fix: add marked.min.js to package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
       "default": "./lib/marked.cjs"
     },
     "./bin/marked": "./bin/marked.js",
+    "./marked.min.js": "./marked.min.js",
     "./package.json": "./package.json"
   },
   "repository": "git://github.com/markedjs/marked.git",


### PR DESCRIPTION
This change adds the minified js to the package's export conditions.  This will allow projects using PnP to have access to the script during build time.  

Fixes #2885

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
