### PR TITLE
fix: fix list with no items looping forever

### DIFF
--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -418,6 +418,9 @@ export class _Tokenizer {
       if (lastItem) {
         lastItem.raw = lastItem.raw.trimEnd();
         lastItem.text = lastItem.text.trimEnd();
+      } else {
+        // not a list since there were no items
+        return;
       }
       list.raw = list.raw.trimEnd();
 

--- a/test/unit/marked.test.js
+++ b/test/unit/marked.test.js
@@ -127,6 +127,20 @@ describe('marked unit', () => {
       assert.strictEqual(html, '<p>Not Underlined A</p>\n<u>Underlined B</u>\n<p>Not Underlined C\n:Not Underlined D</p>\n');
     });
 
+    it('should not return list if no items', () => {
+      const noHr = {
+        tokenizer: {
+          hr() {
+            return undefined;
+          },
+        },
+      };
+      marked.use(noHr);
+      const markdown = '- - -';
+      const html = marked.parse(markdown);
+      assert.strictEqual(html, '<p>- - -</p>\n');
+    });
+
     it('should use custom inline tokenizer + renderer extensions', () => {
       const underline = {
         name: 'underline',


### PR DESCRIPTION
**Marked version:** 15.0.3

## Description

Fix looping forever when a list doesn't have any items. For example if it thinks the item is an hr but hr has been disabled like

```js
tokenizer: {
  hr() {
    return undefined;
  }
}
```

- Fixes #3559 

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
