### PR TITLE
fix: kill SIGINT signal at man for marked --help

### DIFF
--- a/bin/main.js
+++ b/bin/main.js
@@ -35,10 +35,14 @@ export async function main(nodeProcess) {
     const helpText = await readFile(resolve(__dirname, '../man/marked.1.md'), 'utf8');
 
     await new Promise(res => {
-      spawn('man', [resolve(__dirname, '../man/marked.1')], options)
-        .on('error', () => {
-          console.log(helpText);
-        })
+      const manProcess = spawn('man', [resolve(__dirname, '../man/marked.1')], options);
+      nodeProcess.on('SIGINT', () => {
+        manProcess.kill('SIGINT');
+      });
+
+      manProcess.on('error', () => {
+        console.log(helpText);
+      })
         .on('close', res);
     });
   }


### PR DESCRIPTION
**Marked version:**

v14.1.2

**Markdown flavor:** n/a

## Description ##

Doing a Ctrl + C (^C ) caused an error on the child process spawned by marked.
The fix was to forward the signal and kill it in the spawned process. 

- Fixes https://github.com/markedjs/marked/issues/2706

Sorry for the silliest oopsie at #3482
## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
