### PR TITLE
fix: expose Lexer.rules.other

### DIFF
--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -60,6 +60,7 @@ export class _Lexer {
    */
   static get rules() {
     return {
+      other,
       block,
       inline,
     };


### PR DESCRIPTION
<!--

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->

**Marked version:**

<!-- The NPM version or commit hash having the issue -->

**Markdown flavor:** n/a

## Description

I'd like to extend the renderer, and I noticed there is no access to the "other" regexes.

<!--

	If no issue exists that you're aware of. The maintainers should be able to figure out if it's a duplicate.

## Expectation

Describe the output you are expecting from marked

## Result

Describe the output you received from marked

## What was attempted

Describe what code combination got you there

-->

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [X] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
