### PR TITLE
feat: flatten childToken arrays

### DIFF
--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -63,7 +63,8 @@ export class Marked {
           const genericToken = token as Tokens.Generic;
           if (this.defaults.extensions?.childTokens?.[genericToken.type]) {
             this.defaults.extensions.childTokens[genericToken.type].forEach((childTokens) => {
-              values = values.concat(this.walkTokens(genericToken[childTokens], callback));
+              const tokens = genericToken[childTokens].flat(Infinity) as Token[] | TokensList;
+              values = values.concat(this.walkTokens(tokens, callback));
             });
           } else if (genericToken.tokens) {
             values = values.concat(this.walkTokens(genericToken.tokens, callback));


### PR DESCRIPTION
**Marked version:** 11.1.1

## Description

Flatten custom extension childToken arrays before running them through walk tokens. This will allow custom extensions to have child tokens like the `table` token where the `rows` field is an array of arrays of tokens.

- Fixes #3170 

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
