### PR TITLE
chore: add only test scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.15.3",
-        "@markedjs/testutils": "12.0.0-0",
+        "@markedjs/testutils": "13.0.1-0",
         "@rollup/plugin-terser": "^0.4.4",
         "@rollup/plugin-typescript": "^11.1.6",
         "@semantic-release/commit-analyzer": "^13.0.0",
@@ -444,21 +444,21 @@
       }
     },
     "node_modules/@markedjs/testutils": {
-      "version": "12.0.0-0",
-      "resolved": "https://registry.npmjs.org/@markedjs/testutils/-/testutils-12.0.0-0.tgz",
-      "integrity": "sha512-TzOhMcElD0bVduC8+YvnH04aa5tOovXeIXoZ1WRYOvlABmd42p4bZRS0W/dZlVIuncsN5+uUDHMaWpw0WCDZbw==",
+      "version": "13.0.1-0",
+      "resolved": "https://registry.npmjs.org/@markedjs/testutils/-/testutils-13.0.1-0.tgz",
+      "integrity": "sha512-5r5zLAC2/tXezviSChsiVu9496vlbL+jLMd3XsU8wD4vne/CiblzRrCpU++eIHnYI35LDkXIwonNklbBttHnOw==",
       "dev": true,
       "dependencies": {
         "@markedjs/html-differ": "^4.0.2",
         "front-matter": "^4.0.2",
-        "marked": "^12.0.0",
-        "marked-repo": "https://github.com/markedjs/marked/tarball/v12.0.0"
+        "marked": "^13.0.1",
+        "marked-repo": "https://github.com/markedjs/marked/tarball/v13.0.1"
       }
     },
     "node_modules/@markedjs/testutils/node_modules/marked": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.0.tgz",
-      "integrity": "sha512-Vkwtq9rLqXryZnWaQc86+FHLC6tr/fycMfYAhiOIXkrNmeGAyhSxjqu0Rs1i0bBqw5u0S7+lV9fdH2ZSVaoa0w==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-13.0.1.tgz",
+      "integrity": "sha512-7kBohS6GrZKvCsNXZyVVXSW7/hGBHe49ng99YPkDCckSUrrG7MSFLCexsRxptzOmyW2eT5dySh4Md1V6my52fA==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"
@@ -5489,11 +5489,10 @@
     },
     "node_modules/marked-repo": {
       "name": "marked",
-      "version": "12.0.0",
-      "resolved": "https://github.com/markedjs/marked/tarball/v12.0.0",
-      "integrity": "sha512-Cyo+8nmtvEGnYIx5fl9D/V8jSqQOzQu6uEMJcLOj/viJeW43mqN1Nr4p2CQvmiAxX1RjMiLXsidyhSBarirVoA==",
+      "version": "13.0.1",
+      "resolved": "https://github.com/markedjs/marked/tarball/v13.0.1",
+      "integrity": "sha512-PTGvcbhIqtrJN4z3/X4o5a0qd54BDri2sTbtM0J57bSZAiQ3Qo1boDkP19AgBGKM8M/FiiDGx0fvH76J6b1l7w==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
     "html"
   ],
   "devDependencies": {
-    "@markedjs/testutils": "12.0.0-0",
     "@arethetypeswrong/cli": "^0.15.3",
+    "@markedjs/testutils": "13.0.1-0",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^11.1.6",
     "@semantic-release/commit-analyzer": "^13.0.0",
@@ -87,9 +87,12 @@
   },
   "scripts": {
     "test": "npm run build && npm run test:specs && npm run test:unit",
+    "test:only": "npm run build && npm run test:specs:only && npm run test:unit:only",
     "test:all": "npm test && npm run test:umd && npm run test:types && npm run test:lint",
     "test:unit": "node --test --test-reporter=spec test/unit/*.test.js",
+    "test:unit:only": "node --test --test-only --test-reporter=spec test/unit/*.test.js",
     "test:specs": "node --test --test-reporter=spec test/run-spec-tests.js",
+    "test:specs:only": "node --test --test-only --test-reporter=spec test/run-spec-tests.js",
     "test:lint": "eslint .",
     "test:redos": "node test/recheck.js > vuln.js",
     "test:types": "tsc --project tsconfig-type-test.json && attw -P --exclude-entrypoints ./bin/marked ./marked.min.js",


### PR DESCRIPTION
## Description

add npm scripts to only run tests with `only: true` set

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
