### PR TITLE
fix: update punctuation regex syntax for compatibility

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -243,7 +243,7 @@ const br = /^( {2,}|\\)\n(?!\s*$)/;
 const inlineText = /^(`+|[^`])(?:(?= {2,}\n)|[\s\S]*?(?:(?=[\\<!\[`*_]|\b_|$)|[^ ](?= {2,}\n)))/;
 
 // list of unicode punctuation marks, plus any missing characters from CommonMark spec
-const _punctuation = '\\p{P}\\p{S}';
+const _punctuation = /\p{P}\p{S}/u;
 const punctuation = edit(/^((?![*_])[\spunctuation])/, 'u')
   .replace(/punctuation/g, _punctuation).getRegex();
 


### PR DESCRIPTION
**Marked version:** 13.0.1

**Markdown flavor:** Markdown.pl|CommonMark|GitHub Flavored Markdown|n/a

## Description

- as [pr3229](https://github.com/markedjs/marked/pull/3229) said, the punctuation regex syntax is not supported in some browser

- change the string to a regular expression. Then babel can transpile it correctly.


## Expectation

Marked should work fine in most cases.

## Result

Host environment reports error due to unsupported regex syntax.

## What was attempted

-->

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
