### PR TITLE
fix: fix emstrong inside escaped backticks

### DIFF
--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -312,14 +312,15 @@ export class _Lexer {
         }
       }
     }
-    // Mask out other blocks
-    while ((match = this.tokenizer.rules.inline.blockSkip.exec(maskedSrc)) != null) {
-      maskedSrc = maskedSrc.slice(0, match.index) + '[' + 'a'.repeat(match[0].length - 2) + ']' + maskedSrc.slice(this.tokenizer.rules.inline.blockSkip.lastIndex);
-    }
 
     // Mask out escaped characters
     while ((match = this.tokenizer.rules.inline.anyPunctuation.exec(maskedSrc)) != null) {
       maskedSrc = maskedSrc.slice(0, match.index) + '++' + maskedSrc.slice(this.tokenizer.rules.inline.anyPunctuation.lastIndex);
+    }
+    
+    // Mask out other blocks
+    while ((match = this.tokenizer.rules.inline.blockSkip.exec(maskedSrc)) != null) {
+      maskedSrc = maskedSrc.slice(0, match.index) + '[' + 'a'.repeat(match[0].length - 2) + ']' + maskedSrc.slice(this.tokenizer.rules.inline.blockSkip.lastIndex);
     }
 
     let keepPrevChar = false;

--- a/test/specs/new/escape_tick.html
+++ b/test/specs/new/escape_tick.html
@@ -1,1 +1,9 @@
+<p><em>italics</em></p>
+<p><strong>bold</strong></p>
+<p><em><strong>bold italics</strong></em></p>
+<p><code>*quoted italics*</code></p>
+<p><code>**quoted bold**</code></p>
+<p><code>***quoted bold italics***</code></p>
 <p>`<em>escaped quoted italics</em>`</p>
+<p>`<strong>escaped quoted bold</strong>`</p>
+<p>`<em><strong>escaped quoted bold italics</strong></em>`</p>

--- a/test/specs/new/escape_tick.html
+++ b/test/specs/new/escape_tick.html
@@ -1,0 +1,1 @@
+<p>`<em>escaped quoted italics</em>`</p>

--- a/test/specs/new/escape_tick.md
+++ b/test/specs/new/escape_tick.md
@@ -1,0 +1,4 @@
+---
+only: true
+---
+\`*escaped quoted italics*\`

--- a/test/specs/new/escape_tick.md
+++ b/test/specs/new/escape_tick.md
@@ -1,4 +1,17 @@
----
-only: true
----
+*italics*
+
+**bold**
+
+***bold italics***
+
+`*quoted italics*`
+
+`**quoted bold**`
+
+`***quoted bold italics***`
+
 \`*escaped quoted italics*\`
+
+\`**escaped quoted bold**\`
+
+\`***escaped quoted bold italics***\`


### PR DESCRIPTION
**Marked version:** 15.0.7

## Description

Mask escaped characters before blocks

- Fixes #3648

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
