### PR TITLE
fix: fix link url with no closing parenthesis

### DIFF
--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -636,6 +636,11 @@ export class _Tokenizer {
       } else {
         // find closing parenthesis
         const lastParenIndex = findClosingBracket(cap[2], '()');
+        if (lastParenIndex === -2) {
+          // more open parens than closed
+          return;
+        }
+
         if (lastParenIndex > -1) {
           const start = cap[0].indexOf('!') === 0 ? 5 : 4;
           const linkLen = start + cap[1].length + lastParenIndex;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -141,5 +141,9 @@ export function findClosingBracket(str: string, b: string) {
       }
     }
   }
+  if (level > 0) {
+    return -2;
+  }
+
   return -1;
 }

--- a/test/specs/commonmark/commonmark.0.31.2.json
+++ b/test/specs/commonmark/commonmark.0.31.2.json
@@ -3975,8 +3975,7 @@
     "example": 497,
     "start_line": 7666,
     "end_line": 7670,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "[link](foo\\(and\\(bar\\))\n",

--- a/test/specs/gfm/commonmark.0.31.2.json
+++ b/test/specs/gfm/commonmark.0.31.2.json
@@ -3975,8 +3975,7 @@
     "example": 497,
     "start_line": 7666,
     "end_line": 7670,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "[link](foo\\(and\\(bar\\))\n",

--- a/test/specs/new/link_unbalanced.html
+++ b/test/specs/new/link_unbalanced.html
@@ -1,0 +1,5 @@
+<p>[link](foo(bar())</p>
+
+<p><a href="foo(bar()">link</a></p>
+
+<p><a href="foo(bar()">link</a></p>

--- a/test/specs/new/link_unbalanced.html
+++ b/test/specs/new/link_unbalanced.html
@@ -3,3 +3,5 @@
 <p><a href="foo(bar()">link</a></p>
 
 <p><a href="foo(bar()">link</a></p>
+
+<p>[link](foo(bar\())</p>

--- a/test/specs/new/link_unbalanced.md
+++ b/test/specs/new/link_unbalanced.md
@@ -3,3 +3,5 @@
 [link](foo\(bar())
 
 [link](foo(bar\())
+
+[link](foo(bar\\())

--- a/test/specs/new/link_unbalanced.md
+++ b/test/specs/new/link_unbalanced.md
@@ -1,0 +1,5 @@
+[link](foo(bar())
+
+[link](foo\(bar())
+
+[link](foo(bar\())


### PR DESCRIPTION
**Marked version:** 15.0.8

## Description

fixes https://spec.commonmark.org/0.31.2/#example-497

Links and images with unbalanced parentheses need to be escaped

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
