### PR TITLE
fix: fix instance options sent to lexer and parser

### DIFF
--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -24,11 +24,9 @@ export class Marked {
   parseInline = this.#parseMarkdown(_Lexer.lexInline, _Parser.parseInline);
 
   Parser = _Parser;
-  parser = _Parser.parse;
   Renderer = _Renderer;
   TextRenderer = _TextRenderer;
   Lexer = _Lexer;
-  lexer = _Lexer.lex;
   Tokenizer = _Tokenizer;
   Hooks = _Hooks;
 
@@ -230,6 +228,14 @@ export class Marked {
   setOptions(opt: MarkedOptions) {
     this.defaults = { ...this.defaults, ...opt };
     return this;
+  }
+
+  lexer(src: string, options?: MarkedOptions) {
+    return _Lexer.lex(src, options ?? this.defaults);
+  }
+
+  parser(tokens: Token[], options?: MarkedOptions) {
+    return _Parser.parse(tokens, options ?? this.defaults);
   }
 
   #parseMarkdown(lexer: (src: string, options?: MarkedOptions) => TokensList | Token[], parser: (tokens: Token[], options?: MarkedOptions) => string) {

--- a/test/unit/instance-spec.js
+++ b/test/unit/instance-spec.js
@@ -72,4 +72,19 @@ describe('Marked', () => {
     expect(marked2.parse('# header')).toBe('im marked2');
     expect(marked.parse('# header')).toBe('<h1>header</h1>\n');
   });
+
+  it('should pass defaults to lexer and parser', () => {
+    const marked1 = new Marked();
+    marked1.use({
+      renderer: {
+        heading() {
+          return 'test';
+        }
+      }
+    });
+    const tokens = marked1.lexer('# hi');
+    const html = marked1.parser(tokens);
+
+    expect(html).toBe('test');
+  });
 });


### PR DESCRIPTION
**Marked version:** 9.1.5

## Description

Fix instance.lexer setting default options when none passed in.

```js
import { Marked } from 'marked';

const marked = new Marked();

marked.use({
  renderer: {
    heading() {
      return 'test';
    }
  }
});
const tokens = marked.lexer('# hi');
const html = marked.parser(tokens);
```

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
