### PR TITLE
fix: include single nested parens in emStrong link mask

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -175,7 +175,7 @@ const punctuation = edit(/^((?![*_])[\spunctuation])/, 'u')
   .replace(/punctuation/g, _punctuation).getRegex();
 
 // sequences em should skip over [title](link), `code`, <html>
-const blockSkip = /\[[^[\]]*?\]\([^\(\)]*?\)|`[^`]*?`|<[^<>]*?>/g;
+const blockSkip = /\[[^[\]]*?\]\((?:\\.|[^\\\(\)]|\((?:\\.|[^\\\(\)])*\))*\)|`[^`]*?`|<[^<>]*?>/g;
 
 const emStrongLDelim = edit(/^(?:\*+(?:((?!\*)[punct])|[^\s*]))|^_+(?:((?!_)[punct])|([^\s_]))/, 'u')
   .replace(/punct/g, _punctuation)

--- a/test/specs/new/underscore_link.html
+++ b/test/specs/new/underscore_link.html
@@ -1,0 +1,1 @@
+<p><em><a href="https://example.com?link=with_(underscore)">test</a></em></p>

--- a/test/specs/new/underscore_link.md
+++ b/test/specs/new/underscore_link.md
@@ -1,0 +1,1 @@
+_[test](https://example.com?link=with_(underscore))_


### PR DESCRIPTION
<!--

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->

**Marked version:** 14.1.2

## Description

Include a single set of nested parentheses in the emStrong link mask. This won't fix the issue completely but will fix for common wikipedia urls like https://en.wikipedia.org/wiki/Node_(networking)

- Fixes #3468 

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
