### PR TITLE
fix: don't export block or inline

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "build:docs": "npm run build && node docs/build.js",
     "build:man": "marked-man man/marked.1.md > man/marked.1",
     "build:reset": "git checkout upstream/master lib/marked.cjs lib/marked.umd.js lib/marked.esm.js marked.min.js",
-    "build:types": "tsc && dts-bundle-generator --project tsconfig.json -o lib/marked.d.ts src/marked.ts && dts-bundle-generator --project tsconfig.json -o lib/marked.d.cts src/marked.ts",
+    "build:types": "tsc && dts-bundle-generator --export-referenced-types --project tsconfig.json -o lib/marked.d.ts src/marked.ts && dts-bundle-generator --export-referenced-types --project tsconfig.json -o lib/marked.d.cts src/marked.ts",
     "lint": "eslint --fix",
     "rollup": "rollup -c rollup.config.js",
     "rules": "node test/rules.js",

--- a/src/marked.ts
+++ b/src/marked.ts
@@ -117,5 +117,4 @@ export { _TextRenderer as TextRenderer } from './TextRenderer.ts';
 export { _Hooks as Hooks } from './Hooks.ts';
 export { Marked } from './Instance.ts';
 export type * from './MarkedOptions.ts';
-export type * from './rules.ts';
 export type * from './Tokens.ts';

--- a/test/types/marked.ts
+++ b/test/types/marked.ts
@@ -360,3 +360,11 @@ marked.use({
     }
   }
 });
+
+// @ts-expect-error block is not exported
+import { block } from 'marked';
+// @ts-expect-error inline is not exported
+import { inline } from 'marked';
+// Rules is exported
+import type { Rules } from 'marked';
+


### PR DESCRIPTION
**Marked version:** 14.0.0

## Description

remove block and inline from export types. They were never actually exported. This is caused by https://github.com/timocov/dts-bundle-generator/issues/330

- Fixes #3426 

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
