### PR TITLE
fix: fix hooks type

### DIFF
--- a/src/MarkedOptions.ts
+++ b/src/MarkedOptions.ts
@@ -72,8 +72,8 @@ export interface MarkedExtension {
    * postprocess is called to process html after marked has finished parsing.
    */
   hooks?: {
-    preprocess: (markdown: string) => string | Promise<string>,
-    postprocess: (html: string) => string | Promise<string>,
+    preprocess?: (markdown: string) => string | Promise<string>,
+    postprocess?: (html: string) => string | Promise<string>,
     // eslint-disable-next-line no-use-before-define
     options?: MarkedOptions
   } | null;


### PR DESCRIPTION
It shouldn't be required to define both a preprocess and postprocess hook.

## Description

At the moment both `preprocess` and `postprocess` must be defined when creating custom hooks, forcing the following to keep the TypeScript compiler happy:

```ts
marked.use({
  hooks: {
    preprocess: (md) => { /* my preprocess hook */ },
    postprocess: md => md, // dummy postprocess hook I have to define
  },
})
```

This PR makes both hooks optional.