### PR TITLE
Add a autolink field

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,8 +100,8 @@
     "test:specs": "node --test --test-reporter=spec test/run-spec-tests.js",
     "test:types": "tsc --project tsconfig-type-test.json && attw -P --exclude-entrypoints ./bin/marked ./marked.min.js",
     "test:umd": "node test/umd-test.js",
-    "test:unit:only": "node --test --test-only --test-reporter=spec test/unit/*.test.js",
-    "test:unit": "node --test --test-reporter=spec test/unit/*.test.js",
+    "test:unit:only": "node --test --test-only --test-reporter=spec test/unit",
+    "test:unit": "node --test --test-reporter=spec test/unit",
     "test:update": "node test/update-specs.js"
   },
   "engines": {

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -804,6 +804,7 @@ export class _Tokenizer {
         raw: cap[0],
         text,
         href,
+        autolink: true,
         tokens: [
           {
             type: 'text',

--- a/src/Tokens.ts
+++ b/src/Tokens.ts
@@ -155,6 +155,7 @@ export namespace Tokens {
     raw: string;
     href: string;
     title?: string | null;
+    autolink?: boolean;
     text: string;
     tokens: Token[];
   }

--- a/test/unit/Lexer.test.js
+++ b/test/unit/Lexer.test.js
@@ -1561,6 +1561,7 @@ paragraph
                 raw: '<https://example.com>',
                 text: 'https://example.com',
                 href: 'https://example.com',
+                autolink: true,
                 tokens: [
                   { type: 'text', raw: 'https://example.com', text: 'https://example.com' },
                 ],
@@ -1579,6 +1580,7 @@ paragraph
                 raw: '<test@example.com>',
                 text: 'test@example.com',
                 href: 'mailto:test@example.com',
+                autolink: true,
                 tokens: [
                   { type: 'text', raw: 'test@example.com', text: 'test@example.com' },
                 ],


### PR DESCRIPTION
I'm working on an extension that will render markdown to markdown.
Then you can use marked to lex the markdown, change things, and then write it back to markdown.

While I know that parsing is an inherently lossy process, some of the details can be preserved.

In this PR, I propose to indicate if a link was an autolink or a regular link.

In the future, I might have more of these PRs.

This PR also fixes an issue with the node test runner. I'm running node 20.x, which indicated no unit tests were found.
With the changed command, the unit test now runs again.

If you have any questions or need any changes, please let me know because I'm happy to help.

**Marked version:** any

<!-- The NPM version or commit hash having the issue -->

**Markdown flavor:** Markdown.pl|CommonMark|GitHub Flavored Markdown

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [x] If submitting a new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
