### PR TITLE
refac: improve lexing inline elements step's performance

### DIFF
--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -93,6 +93,7 @@ export class _Lexer {
       const next = this.inlineQueue[i];
       this.inlineTokens(next.src, next.tokens);
     }
+    this.inlineQueue = [];
 
     return this.tokens;
   }

--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -89,8 +89,8 @@ export class _Lexer {
 
     this.blockTokens(src, this.tokens);
 
-    let next;
-    while (next = this.inlineQueue.shift()) {
+    for (let i = 0; i < this.inlineQueue.length; i++) {
+      const next = this.inlineQueue[i];
       this.inlineTokens(next.src, next.tokens);
     }
 


### PR DESCRIPTION
**Marked version:** 11.1.0

**Markdown flavor:** n/a

## Description

Improves performance of the lexing step, specifically lexing inline elements. Prompted by this issue https://github.com/markedjs/marked/issues/2355

## What was attempted

Create a benchmark file `bench-100.md` - this file copy pasted x 100 https://raw.githubusercontent.com/thephpleague/commonmark/2.2/tests/benchmark/sample.md (I saw that file linked in the issue and it looked good to me)

master:
- `npm run build`
- create a cpu profile with `node --cpu-prof bin/marked.js -i bench-100.md -o bench-100.html`

Apply my changes:
- `npm run build`
-  create an updated cpu profile with `node --cpu-prof bin/marked.js -i bench-100.md -o bench-100.html`

Load the two profiles in https://www.speedscope.app/ 
- before: 358ms doing marked stuff, 334ms lexing
- after: 242ms doing marked stuff, 218ms lexing
- the difference is even bigger with larger files
- I tried to attach the actual cpu profiles, but github wouldn't let me. I have screenshots of the speedscope though
before:
<img width="2048" alt="speedscope before" src="https://github.com/markedjs/marked/assets/35475068/f3fc06c3-3c78-4bf4-843d-1047fc0229bf">
after:
<img width="2048" alt="speedscope after" src="https://github.com/markedjs/marked/assets/35475068/1747d3c1-49ef-4ac1-a980-979ab5a8d9ee">

The output file is identical, all the tests still pass, and as far as I can tell from reading the code, there shouldn't be any differences in behavior.

The reason this change speeds it up is because changing from `while loop + shift` to `for loop` is that `while + shift` is an n^2 operation; shift shuffles every remaining item in the array down by one, an n time operation, which is done once per item in the array (n * n). Running through the array with a for loop is just n time.

This optimization makes no difference in the automated benchmark. I haven’t read all the benchmark test cases, but I think they’re mostly tiny single item parses, which don’t accumulate a big queue to burn though. The benchmark file has lots of inline elements, so the optimization shows up strongly there.

I think a markdown file that had a good, statistically accurate representation of real world use patterns for all the different markdown features would be super helpful for benchmarking, although it seemed like overkill for this PR.

I’m not sure, and I don’t know if I have the time to do them if they do exist, but I think there might be other architecture level opportunities to improve performance, as opposed to micro level optimizations on things like the regexes. Is there interest in changes like that, even if they meant significant changes to the existing classes?

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
