### PR TITLE
fix: blockquote code continuation

### DIFF
--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -101,9 +101,9 @@ export class _Lexer {
   /**
    * Lexing
    */
-  blockTokens(src: string, tokens?: Token[]): Token[];
-  blockTokens(src: string, tokens?: TokensList): TokensList;
-  blockTokens(src: string, tokens: Token[] = []) {
+  blockTokens(src: string, tokens?: Token[], lastParagraphClipped?: boolean): Token[];
+  blockTokens(src: string, tokens?: TokensList, lastParagraphClipped?: boolean): TokensList;
+  blockTokens(src: string, tokens: Token[] = [], lastParagraphClipped = false) {
     if (this.options.pedantic) {
       src = src.replace(/\t/g, '    ').replace(/^ +$/gm, '');
     } else {
@@ -115,7 +115,6 @@ export class _Lexer {
     let token: Tokens.Generic | undefined;
     let lastToken;
     let cutSrc;
-    let lastParagraphClipped;
 
     while (src) {
       if (this.options.extensions
@@ -249,7 +248,7 @@ export class _Lexer {
       }
       if (this.state.top && (token = this.tokenizer.paragraph(cutSrc))) {
         lastToken = tokens[tokens.length - 1];
-        if (lastParagraphClipped && lastToken.type === 'paragraph') {
+        if (lastParagraphClipped && lastToken?.type === 'paragraph') {
           lastToken.raw += '\n' + token.raw;
           lastToken.text += '\n' + token.text;
           this.inlineQueue.pop();

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -165,17 +165,19 @@ export class _Tokenizer {
         let inBlockquote = false;
         const currentLines = [];
 
-        while (lines.length > 0) {
+        let i;
+        for (i = 0; i < lines.length; i++) {
           // get lines up to a continuation
-          if (/^ {0,3}>/.test(lines[0])) {
-            currentLines.push(lines.shift());
+          if (/^ {0,3}>/.test(lines[i])) {
+            currentLines.push(lines[i]);
             inBlockquote = true;
           } else if (!inBlockquote) {
-            currentLines.push(lines.shift());
+            currentLines.push(lines[i]);
           } else {
             break;
           }
         }
+        lines = lines.slice(i);
 
         const currentRaw = currentLines.join('\n');
         const currentText = currentRaw
@@ -204,23 +206,23 @@ export class _Tokenizer {
           break;
         } else if (lastToken?.type === 'blockquote') {
           // include continuation in nested blockquote
-          const oldBlockquoteToken = lastToken as Tokens.Blockquote;
-          const newText = oldBlockquoteToken.raw + '\n' + lines.join('\n');
-          const newBlockquoteToken = this.blockquote(newText)!;
-          tokens[tokens.length - 1] = newBlockquoteToken;
+          const oldToken = lastToken as Tokens.Blockquote;
+          const newText = oldToken.raw + '\n' + lines.join('\n');
+          const newToken = this.blockquote(newText)!;
+          tokens[tokens.length - 1] = newToken;
 
-          raw = raw.substring(0, raw.length - oldBlockquoteToken.raw.length) + newBlockquoteToken.raw;
-          text = text.substring(0, text.length - oldBlockquoteToken.text.length) + newBlockquoteToken.text;
+          raw = raw.substring(0, raw.length - oldToken.raw.length) + newToken.raw;
+          text = text.substring(0, text.length - oldToken.text.length) + newToken.text;
           break;
         } else if (lastToken?.type === 'list') {
           // include continuation in nested list
-          const oldListToken = lastToken as Tokens.List;
-          const newText = oldListToken.raw + '\n' + lines.join('\n');
-          const newListToken = this.list(newText)!;
-          tokens[tokens.length - 1] = newListToken;
+          const oldToken = lastToken as Tokens.List;
+          const newText = oldToken.raw + '\n' + lines.join('\n');
+          const newToken = this.list(newText)!;
+          tokens[tokens.length - 1] = newToken;
 
-          raw = raw.substring(0, raw.length - lastToken.raw.length) + newListToken.raw;
-          text = text.substring(0, text.length - oldListToken.raw.length) + newListToken.raw;
+          raw = raw.substring(0, raw.length - lastToken.raw.length) + newToken.raw;
+          text = text.substring(0, text.length - oldToken.raw.length) + newToken.raw;
           lines = newText.substring(tokens[tokens.length - 1].raw.length).split('\n');
           continue;
         }

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -148,7 +148,7 @@ export class _Tokenizer {
     if (cap) {
       return {
         type: 'hr',
-        raw: cap[0]
+        raw: rtrim(cap[0], '\n')
       };
     }
   }

--- a/test/specs/commonmark/commonmark.0.31.json
+++ b/test/specs/commonmark/commonmark.0.31.json
@@ -1887,8 +1887,7 @@
     "example": 236,
     "start_line": 3838,
     "end_line": 3848,
-    "section": "Block quotes",
-    "shouldFail": true
+    "section": "Block quotes"
   },
   {
     "markdown": "> ```\nfoo\n```\n",
@@ -1896,8 +1895,7 @@
     "example": 237,
     "start_line": 3851,
     "end_line": 3861,
-    "section": "Block quotes",
-    "shouldFail": true
+    "section": "Block quotes"
   },
   {
     "markdown": "> foo\n    - bar\n",

--- a/test/specs/gfm/commonmark.0.31.json
+++ b/test/specs/gfm/commonmark.0.31.json
@@ -1887,8 +1887,7 @@
     "example": 236,
     "start_line": 3838,
     "end_line": 3848,
-    "section": "Block quotes",
-    "shouldFail": true
+    "section": "Block quotes"
   },
   {
     "markdown": "> ```\nfoo\n```\n",
@@ -1896,8 +1895,7 @@
     "example": 237,
     "start_line": 3851,
     "end_line": 3861,
-    "section": "Block quotes",
-    "shouldFail": true
+    "section": "Block quotes"
   },
   {
     "markdown": "> foo\n    - bar\n",

--- a/test/unit/marked.test.js
+++ b/test/unit/marked.test.js
@@ -18,7 +18,7 @@ describe('marked unit', () => {
 
       assert.strictEqual(tokens[0].type, 'paragraph');
       assert.strictEqual(tokens[2].tokens[0].type, 'paragraph');
-      assert.strictEqual(tokens[3].items[0].tokens[0].type, 'text');
+      assert.strictEqual(tokens[4].items[0].tokens[0].type, 'text');
     });
   });
 
@@ -924,6 +924,7 @@ br
         ['blockquote', '> blockquote'],
         ['paragraph', 'blockquote'],
         ['text', 'blockquote'],
+        ['space', ''],
         ['list', '- list'],
         ['list_item', '- list'],
         ['text', 'list'],

--- a/test/unit/marked.test.js
+++ b/test/unit/marked.test.js
@@ -910,6 +910,7 @@ br
         ['text', 'paragraph'],
         ['space', ''],
         ['hr', '---'],
+        ['space', ''],
         ['heading', '# heading'],
         ['text', 'heading'],
         ['code', '```code```'],


### PR DESCRIPTION
**Marked version:** 12.0.2

## Description

Fix blockquote continuation for code blocks

Fixes [CommonMark #236](https://spec.commonmark.org/0.31.2/#example-236)
Fixes [CommonMark #237](https://spec.commonmark.org/0.31.2/#example-237)

also adds space token after blockquote and hr if there are multiple newlines. fixes #3167.

I believe this will be a breaking change since tokens will change even though the output won't change.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
