### PR TITLE
fix: fix image alt text rendered

### DIFF
--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -193,8 +193,10 @@ export class _Renderer {
     return out;
   }
 
-  image({ href, title, tokens }: Tokens.Image): string {
-    const text = this.parser.parseInline(tokens, this.parser.textRenderer);
+  image({ href, title, text, tokens }: Tokens.Image): string {
+    if (tokens) {
+      text = this.parser.parseInline(tokens, this.parser.textRenderer);
+    }
     const cleanHref = cleanUrl(href);
     if (cleanHref === null) {
       return escape(text);

--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -193,7 +193,8 @@ export class _Renderer {
     return out;
   }
 
-  image({ href, title, text }: Tokens.Image): string {
+  image({ href, title, tokens }: Tokens.Image): string {
+    const text = this.parser.parseInline(tokens, this.parser.textRenderer);
     const cleanHref = cleanUrl(href);
     if (cleanHref === null) {
       return escape(text);

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -14,26 +14,17 @@ function outputLink(cap: string[], link: Pick<Tokens.Link, 'href' | 'title'>, ra
   const title = link.title || null;
   const text = cap[1].replace(rules.other.outputLinkReplace, '$1');
 
-  if (cap[0].charAt(0) !== '!') {
-    lexer.state.inLink = true;
-    const token: Tokens.Link = {
-      type: 'link',
-      raw,
-      href,
-      title,
-      text,
-      tokens: lexer.inlineTokens(text),
-    };
-    lexer.state.inLink = false;
-    return token;
-  }
-  return {
-    type: 'image',
+  lexer.state.inLink = true;
+  const token: Tokens.Link | Tokens.Image = {
+    type: cap[0].charAt(0) === '!' ? 'image' : 'link',
     raw,
     href,
     title,
     text,
+    tokens: lexer.inlineTokens(text),
   };
+  lexer.state.inLink = false;
+  return token;
 }
 
 function indentCodeCompensation(raw: string, text: string, rules: Rules) {

--- a/src/Tokens.ts
+++ b/src/Tokens.ts
@@ -123,6 +123,7 @@ export namespace Tokens {
     href: string;
     title: string | null;
     text: string;
+    tokens: Token[];
   }
 
   export interface Link {

--- a/test/specs/commonmark/commonmark.0.31.2.json
+++ b/test/specs/commonmark/commonmark.0.31.2.json
@@ -4597,8 +4597,7 @@
     "example": 573,
     "start_line": 8548,
     "end_line": 8554,
-    "section": "Images",
-    "shouldFail": true
+    "section": "Images"
   },
   {
     "markdown": "![foo ![bar](/url)](/url2)\n",
@@ -4606,8 +4605,7 @@
     "example": 574,
     "start_line": 8557,
     "end_line": 8561,
-    "section": "Images",
-    "shouldFail": true
+    "section": "Images"
   },
   {
     "markdown": "![foo [bar](/url)](/url2)\n",
@@ -4615,8 +4613,7 @@
     "example": 575,
     "start_line": 8564,
     "end_line": 8568,
-    "section": "Images",
-    "shouldFail": true
+    "section": "Images"
   },
   {
     "markdown": "![foo *bar*][]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
@@ -4624,8 +4621,7 @@
     "example": 576,
     "start_line": 8578,
     "end_line": 8584,
-    "section": "Images",
-    "shouldFail": true
+    "section": "Images"
   },
   {
     "markdown": "![foo *bar*][foobar]\n\n[FOOBAR]: train.jpg \"train & tracks\"\n",
@@ -4633,8 +4629,7 @@
     "example": 577,
     "start_line": 8587,
     "end_line": 8593,
-    "section": "Images",
-    "shouldFail": true
+    "section": "Images"
   },
   {
     "markdown": "![foo](train.jpg)\n",
@@ -4698,8 +4693,7 @@
     "example": 585,
     "start_line": 8655,
     "end_line": 8661,
-    "section": "Images",
-    "shouldFail": true
+    "section": "Images"
   },
   {
     "markdown": "![Foo][]\n\n[foo]: /url \"title\"\n",
@@ -4731,8 +4725,7 @@
     "example": 589,
     "start_line": 8700,
     "end_line": 8706,
-    "section": "Images",
-    "shouldFail": true
+    "section": "Images"
   },
   {
     "markdown": "![[foo]]\n\n[[foo]]: /url \"title\"\n",

--- a/test/specs/gfm/commonmark.0.31.2.json
+++ b/test/specs/gfm/commonmark.0.31.2.json
@@ -4597,8 +4597,7 @@
     "example": 573,
     "start_line": 8548,
     "end_line": 8554,
-    "section": "Images",
-    "shouldFail": true
+    "section": "Images"
   },
   {
     "markdown": "![foo ![bar](/url)](/url2)\n",
@@ -4606,8 +4605,7 @@
     "example": 574,
     "start_line": 8557,
     "end_line": 8561,
-    "section": "Images",
-    "shouldFail": true
+    "section": "Images"
   },
   {
     "markdown": "![foo [bar](/url)](/url2)\n",
@@ -4615,8 +4613,7 @@
     "example": 575,
     "start_line": 8564,
     "end_line": 8568,
-    "section": "Images",
-    "shouldFail": true
+    "section": "Images"
   },
   {
     "markdown": "![foo *bar*][]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
@@ -4624,8 +4621,7 @@
     "example": 576,
     "start_line": 8578,
     "end_line": 8584,
-    "section": "Images",
-    "shouldFail": true
+    "section": "Images"
   },
   {
     "markdown": "![foo *bar*][foobar]\n\n[FOOBAR]: train.jpg \"train & tracks\"\n",
@@ -4633,8 +4629,7 @@
     "example": 577,
     "start_line": 8587,
     "end_line": 8593,
-    "section": "Images",
-    "shouldFail": true
+    "section": "Images"
   },
   {
     "markdown": "![foo](train.jpg)\n",
@@ -4698,8 +4693,7 @@
     "example": 585,
     "start_line": 8655,
     "end_line": 8661,
-    "section": "Images",
-    "shouldFail": true
+    "section": "Images"
   },
   {
     "markdown": "![Foo][]\n\n[foo]: /url \"title\"\n",
@@ -4731,8 +4725,7 @@
     "example": 589,
     "start_line": 8700,
     "end_line": 8706,
-    "section": "Images",
-    "shouldFail": true
+    "section": "Images"
   },
   {
     "markdown": "![[foo]]\n\n[[foo]]: /url \"title\"\n",

--- a/test/types/marked.ts
+++ b/test/types/marked.ts
@@ -104,7 +104,7 @@ class ExtendedRenderer extends marked.Renderer {
   br = ({ type, raw }: Tokens.Br): string => super.br({ type, raw });
   del = ({ type, raw, text, tokens }: Tokens.Del): string => super.del({ type, raw, text, tokens });
   link = ({ type, raw, href, title, text, tokens }: Tokens.Link): string => super.link({ type, raw, href, title, text, tokens });
-  image = ({ type, raw, href, title, text }: Tokens.Image): string => super.image({ type, raw, href, title, text });
+  image = ({ type, raw, href, title, text }: Tokens.Image): string => super.image({ type, raw, href, title, text, tokens });
 }
 
 const rendererOptions: MarkedOptions = renderer.options;

--- a/test/unit/Lexer.test.js
+++ b/test/unit/Lexer.test.js
@@ -1340,6 +1340,12 @@ paragraph
               text: 'image',
               href: 'https://example.com/image.png',
               title: null,
+              tokens: [{
+                type: 'text',
+                raw: 'image',
+                text: 'image',
+                escaped: false,
+              }],
             },
           ],
         });
@@ -1355,6 +1361,12 @@ paragraph
               text: 'image',
               href: 'https://example.com/image.png',
               title: 'title',
+              tokens: [{
+                type: 'text',
+                raw: 'image',
+                text: 'image',
+                escaped: false,
+              }],
             },
           ],
         });

--- a/test/unit/Parser.test.js
+++ b/test/unit/Parser.test.js
@@ -396,6 +396,12 @@ describe('Parser', () => {
             text: 'image',
             href: 'image.png',
             title: 'title',
+            tokens: [{
+              type: 'text',
+              raw: 'image',
+              text: 'image',
+              escaped: false,
+            }],
           },
         ],
         html: '<img src="image.png" alt="image" title="title">',

--- a/test/unit/marked.test.js
+++ b/test/unit/marked.test.js
@@ -959,6 +959,7 @@ br
         ['space', ''],
         ['paragraph', '![image](https://example.com/image.jpg)'],
         ['image', '![image](https://example.com/image.jpg)'],
+        ['text', 'image'],
         ['space', ''],
         ['paragraph', '**strong**'],
         ['strong', '**strong**'],


### PR DESCRIPTION
**Marked version:** 15.0.9

## Description

Image alt text should be rendered in plain text.

fixes:
 - https://spec.commonmark.org/0.31.2/#example-573
 - https://spec.commonmark.org/0.31.2/#example-574
 - https://spec.commonmark.org/0.31.2/#example-575
 - https://spec.commonmark.org/0.31.2/#example-576
 - https://spec.commonmark.org/0.31.2/#example-577
 - https://spec.commonmark.org/0.31.2/#example-585
 - https://spec.commonmark.org/0.31.2/#example-589

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
