### PR TITLE
fix: allow Renderer class in marked.use

### DIFF
--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -142,8 +142,12 @@ export class Marked {
       if (pack.renderer) {
         const renderer = this.defaults.renderer || new _Renderer(this.defaults);
         for (const prop in pack.renderer) {
-          if (!(prop in renderer) || prop === 'options') {
+          if (!(prop in renderer)) {
             throw new Error(`renderer '${prop}' does not exist`);
+          }
+          if (prop === 'options') {
+            // ignore options property
+            continue;
           }
           const rendererProp = prop as Exclude<keyof _Renderer, 'options'>;
           const rendererFunc = pack.renderer[rendererProp] as GenericRendererFunction;
@@ -162,8 +166,12 @@ export class Marked {
       if (pack.tokenizer) {
         const tokenizer = this.defaults.tokenizer || new _Tokenizer(this.defaults);
         for (const prop in pack.tokenizer) {
-          if (!(prop in tokenizer) || ['options', 'rules', 'lexer'].includes(prop)) {
+          if (!(prop in tokenizer)) {
             throw new Error(`tokenizer '${prop}' does not exist`);
+          }
+          if (['options', 'rules', 'lexer'].includes(prop)) {
+            // ignore options, rules, and lexer properties
+            continue;
           }
           const tokenizerProp = prop as Exclude<keyof _Tokenizer, 'options' | 'rules' | 'lexer'>;
           const tokenizerFunc = pack.tokenizer[tokenizerProp] as UnknownFunction;
@@ -185,8 +193,12 @@ export class Marked {
       if (pack.hooks) {
         const hooks = this.defaults.hooks || new _Hooks();
         for (const prop in pack.hooks) {
-          if (!(prop in hooks) || prop === 'options') {
+          if (!(prop in hooks)) {
             throw new Error(`hook '${prop}' does not exist`);
+          }
+          if (prop === 'options') {
+            // ignore options property
+            continue;
           }
           const hooksProp = prop as Exclude<keyof _Hooks, 'options'>;
           const hooksFunc = pack.hooks[hooksProp] as UnknownFunction;


### PR DESCRIPTION
**Marked version:** 11.0.0

## Description

Ignore extra properties (like `options`) of classes instead of throwing an error when sending renderer, tokenizer, and hooks to `marked.use`

Example:

```js
const renderer = new Renderer();
marked.use({ renderer });
```

Typescript doesn't allow the extra properties and in v11 we throw an error if these properties exist but this will break old extensions. This PR just skips the properties instead of throwing an error.

- Fixes #3117 

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
