### PR TITLE
Chore: Typo fixed in multiple files

### DIFF
--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -137,7 +137,7 @@ export class _Lexer {
         src = src.substring(token.raw.length);
         if (token.raw.length === 1 && tokens.length > 0) {
           // if there's a single \n as a spacer, it's terminating the last line,
-          // so move it there so that we don't get unecessary paragraph tags
+          // so move it there so that we don't get uneccessary paragraph tags
           tokens[tokens.length - 1].raw += '\n';
         } else {
           tokens.push(token);

--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -137,7 +137,7 @@ export class _Lexer {
         src = src.substring(token.raw.length);
         if (token.raw.length === 1 && tokens.length > 0) {
           // if there's a single \n as a spacer, it's terminating the last line,
-          // so move it there so that we don't get uneccessary paragraph tags
+          // so move it there so that we don't get unnecessary paragraph tags
           tokens[tokens.length - 1].raw += '\n';
         } else {
           tokens.push(token);

--- a/test/specs/original/markdown_documentation_basics.html
+++ b/test/specs/original/markdown_documentation_basics.html
@@ -114,7 +114,7 @@ Or, if you prefer, &lt;strong&gt;use two underscores instead&lt;/strong&gt;.&lt;
 
 <p>Unordered (bulleted) lists use asterisks, pluses, and hyphens (<code>*</code>,
 <code>+</code>, and <code>-</code>) as list markers. These three markers are
-interchangable; this:</p>
+interchangeable; this:</p>
 
 <pre><code>*   Candy.
 *   Gum.
@@ -275,7 +275,7 @@ it easy to use Markdown to write about HTML example code:</p>
 <pre><code>I strongly recommend against using any `&lt;blink&gt;` tags.
 
 I wish SmartyPants used named entities like `&amp;mdash;`
-instead of decimal-encoded entites like `&amp;#8212;`.
+instead of decimal-encoded entities like `&amp;#8212;`.
 </code></pre>
 
 <p>Output:</p>
@@ -285,7 +285,7 @@ instead of decimal-encoded entites like `&amp;#8212;`.
 
 &lt;p&gt;I wish SmartyPants used named entities like
 &lt;code&gt;&amp;amp;mdash;&lt;/code&gt; instead of decimal-encoded
-entites like &lt;code&gt;&amp;amp;#8212;&lt;/code&gt;.&lt;/p&gt;
+entities like &lt;code&gt;&amp;amp;#8212;&lt;/code&gt;.&lt;/p&gt;
 </code></pre>
 
 <p>To specify an entire block of pre-formatted code, indent every line of

--- a/test/specs/original/markdown_documentation_basics.md
+++ b/test/specs/original/markdown_documentation_basics.md
@@ -127,7 +127,7 @@ Output:
 
 Unordered (bulleted) lists use asterisks, pluses, and hyphens (`*`,
 `+`, and `-`) as list markers. These three markers are
-interchangable; this:
+interchangeable; this:
 
     *   Candy.
     *   Gum.
@@ -274,7 +274,7 @@ it easy to use Markdown to write about HTML example code:
     I strongly recommend against using any `<blink>` tags.
 
     I wish SmartyPants used named entities like `&mdash;`
-    instead of decimal-encoded entites like `&#8212;`.
+    instead of decimal-encoded entities like `&#8212;`.
 
 Output:
 
@@ -283,7 +283,7 @@ Output:
 
     <p>I wish SmartyPants used named entities like
     <code>&amp;mdash;</code> instead of decimal-encoded
-    entites like <code>&amp;#8212;</code>.</p>
+    entities like <code>&amp;#8212;</code>.</p>
 
 
 To specify an entire block of pre-formatted code, indent every line of

--- a/test/specs/original/markdown_documentation_syntax.html
+++ b/test/specs/original/markdown_documentation_syntax.html
@@ -298,7 +298,7 @@ Quote Level from the Text menu.</p>
 
 <p>Markdown supports ordered (numbered) and unordered (bulleted) lists.</p>
 
-<p>Unordered lists use asterisks, pluses, and hyphens -- interchangably
+<p>Unordered lists use asterisks, pluses, and hyphens -- interchangeably
 -- as list markers:</p>
 
 <pre><code>*   Red

--- a/test/specs/original/markdown_documentation_syntax.md
+++ b/test/specs/original/markdown_documentation_syntax.md
@@ -302,7 +302,7 @@ Quote Level from the Text menu.
 
 Markdown supports ordered (numbered) and unordered (bulleted) lists.
 
-Unordered lists use asterisks, pluses, and hyphens -- interchangably
+Unordered lists use asterisks, pluses, and hyphens -- interchangeably
 -- as list markers:
 
     *   Red

--- a/test/unit/marked-spec.js
+++ b/test/unit/marked-spec.js
@@ -912,7 +912,7 @@ br
     ]);
   });
 
-  it('should asign marked to `this`', () => {
+  it('should assign marked to `this`', () => {
     marked.use({
       walkTokens(token) {
         if (token.type === 'em') {


### PR DESCRIPTION
This PR fix the typo in multiples files

```pseudo
unecessary > unecessary
interchangable > interchangeable
entites > entities
asign > assign
```