### PR TITLE
Remove gzip size badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 # Marked
 
 [![npm](https://badgen.net/npm/v/marked)](https://www.npmjs.com/package/marked)
-[![gzip size](https://badgen.net/badgesize/gzip/https://cdn.jsdelivr.net/npm/marked/marked.min.js)](https://cdn.jsdelivr.net/npm/marked/marked.min.js)
 [![install size](https://badgen.net/packagephobia/install/marked)](https://packagephobia.now.sh/result?p=marked)
 [![downloads](https://badgen.net/npm/dt/marked)](https://www.npmjs.com/package/marked)
 [![github actions](https://github.com/markedjs/marked/workflows/Tests/badge.svg)](https://github.com/markedjs/marked/actions)


### PR DESCRIPTION
It seems (per badgen/badgen.net#663) that size badge is no longer supported so it has to be removed


**Marked version:**

N/A

**Markdown flavor:** n/a

## Description

- Fixes a problem with broken badge in the project's readme file

## Expectation

There should be no broken badge in the project's readme file

## Result

There is a broken badge in the project's readme file

## What was attempted

The broken badge was removed 🙂 

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
