### PR TITLE
chore: fix tests in node v21

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   "scripts": {
     "test": "npm run build && npm run test:specs && npm run test:unit",
     "test:all": "npm test && npm run test:umd && npm run test:types && npm run test:lint",
-    "test:unit": "node --test --test-reporter=spec test/unit",
+    "test:unit": "node --test --test-reporter=spec test/unit/*.test.js",
     "test:specs": "node --test --test-reporter=spec test/run-spec-tests.js",
     "test:lint": "eslint .",
     "test:redos": "node test/recheck.js > vuln.js",

--- a/test/unit/marked.test.js
+++ b/test/unit/marked.test.js
@@ -7,6 +7,7 @@ describe('marked unit', () => {
   let marked;
   beforeEach(() => {
     marked = new Marked();
+    setOptions(getDefaults());
   });
 
   describe('Test paragraph token type', () => {


### PR DESCRIPTION
## Description

Unit tests fail in node v21 because of changes to node test runner

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
