### PR TITLE
fix: trim newline from blockquote token.text

### DIFF
--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -156,7 +156,7 @@ export class _Tokenizer {
   blockquote(src: string): Tokens.Blockquote | undefined {
     const cap = this.rules.block.blockquote.exec(src);
     if (cap) {
-      const text = cap[0].replace(/^ *>[ \t]?/gm, '');
+      const text = rtrim(cap[0].replace(/^ *>[ \t]?/gm, ''), '\n');
       const top = this.lexer.state.top;
       this.lexer.state.top = true;
       const tokens = this.lexer.blockTokens(text);

--- a/test/unit/Lexer-spec.js
+++ b/test/unit/Lexer-spec.js
@@ -382,6 +382,27 @@ a | b
       });
     });
 
+    it('trim newline in text', () => {
+      expectTokens({
+        md: '> blockquote\n',
+        tokens: [
+          {
+            type: 'blockquote',
+            raw: '> blockquote\n',
+            text: 'blockquote',
+            tokens: [{
+              type: 'paragraph',
+              raw: 'blockquote',
+              text: 'blockquote',
+              tokens: [
+                { type: 'text', raw: 'blockquote', text: 'blockquote' }
+              ]
+            }]
+          }
+        ]
+      });
+    });
+
     it('paragraph token in list', () => {
       expectTokens({
         md: '- > blockquote',


### PR DESCRIPTION
**Marked version:** 9.1.1

## Description

Trim newline from blockquote token.text

- Fixes #3036

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
