### PR TITLE
fix: allow async option to dictate type returned

### DIFF
--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -521,6 +521,7 @@ export class Marked {
       (src: string, options?: MarkedOptions | undefined | null): string | Promise<string>;
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const parse: overloadedParse = (src: string, options?: MarkedOptions | undefined | null): any => {
       const origOpt = { ...options };
       const opt = { ...this.defaults, ...origOpt };

--- a/src/marked.ts
+++ b/src/marked.ts
@@ -32,8 +32,10 @@ export function marked(src: string, options: MarkedOptions & { async: true }): P
  * @param options Optional hash of options
  * @return String of compiled HTML. Will be a Promise of string if async is set to true by any extensions.
  */
-export function marked(src: string, options?: MarkedOptions): string | Promise<string>;
-export function marked(src: string, opt?: MarkedOptions): string | Promise<string> {
+export function marked(src: string, options: MarkedOptions & { async: false }): string;
+export function marked(src: string, options: MarkedOptions & { async: true }): Promise<string>;
+export function marked(src: string, options?: MarkedOptions | undefined | null): string | Promise<string>;
+export function marked(src: string, opt?: MarkedOptions | undefined | null): string | Promise<string> {
   return markedInstance.parse(src, opt);
 }
 

--- a/test/types/marked.ts
+++ b/test/types/marked.ts
@@ -261,7 +261,6 @@ marked.use(asyncExtension);
 const md = '# foobar';
 const asyncMarked: string = await marked(md, { async: true });
 const promiseMarked: Promise<string> = marked(md, { async: true });
-// @ts-expect-error marked can still be async if an extension sets `async: true`
 const notAsyncMarked: string = marked(md, { async: false });
 // @ts-expect-error marked can still be async if an extension sets `async: true`
 const defaultMarked: string = marked(md);
@@ -270,7 +269,6 @@ const stringMarked: string = marked(md) as string;
 
 const asyncMarkedParse: string = await marked.parse(md, { async: true });
 const promiseMarkedParse: Promise<string> = marked.parse(md, { async: true });
-// @ts-expect-error marked can still be async if an extension sets `async: true`
 const notAsyncMarkedParse: string = marked.parse(md, { async: false });
 // @ts-expect-error marked can still be async if an extension sets `async: true`
 const defaultMarkedParse: string = marked.parse(md);

--- a/test/unit/marked.test.js
+++ b/test/unit/marked.test.js
@@ -630,10 +630,10 @@ used extension2 walked</p>
       assert.strictEqual(typeof marked.parse('test', { async: false }), 'string');
     });
 
-    it('should return Promise if async is set by extension', () => {
+    it('should throw and error if async is set by extension', () => {
       marked.use({ async: true });
 
-      assert.ok(marked.parse('test', { async: false }) instanceof Promise);
+      assert.throws(() => marked.parse('test', { async: false }));
     });
 
     it('should allow deleting/editing tokens', () => {

--- a/test/unit/marked.test.js
+++ b/test/unit/marked.test.js
@@ -630,7 +630,7 @@ used extension2 walked</p>
       assert.strictEqual(typeof marked.parse('test', { async: false }), 'string');
     });
 
-    it('should throw and error if async is set by extension', () => {
+    it('should throw an error if async is set by extension', () => {
       marked.use({ async: true });
 
       assert.throws(() => marked.parse('test', { async: false }));


### PR DESCRIPTION
**Marked version:** v13

## Description

BREAKING CHANGE: throw an error if `async: false` is sent with parse options when using an async extension.

This allows us to overload the parse method when the `async ` option is set.

```js
const html: Promise<string> = marked.parse(md, { async: true });
const html: string = marked.parse(md, { async: false});
const html: Promise<string> | string = marked.parse(md);
```

closes #3116

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
