### PR TITLE
Fix ENOENT error message in CLI

### DIFF
--- a/bin/main.js
+++ b/bin/main.js
@@ -270,7 +270,7 @@ export async function main(nodeProcess) {
     nodeProcess.exit(0);
   } catch (err) {
     if (err.code === 'ENOENT') {
-      nodeProcess.stderr.write('marked: ' + err.path + ': No such directory');
+      nodeProcess.stderr.write('marked: ' + err.path + ': No such file or directory');
     } else {
       nodeProcess.stderr.write(err.message);
     }

--- a/bin/main.js
+++ b/bin/main.js
@@ -271,9 +271,10 @@ export async function main(nodeProcess) {
     nodeProcess.exit(0);
   } catch (err) {
     if (err.code === 'ENOENT') {
-      nodeProcess.stderr.write('marked: output to ' + err.path + ': No such directory');
+      nodeProcess.stderr.write('marked: ' + err.path + ': No such directory');
+    } else {
+      nodeProcess.stderr.write(err.message);
     }
-    nodeProcess.stderr.write(err);
     return nodeProcess.exit(1);
   }
 }

--- a/bin/main.js
+++ b/bin/main.js
@@ -158,7 +158,7 @@ export async function main(nodeProcess) {
         input = files.pop();
       }
       if (!await fileExists(input)) {
-        throw Error(`Input file "${input}" not found.`);
+        throw Error(`Cannot load input file '${input}'`);
       }
       return await readFile(input, 'utf8');
     }

--- a/bin/main.js
+++ b/bin/main.js
@@ -157,9 +157,6 @@ export async function main(nodeProcess) {
         }
         input = files.pop();
       }
-      if (!await fileExists(input)) {
-        throw Error(`Cannot load input file '${input}'`);
-      }
       return await readFile(input, 'utf8');
     }
 

--- a/bin/main.js
+++ b/bin/main.js
@@ -157,6 +157,9 @@ export async function main(nodeProcess) {
         }
         input = files.pop();
       }
+      if (!await fileExists(input)) {
+        throw Error(`Input file "${input}" not found.`);
+      }
       return await readFile(input, 'utf8');
     }
 
@@ -222,8 +225,7 @@ export async function main(nodeProcess) {
 
     if (output) {
       if (noclobber && await fileExists(output)) {
-        nodeProcess.stderr.write('marked: output file \'' + output + '\' already exists, disable the \'-n\' / \'--no-clobber\' flag to overwrite\n');
-        nodeProcess.exit(1);
+        throw Error('marked: output file \'' + output + '\' already exists, disable the \'-n\' / \'--no-clobber\' flag to overwrite\n');
       }
       return await writeFile(output, html);
     }

--- a/test/unit/bin.test.js
+++ b/test/unit/bin.test.js
@@ -97,4 +97,12 @@ describe('bin/marked', () => {
       code: 1
     }));
   });
+
+  describe('input', () => {
+    it('input file not found', testInput({
+      args: [fixturePath('does-not-exist.md')],
+      stderr: `marked: ${fixturePath('does-not-exist.md')} : No such directory'`,
+      code: 1
+    }));
+  });
 });

--- a/test/unit/bin.test.js
+++ b/test/unit/bin.test.js
@@ -67,7 +67,7 @@ function fixturePath(filePath) {
   return resolve(__dirname, './fixtures', filePath);
 }
 
-describe.only('bin/marked', () => {
+describe('bin/marked', () => {
   describe('string', () => {
     it('-s', testInput({
       args: ['-s', '# test'],
@@ -98,9 +98,15 @@ describe.only('bin/marked', () => {
     }));
   });
 
-  describe.only('input', () => {
-    it.only('input file not found', testInput({
+  describe('input', () => {
+    it('input file not found', testInput({
       args: [fixturePath('does-not-exist.md')],
+      stderr: `Cannot load input file '${fixturePath('does-not-exist.md')}'`,
+      code: 1
+    }));
+
+    it('input file not found --input', testInput({
+      args: ['--input', fixturePath('does-not-exist.md')],
       stderr: `Cannot load input file '${fixturePath('does-not-exist.md')}'`,
       code: 1
     }));

--- a/test/unit/bin.test.js
+++ b/test/unit/bin.test.js
@@ -32,7 +32,7 @@ function createMocks() {
         on: mock.fn((method, func) => {
           mocks.stdin[method] = func;
         }),
-        resume: mock.fn
+        resume: mock.fn()
       },
       exit: mock.fn((code) => { mocks.code = code; })
     }
@@ -44,7 +44,7 @@ function createMocks() {
 function testInput({ args = [], stdin = '', stdinError = '', stdout = '', stderr = '', code = 0 } = {}) {
   return async() => {
     const mocks = createMocks();
-    mocks.process.argv = args;
+    mocks.process.argv = ['node', 'marked', ...args];
     const mainPromise = main(mocks.process);
     if (typeof mocks.stdin.end === 'function') {
       if (stdin) {
@@ -67,7 +67,7 @@ function fixturePath(filePath) {
   return resolve(__dirname, './fixtures', filePath);
 }
 
-describe('bin/marked', () => {
+describe.only('bin/marked', () => {
   describe('string', () => {
     it('-s', testInput({
       args: ['-s', '# test'],
@@ -98,8 +98,8 @@ describe('bin/marked', () => {
     }));
   });
 
-  describe('input', () => {
-    it('input file not found', testInput({
+  describe.only('input', () => {
+    it.only('input file not found', testInput({
       args: [fixturePath('does-not-exist.md')],
       stderr: `Cannot load input file '${fixturePath('does-not-exist.md')}'`,
       code: 1

--- a/test/unit/bin.test.js
+++ b/test/unit/bin.test.js
@@ -101,13 +101,13 @@ describe('bin/marked', () => {
   describe('input', () => {
     it('input file not found', testInput({
       args: [fixturePath('does-not-exist.md')],
-      stderr: `Cannot load input file '${fixturePath('does-not-exist.md')}'`,
+      stderr: `marked: ${fixturePath('does-not-exist.md')}: No such directory`,
       code: 1
     }));
 
     it('input file not found --input', testInput({
       args: ['--input', fixturePath('does-not-exist.md')],
-      stderr: `Cannot load input file '${fixturePath('does-not-exist.md')}'`,
+      stderr: `marked: ${fixturePath('does-not-exist.md')}: No such directory`,
       code: 1
     }));
   });

--- a/test/unit/bin.test.js
+++ b/test/unit/bin.test.js
@@ -101,13 +101,13 @@ describe('bin/marked', () => {
   describe('input', () => {
     it('input file not found', testInput({
       args: [fixturePath('does-not-exist.md')],
-      stderr: `marked: ${fixturePath('does-not-exist.md')}: No such directory`,
+      stderr: `marked: ${fixturePath('does-not-exist.md')}: No such file or directory`,
       code: 1
     }));
 
     it('input file not found --input', testInput({
       args: ['--input', fixturePath('does-not-exist.md')],
-      stderr: `marked: ${fixturePath('does-not-exist.md')}: No such directory`,
+      stderr: `marked: ${fixturePath('does-not-exist.md')}: No such file or directory`,
       code: 1
     }));
   });

--- a/test/unit/bin.test.js
+++ b/test/unit/bin.test.js
@@ -91,9 +91,9 @@ describe('bin/marked', () => {
       stdout: '<p>line1<br>line2</p>'
     }));
 
-    it('not found', testInput({
+    it('config not found', testInput({
       args: ['--config', fixturePath('does-not-exist.js'), '-s', 'line1\nline2'],
-      stderr: `Error: Cannot load config file '${fixturePath('does-not-exist.js')}'`,
+      stderr: `Cannot load config file '${fixturePath('does-not-exist.js')}'`,
       code: 1
     }));
   });

--- a/test/unit/bin.test.js
+++ b/test/unit/bin.test.js
@@ -101,7 +101,7 @@ describe('bin/marked', () => {
   describe('input', () => {
     it('input file not found', testInput({
       args: [fixturePath('does-not-exist.md')],
-      stderr: `marked: ${fixturePath('does-not-exist.md')} : No such directory'`,
+      stderr: `Cannot load input file '${fixturePath('does-not-exist.md')}'`,
       code: 1
     }));
   });


### PR DESCRIPTION
<!--

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->

**Marked version:** 11.1.1

**Markdown flavor:** n/a

## Description

This PR fixes a slight bug in the `marked` CLI in which the error message due to a `ENOENT` was bugging out the error output. 

I also updated the language in the `ENOENT` error to better reflect the fact that the `ENOENT` may have been due to any of the inputted files. 

## Expectation

When running the `marked` CLI with an input file that does not exist, I expect it to print out an error containing only the relevant information.

<img width="280" alt="Screenshot 2024-01-18 at 1 58 05 AM" src="https://github.com/markedjs/marked/assets/21364815/87a06995-2f1c-48e4-b943-b06a61c7ed62">

## Result

Marked was attempting to print out both error paths, and attempting to print an error object to `stderr`

<img width="1085" alt="Screenshot 2024-01-18 at 1 59 27 AM" src="https://github.com/markedjs/marked/assets/21364815/0b46efb5-a2de-4d67-9092-f46f6ceabd08">

## What was attempted

The stacktrace above was remediated.

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
