### PR TITLE
feat: add provideLexer and provideParser hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ docs/LICENSE.md
 vuln.js
 man/marked.1
 marked.min.js
+test.js

--- a/docs/USING_PRO.md
+++ b/docs/USING_PRO.md
@@ -261,6 +261,8 @@ Hooks are methods that hook into some part of marked. The following hooks are av
 | `preprocess(markdown: string): string` | Process markdown before sending it to marked. |
 | `postprocess(html: string): string` | Process html after marked has finished parsing. |
 | `processAllTokens(tokens: Token[]): Token[]` | Process all tokens before walk tokens. |
+| `provideLexer(): (src: string, options?: MarkedOptions) => Token[]` | Provide function to tokenize markdown. |
+| `provideParser(): (tokens: Token[], options?: MarkedOptions) => Token[]` | Provide function to parse tokens. |
 
 `marked.use()` can be called multiple times with different `hooks` functions. Each function will be called in order, starting with the function that was assigned *last*.
 

--- a/docs/USING_PRO.md
+++ b/docs/USING_PRO.md
@@ -262,7 +262,7 @@ Hooks are methods that hook into some part of marked. The following hooks are av
 | `postprocess(html: string): string` | Process html after marked has finished parsing. |
 | `processAllTokens(tokens: Token[]): Token[]` | Process all tokens before walk tokens. |
 | `provideLexer(): (src: string, options?: MarkedOptions) => Token[]` | Provide function to tokenize markdown. |
-| `provideParser(): (tokens: Token[], options?: MarkedOptions) => Token[]` | Provide function to parse tokens. |
+| `provideParser(): (tokens: Token[], options?: MarkedOptions) => string` | Provide function to parse tokens. |
 
 `marked.use()` can be called multiple times with different `hooks` functions. Each function will be called in order, starting with the function that was assigned *last*.
 

--- a/docs/USING_PRO.md
+++ b/docs/USING_PRO.md
@@ -327,6 +327,45 @@ console.log(marked.parse(`
 <img src="x">
 ```
 
+**Example:** Save reflinks for chucked rendering
+
+```js
+import { marked, Lexer } from 'marked';
+
+let refLinks = {};
+
+// Override function
+function processAllTokens(tokens) {
+  refLinks = tokens.links;
+  return tokens;
+}
+
+function provideLexer(src, options) {
+  return (src, options) => {
+    const lexer = new Lexer(options);
+    lexer.tokens.links = refLinks;
+    return this.block ? lexer.lex(src) : lexer.inlineTokens(src);
+  };
+}
+
+marked.use({ hooks: { processAllTokens, provideLexer } });
+
+// Parse reflinks separately from markdown that uses them
+marked.parse(`
+[test]: http://example.com
+`);
+
+console.log(marked.parse(`
+[test link][test]
+`));
+```
+
+**Output:**
+
+```html
+<p><a href="http://example.com">test link</a></p>
+```
+
 ***
 
 <h2 id="extensions">Custom Extensions : <code>extensions</code></h2>

--- a/docs/USING_PRO.md
+++ b/docs/USING_PRO.md
@@ -327,7 +327,7 @@ console.log(marked.parse(`
 <img src="x">
 ```
 
-**Example:** Save reflinks for chucked rendering
+**Example:** Save reflinks for chunked rendering
 
 ```js
 import { marked, Lexer } from 'marked';

--- a/src/Hooks.ts
+++ b/src/Hooks.ts
@@ -1,9 +1,12 @@
 import { _defaults } from './defaults.ts';
+import { _Lexer } from './Lexer.ts';
 import type { MarkedOptions } from './MarkedOptions.ts';
+import { _Parser } from './Parser.ts';
 import type { Token, TokensList } from './Tokens.ts';
 
 export class _Hooks {
   options: MarkedOptions;
+  block: boolean | undefined;
 
   constructor(options?: MarkedOptions) {
     this.options = options || _defaults;
@@ -34,5 +37,19 @@ export class _Hooks {
    */
   processAllTokens(tokens: Token[] | TokensList) {
     return tokens;
+  }
+
+  /**
+   * Provide function to tokenize markdown
+   */
+  provideLexer() {
+    return this.block ? _Lexer.lex : _Lexer.lexInline;
+  }
+
+  /**
+   * Provide function to parse tokens
+   */
+  provideParser() {
+    return this.block ? _Parser.parse : _Parser.parseInline;
   }
 }

--- a/src/Hooks.ts
+++ b/src/Hooks.ts
@@ -1,7 +1,7 @@
 import { _defaults } from './defaults.ts';
 import { _Lexer } from './Lexer.ts';
-import type { MarkedOptions } from './MarkedOptions.ts';
 import { _Parser } from './Parser.ts';
+import type { MarkedOptions } from './MarkedOptions.ts';
 import type { Token, TokensList } from './Tokens.ts';
 
 export class _Hooks {

--- a/src/MarkedOptions.ts
+++ b/src/MarkedOptions.ts
@@ -34,7 +34,7 @@ export interface RendererExtension {
 
 export type TokenizerAndRendererExtension = TokenizerExtension | RendererExtension | (TokenizerExtension & RendererExtension);
 
-type HooksApi = Omit<_Hooks, 'constructor' | 'options'>;
+type HooksApi = Omit<_Hooks, 'constructor' | 'options' | 'block'>;
 type HooksObject = {
   [K in keyof HooksApi]?: (this: _Hooks, ...args: Parameters<HooksApi[K]>) => ReturnType<HooksApi[K]> | Promise<ReturnType<HooksApi[K]>>
 };
@@ -77,6 +77,8 @@ export interface MarkedExtension {
    * preprocess is called to process markdown before sending it to marked.
    * processAllTokens is called with the TokensList before walkTokens.
    * postprocess is called to process html after marked has finished parsing.
+   * provideLexer is called to provide a function to tokenize markdown.
+   * provideParser is called to provide a function to parse tokens.
    */
   hooks?: HooksObject | undefined | null;
 

--- a/test/types/marked.ts
+++ b/test/types/marked.ts
@@ -347,6 +347,16 @@ marked.use({
   }
 });
 marked.use({
+  hooks: {
+    provideLexer() {
+      return this.block ? Lexer.lex : Lexer.lexInline;
+    },
+    provideParser() {
+      return this.block ? Parser.parse : Parser.parseInline;
+    },
+  }
+});
+marked.use({
   async: true,
   hooks: {
     async preprocess(markdown) {

--- a/test/unit/Hooks.test.js
+++ b/test/unit/Hooks.test.js
@@ -203,7 +203,7 @@ describe('Hooks', () => {
     assert.strictEqual(html.trim(), '<h1>text</h1>');
   });
 
-  it('should provide lexer async', () => {
+  it('should provide lexer async', async() => {
     marked.use({
       async: true,
       hooks: {
@@ -215,8 +215,20 @@ describe('Hooks', () => {
         },
       },
     });
-    const html = marked.parse('text');
+    const html = await marked.parse('text');
     assert.strictEqual(html.trim(), '<h1>text</h1>');
+  });
+
+  it('should provide parser return object', () => {
+    marked.use({
+      hooks: {
+        provideParser() {
+          return (tokens) => ({ text: 'test parser' });
+        },
+      },
+    });
+    const html = marked.parse('text');
+    assert.strictEqual(html.text, 'test parser');
   });
 
   it('should provide parser', () => {
@@ -231,7 +243,7 @@ describe('Hooks', () => {
     assert.strictEqual(html.trim(), 'test parser');
   });
 
-  it('should provide parser async', () => {
+  it('should provide parser async', async() => {
     marked.use({
       async: true,
       hooks: {
@@ -243,7 +255,7 @@ describe('Hooks', () => {
         },
       },
     });
-    const html = marked.parse('text');
+    const html = await marked.parse('text');
     assert.strictEqual(html.trim(), 'test parser');
   });
 });

--- a/test/unit/Hooks.test.js
+++ b/test/unit/Hooks.test.js
@@ -190,4 +190,60 @@ describe('Hooks', () => {
 <h1>postprocess2 async</h1>
 <h1>postprocess1</h1>`);
   });
+
+  it('should provide lexer', () => {
+    marked.use({
+      hooks: {
+        provideLexer() {
+          return (src) => [createHeadingToken(src)];
+        },
+      },
+    });
+    const html = marked.parse('text');
+    assert.strictEqual(html.trim(), '<h1>text</h1>');
+  });
+
+  it('should provide lexer async', () => {
+    marked.use({
+      async: true,
+      hooks: {
+        provideLexer() {
+          return async(src) => {
+            await timeout();
+            return [createHeadingToken(src)];
+          };
+        },
+      },
+    });
+    const html = marked.parse('text');
+    assert.strictEqual(html.trim(), '<h1>text</h1>');
+  });
+
+  it('should provide parser', () => {
+    marked.use({
+      hooks: {
+        provideParser() {
+          return (tokens) => 'test parser';
+        },
+      },
+    });
+    const html = marked.parse('text');
+    assert.strictEqual(html.trim(), 'test parser');
+  });
+
+  it('should provide parser async', () => {
+    marked.use({
+      async: true,
+      hooks: {
+        provideParser() {
+          return async(tokens) => {
+            await timeout();
+            return 'test parser';
+          };
+        },
+      },
+    });
+    const html = marked.parse('text');
+    assert.strictEqual(html.trim(), 'test parser');
+  });
 });


### PR DESCRIPTION
**Marked version:** 14.0.0

## Description

Add `provideLexer` and `provideParser` hooks to allow extensions that need to change the lexer or parser. This will allow adding links to the Lexer for chunked rendering (#3315). This will also allow extensions to create a new Parser to return something other than an html string. The Parser could return dom elements or react/vue/angular components.

- Fixes #3315

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
