### PR TITLE
fix: fix emstrong unicode

### DIFF
--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -629,7 +629,7 @@ export class _Tokenizer {
       endReg.lastIndex = 0;
 
       // Clip maskedSrc to same section of string as src (move to lexer?)
-      maskedSrc = maskedSrc.slice(-1 * src.length + match[0].length - 1);
+      maskedSrc = maskedSrc.slice(-1 * src.length + lLength);
 
       while ((match = endReg.exec(maskedSrc)) != null) {
         rDelim = match[1] || match[2] || match[3] || match[4] || match[5] || match[6];
@@ -654,8 +654,7 @@ export class _Tokenizer {
 
         // Remove extra characters. *a*** -> *a*
         rLength = Math.min(rLength, rLength + delimTotal + midDelimTotal);
-
-        const raw = [...src].slice(0, lLength + match.index + rLength + 1).join('');
+        const raw = src.slice(0, lLength + match.index + rLength + [...match[0]][0].length);
 
         // Create `em` if smallest delimiter has odd char count. *a***
         if (Math.min(lLength, rLength) % 2) {

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -654,7 +654,9 @@ export class _Tokenizer {
 
         // Remove extra characters. *a*** -> *a*
         rLength = Math.min(rLength, rLength + delimTotal + midDelimTotal);
-        const raw = src.slice(0, lLength + match.index + rLength + [...match[0]][0].length);
+        // char length can be >1 for unicode characters;
+        const lastCharLength = [...match[0]][0].length;
+        const raw = src.slice(0, lLength + match.index + lastCharLength + rLength);
 
         // Create `em` if smallest delimiter has odd char count. *a***
         if (Math.min(lLength, rLength) % 2) {

--- a/test/specs/new/emoji_inline.html
+++ b/test/specs/new/emoji_inline.html
@@ -18,3 +18,5 @@
 <p><strong>⚠️ test</strong></p>
 <p>Here, the emoji rendering works, but the text doesn't get rendered in italic.</p>
 <p><em>💁 test</em></p>
+<p><em>t💁t</em> test</p>
+<p><strong>t💁t</strong> test</p>

--- a/test/specs/new/emoji_inline.md
+++ b/test/specs/new/emoji_inline.md
@@ -37,3 +37,7 @@ Situations where it works:
 Here, the emoji rendering works, but the text doesn't get rendered in italic.
 
 *💁 test*
+
+*t💁t* test
+
+**t💁t** test


### PR DESCRIPTION
**Marked version:** 9.1.4

## Description

Fix unicode emstrong [demo](https://marked-website-git-fork-uzitech-fix-emstrong-unicode-markedjs.vercel.app/demo/?text=**%5B%F0%9F%A4%96%E2%94%83bot-commands%5D(https%3A%2F%2Fdiscord.com%2Fchannels%2F870575002536280074%2F981392899012980796)**%20hello&options=%7B%0A%20%22async%22%3A%20false%2C%0A%20%22breaks%22%3A%20false%2C%0A%20%22extensions%22%3A%20null%2C%0A%20%22gfm%22%3A%20true%2C%0A%20%22hooks%22%3A%20null%2C%0A%20%22pedantic%22%3A%20false%2C%0A%20%22silent%22%3A%20false%2C%0A%20%22tokenizer%22%3A%20null%2C%0A%20%22walkTokens%22%3A%20null%0A%7D&version=master)

- Fixes #3069

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
