### PR TITLE
fix: fix marked types

### DIFF
--- a/src/marked.ts
+++ b/src/marked.ts
@@ -26,13 +26,13 @@ const markedInstance = new Marked();
 export function marked(src: string, options: MarkedOptions & { async: true }): Promise<string>;
 
 /**
- * Compiles markdown to HTML synchronously.
+ * Compiles markdown to HTML.
  *
  * @param src String of markdown source to be compiled
  * @param options Optional hash of options
- * @return String of compiled HTML
+ * @return String of compiled HTML. Wil be a Promise of string if async is set to true by any extensions.
  */
-export function marked(src: string, options?: MarkedOptions): string;
+export function marked(src: string, options?: MarkedOptions): string | Promise<string>;
 export function marked(src: string, opt?: MarkedOptions): string | Promise<string> {
   return markedInstance.parse(src, opt);
 }

--- a/test/types/marked.ts
+++ b/test/types/marked.ts
@@ -247,13 +247,21 @@ marked.use(asyncExtension);
 const md = '# foobar';
 const asyncMarked: string = await marked(md, { async: true });
 const promiseMarked: Promise<string> = marked(md, { async: true });
+// @ts-expect-error marked can still be async if an extension sets `async: true`
 const notAsyncMarked: string = marked(md, { async: false });
+// @ts-expect-error marked can still be async if an extension sets `async: true`
 const defaultMarked: string = marked(md);
+// as string can be used if no extensions set `async: true`
+const stringMarked: string = marked(md) as string;
 
 const asyncMarkedParse: string = await marked.parse(md, { async: true });
 const promiseMarkedParse: Promise<string> = marked.parse(md, { async: true });
+// @ts-expect-error marked can still be async if an extension sets `async: true`
 const notAsyncMarkedParse: string = marked.parse(md, { async: false });
+// @ts-expect-error marked can still be async if an extension sets `async: true`
 const defaultMarkedParse: string = marked.parse(md);
+// as string can be used if no extensions set `async: true`
+const stringMarkedParse: string = marked.parse(md) as string;
 })();
 
 // Tests for List and ListItem


### PR DESCRIPTION
**Marked version:** 10.0.0

## Description

Fix `marked` and `marked.parse` types. `async: false` could still return a `Promise<string>` if an extension sets `async: true`.

- Fixes #3101 

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
