### PR TITLE
fix: fix html comment after list

### DIFF
--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -305,7 +305,7 @@ export class _Tokenizer {
           const hrRegex = new RegExp(`^ {0,${Math.min(3, indent - 1)}}((?:- *){3,}|(?:_ *){3,}|(?:\\* *){3,})(?:\\n+|$)`);
           const fencesBeginRegex = new RegExp(`^ {0,${Math.min(3, indent - 1)}}(?:\`\`\`|~~~)`);
           const headingBeginRegex = new RegExp(`^ {0,${Math.min(3, indent - 1)}}#`);
-          const htmlBeginRegex = new RegExp(`^ {0,${Math.min(3, indent - 1)}}<[a-z].*>`, 'i');
+          const htmlBeginRegex = new RegExp(`^ {0,${Math.min(3, indent - 1)}}<(?:[a-z].*>|!--)`, 'i');
 
           // Check if following lines should be included in List Item
           while (src) {

--- a/test/specs/new/html_following_list.html
+++ b/test/specs/new/html_following_list.html
@@ -5,3 +5,11 @@
 <div class="some-class">
 Content
 </div>
+
+<ul>
+  <li>list item 1</li>
+  <li>list item 2</li>
+</ul>
+<!--
+Comment
+-->

--- a/test/specs/new/html_following_list.md
+++ b/test/specs/new/html_following_list.md
@@ -3,3 +3,9 @@
 <div class="some-class">
 Content
 </div>
+
+- list item 1
+- list item 2
+<!--
+Comment
+-->


### PR DESCRIPTION
**Marked version:** 14.1.3

## Description

HTML comment should end list without a blank line between them

- Fixes #3515 

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
