### PR TITLE
fix: add generic types for parser and renderer output

### DIFF
--- a/src/Hooks.ts
+++ b/src/Hooks.ts
@@ -4,11 +4,11 @@ import { _Parser } from './Parser.ts';
 import type { MarkedOptions } from './MarkedOptions.ts';
 import type { Token, TokensList } from './Tokens.ts';
 
-export class _Hooks<P = string, R = string> {
-  options: MarkedOptions<P, R>;
+export class _Hooks<ParserOutput = string, RendererOutput = string> {
+  options: MarkedOptions<ParserOutput, RendererOutput>;
   block?: boolean;
 
-  constructor(options?: MarkedOptions<P, R>) {
+  constructor(options?: MarkedOptions<ParserOutput, RendererOutput>) {
     this.options = options || _defaults;
   }
 
@@ -28,7 +28,7 @@ export class _Hooks<P = string, R = string> {
   /**
    * Process HTML after marked is finished
    */
-  postprocess(html: P) {
+  postprocess(html: ParserOutput) {
     return html;
   }
 
@@ -50,6 +50,6 @@ export class _Hooks<P = string, R = string> {
    * Provide function to parse tokens
    */
   provideParser() {
-    return this.block ? _Parser.parse<P, R> : _Parser.parseInline<P, R>;
+    return this.block ? _Parser.parse<ParserOutput, RendererOutput> : _Parser.parseInline<ParserOutput, RendererOutput>;
   }
 }

--- a/src/Hooks.ts
+++ b/src/Hooks.ts
@@ -4,11 +4,11 @@ import { _Parser } from './Parser.ts';
 import type { MarkedOptions } from './MarkedOptions.ts';
 import type { Token, TokensList } from './Tokens.ts';
 
-export class _Hooks {
-  options: MarkedOptions;
+export class _Hooks<P = string, R = string> {
+  options: MarkedOptions<P, R>;
   block?: boolean;
 
-  constructor(options?: MarkedOptions) {
+  constructor(options?: MarkedOptions<P, R>) {
     this.options = options || _defaults;
   }
 
@@ -28,7 +28,7 @@ export class _Hooks {
   /**
    * Process HTML after marked is finished
    */
-  postprocess(html: string) {
+  postprocess(html: P) {
     return html;
   }
 
@@ -50,6 +50,6 @@ export class _Hooks {
    * Provide function to parse tokens
    */
   provideParser() {
-    return this.block ? _Parser.parse : _Parser.parseInline;
+    return this.block ? _Parser.parse<P, R> : _Parser.parseInline<P, R>;
   }
 }

--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -7,24 +7,24 @@ import type { MarkedOptions } from './MarkedOptions.ts';
 /**
  * Block Lexer
  */
-export class _Lexer<P = string, R = string> {
+export class _Lexer<ParserOutput = string, RendererOutput = string> {
   tokens: TokensList;
-  options: MarkedOptions<P, R>;
+  options: MarkedOptions<ParserOutput, RendererOutput>;
   state: {
     inLink: boolean;
     inRawBlock: boolean;
     top: boolean;
   };
 
-  private tokenizer: _Tokenizer<P, R>;
+  private tokenizer: _Tokenizer<ParserOutput, RendererOutput>;
   private inlineQueue: { src: string, tokens: Token[] }[];
 
-  constructor(options?: MarkedOptions<P, R>) {
+  constructor(options?: MarkedOptions<ParserOutput, RendererOutput>) {
     // TokenList cannot be created in one go
     this.tokens = [] as unknown as TokensList;
     this.tokens.links = Object.create(null);
     this.options = options || _defaults;
-    this.options.tokenizer = this.options.tokenizer || new _Tokenizer<P, R>();
+    this.options.tokenizer = this.options.tokenizer || new _Tokenizer<ParserOutput, RendererOutput>();
     this.tokenizer = this.options.tokenizer;
     this.tokenizer.options = this.options;
     this.tokenizer.lexer = this;
@@ -68,16 +68,16 @@ export class _Lexer<P = string, R = string> {
   /**
    * Static Lex Method
    */
-  static lex<P = string, R = string>(src: string, options?: MarkedOptions<P, R>) {
-    const lexer = new _Lexer<P, R>(options);
+  static lex<ParserOutput = string, RendererOutput = string>(src: string, options?: MarkedOptions<ParserOutput, RendererOutput>) {
+    const lexer = new _Lexer<ParserOutput, RendererOutput>(options);
     return lexer.lex(src);
   }
 
   /**
    * Static Lex Inline Method
    */
-  static lexInline<P = string, R = string>(src: string, options?: MarkedOptions<P, R>) {
-    const lexer = new _Lexer<P, R>(options);
+  static lexInline<ParserOutput = string, RendererOutput = string>(src: string, options?: MarkedOptions<ParserOutput, RendererOutput>) {
+    const lexer = new _Lexer<ParserOutput, RendererOutput>(options);
     return lexer.inlineTokens(src);
   }
 

--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -7,24 +7,24 @@ import type { MarkedOptions } from './MarkedOptions.ts';
 /**
  * Block Lexer
  */
-export class _Lexer {
+export class _Lexer<P = string, R = string> {
   tokens: TokensList;
-  options: MarkedOptions;
+  options: MarkedOptions<P, R>;
   state: {
     inLink: boolean;
     inRawBlock: boolean;
     top: boolean;
   };
 
-  private tokenizer: _Tokenizer;
+  private tokenizer: _Tokenizer<P, R>;
   private inlineQueue: { src: string, tokens: Token[] }[];
 
-  constructor(options?: MarkedOptions) {
+  constructor(options?: MarkedOptions<P, R>) {
     // TokenList cannot be created in one go
     this.tokens = [] as unknown as TokensList;
     this.tokens.links = Object.create(null);
     this.options = options || _defaults;
-    this.options.tokenizer = this.options.tokenizer || new _Tokenizer();
+    this.options.tokenizer = this.options.tokenizer || new _Tokenizer<P, R>();
     this.tokenizer = this.options.tokenizer;
     this.tokenizer.options = this.options;
     this.tokenizer.lexer = this;
@@ -68,16 +68,16 @@ export class _Lexer {
   /**
    * Static Lex Method
    */
-  static lex(src: string, options?: MarkedOptions) {
-    const lexer = new _Lexer(options);
+  static lex<P = string, R = string>(src: string, options?: MarkedOptions<P, R>) {
+    const lexer = new _Lexer<P, R>(options);
     return lexer.lex(src);
   }
 
   /**
    * Static Lex Inline Method
    */
-  static lexInline(src: string, options?: MarkedOptions) {
-    const lexer = new _Lexer(options);
+  static lexInline<P = string, R = string>(src: string, options?: MarkedOptions<P, R>) {
+    const lexer = new _Lexer<P, R>(options);
     return lexer.inlineTokens(src);
   }
 

--- a/src/MarkedOptions.ts
+++ b/src/MarkedOptions.ts
@@ -21,35 +21,35 @@ export interface TokenizerExtension {
   childTokens?: string[];
 }
 
-export interface RendererThis<P = string, R = string> {
-  parser: _Parser<P, R>;
+export interface RendererThis<ParserOutput = string, RendererOutput = string> {
+  parser: _Parser<ParserOutput, RendererOutput>;
 }
 
-export type RendererExtensionFunction<P = string, R = string> = (this: RendererThis<P, R>, token: Tokens.Generic) => R | false | undefined;
+export type RendererExtensionFunction<ParserOutput = string, RendererOutput = string> = (this: RendererThis<ParserOutput, RendererOutput>, token: Tokens.Generic) => RendererOutput | false | undefined;
 
-export interface RendererExtension<P = string, R = string> {
+export interface RendererExtension<ParserOutput = string, RendererOutput = string> {
   name: string;
-  renderer: RendererExtensionFunction<P, R>;
+  renderer: RendererExtensionFunction<ParserOutput, RendererOutput>;
 }
 
-export type TokenizerAndRendererExtension<P = string, R = string> = TokenizerExtension | RendererExtension<P, R> | (TokenizerExtension & RendererExtension<P, R>);
+export type TokenizerAndRendererExtension<ParserOutput = string, RendererOutput = string> = TokenizerExtension | RendererExtension<ParserOutput, RendererOutput> | (TokenizerExtension & RendererExtension<ParserOutput, RendererOutput>);
 
-type HooksApi<P = string, R = string> = Omit<_Hooks<P, R>, 'constructor' | 'options' | 'block'>;
-type HooksObject<P = string, R = string> = {
-  [K in keyof HooksApi<P, R>]?: (this: _Hooks<P, R>, ...args: Parameters<HooksApi<P, R>[K]>) => ReturnType<HooksApi<P, R>[K]> | Promise<ReturnType<HooksApi<P, R>[K]>>
+type HooksApi<ParserOutput = string, RendererOutput = string> = Omit<_Hooks<ParserOutput, RendererOutput>, 'constructor' | 'options' | 'block'>;
+type HooksObject<ParserOutput = string, RendererOutput = string> = {
+  [K in keyof HooksApi<ParserOutput, RendererOutput>]?: (this: _Hooks<ParserOutput, RendererOutput>, ...args: Parameters<HooksApi<ParserOutput, RendererOutput>[K]>) => ReturnType<HooksApi<ParserOutput, RendererOutput>[K]> | Promise<ReturnType<HooksApi<ParserOutput, RendererOutput>[K]>>
 };
 
-type RendererApi<P = string, R = string> = Omit<_Renderer<P, R>, 'constructor' | 'options' | 'parser'>;
-type RendererObject<P = string, R = string> = {
-  [K in keyof RendererApi<P, R>]?: (this: _Renderer<P, R>, ...args: Parameters<RendererApi<P, R>[K]>) => ReturnType<RendererApi<P, R>[K]> | false
+type RendererApi<ParserOutput = string, RendererOutput = string> = Omit<_Renderer<ParserOutput, RendererOutput>, 'constructor' | 'options' | 'parser'>;
+type RendererObject<ParserOutput = string, RendererOutput = string> = {
+  [K in keyof RendererApi<ParserOutput, RendererOutput>]?: (this: _Renderer<ParserOutput, RendererOutput>, ...args: Parameters<RendererApi<ParserOutput, RendererOutput>[K]>) => ReturnType<RendererApi<ParserOutput, RendererOutput>[K]> | false
 };
 
-type TokenizerApi<P = string, R = string> = Omit<_Tokenizer<P, R>, 'constructor' | 'options' | 'rules' | 'lexer'>;
-type TokenizerObject<P = string, R = string> = {
-  [K in keyof TokenizerApi<P, R>]?: (this: _Tokenizer<P, R>, ...args: Parameters<TokenizerApi<P, R>[K]>) => ReturnType<TokenizerApi<P, R>[K]> | false
+type TokenizerApi<ParserOutput = string, RendererOutput = string> = Omit<_Tokenizer<ParserOutput, RendererOutput>, 'constructor' | 'options' | 'rules' | 'lexer'>;
+type TokenizerObject<ParserOutput = string, RendererOutput = string> = {
+  [K in keyof TokenizerApi<ParserOutput, RendererOutput>]?: (this: _Tokenizer<ParserOutput, RendererOutput>, ...args: Parameters<TokenizerApi<ParserOutput, RendererOutput>[K]>) => ReturnType<TokenizerApi<ParserOutput, RendererOutput>[K]> | false
 };
 
-export interface MarkedExtension<P = string, R = string> {
+export interface MarkedExtension<ParserOutput = string, RendererOutput = string> {
   /**
    * True will tell marked to await any walkTokens functions before parsing the tokens and returning an HTML string.
    */
@@ -64,7 +64,7 @@ export interface MarkedExtension<P = string, R = string> {
    * Add tokenizers and renderers to marked
    */
   extensions?:
-    | TokenizerAndRendererExtension<P, R>[]
+    | TokenizerAndRendererExtension<ParserOutput, RendererOutput>[]
     | null;
 
   /**
@@ -80,7 +80,7 @@ export interface MarkedExtension<P = string, R = string> {
    * provideLexer is called to provide a function to tokenize markdown.
    * provideParser is called to provide a function to parse tokens.
    */
-  hooks?: HooksObject<P, R> | null;
+  hooks?: HooksObject<ParserOutput, RendererOutput> | null;
 
   /**
    * Conform to obscure parts of markdown.pl as much as possible. Don't fix any of the original markdown bugs or poor behavior.
@@ -92,7 +92,7 @@ export interface MarkedExtension<P = string, R = string> {
    *
    * An object containing functions to render tokens to HTML.
    */
-  renderer?: RendererObject<P, R> | null;
+  renderer?: RendererObject<ParserOutput, RendererOutput> | null;
 
   /**
    * Shows an HTML error message when rendering fails.
@@ -113,30 +113,30 @@ export interface MarkedExtension<P = string, R = string> {
   walkTokens?: ((token: Token) => void | Promise<void>) | null;
 }
 
-export interface MarkedOptions<P = string, R = string> extends Omit<MarkedExtension<P, R>, 'hooks' | 'renderer' | 'tokenizer' | 'extensions' | 'walkTokens'> {
+export interface MarkedOptions<ParserOutput = string, RendererOutput = string> extends Omit<MarkedExtension<ParserOutput, RendererOutput>, 'hooks' | 'renderer' | 'tokenizer' | 'extensions' | 'walkTokens'> {
   /**
    * Hooks are methods that hook into some part of marked.
    */
-  hooks?: _Hooks<P, R> | null;
+  hooks?: _Hooks<ParserOutput, RendererOutput> | null;
 
   /**
    * Type: object Default: new Renderer()
    *
    * An object containing functions to render tokens to HTML.
    */
-  renderer?: _Renderer<P, R> | null;
+  renderer?: _Renderer<ParserOutput, RendererOutput> | null;
 
   /**
    * The tokenizer defines how to turn markdown text into tokens.
    */
-  tokenizer?: _Tokenizer<P, R> | null;
+  tokenizer?: _Tokenizer<ParserOutput, RendererOutput> | null;
 
   /**
    * Custom extensions
    */
   extensions?: null | {
     renderers: {
-      [name: string]: RendererExtensionFunction<P, R>;
+      [name: string]: RendererExtensionFunction<ParserOutput, RendererOutput>;
     };
     childTokens: {
       [name: string]: string[];

--- a/src/MarkedOptions.ts
+++ b/src/MarkedOptions.ts
@@ -21,35 +21,35 @@ export interface TokenizerExtension {
   childTokens?: string[];
 }
 
-export interface RendererThis {
-  parser: _Parser;
+export interface RendererThis<P = string, R = string> {
+  parser: _Parser<P, R>;
 }
 
-export type RendererExtensionFunction = (this: RendererThis, token: Tokens.Generic) => string | false | undefined;
+export type RendererExtensionFunction<P = string, R = string> = (this: RendererThis<P, R>, token: Tokens.Generic) => R | false | undefined;
 
-export interface RendererExtension {
+export interface RendererExtension<P = string, R = string> {
   name: string;
-  renderer: RendererExtensionFunction;
+  renderer: RendererExtensionFunction<P, R>;
 }
 
-export type TokenizerAndRendererExtension = TokenizerExtension | RendererExtension | (TokenizerExtension & RendererExtension);
+export type TokenizerAndRendererExtension<P = string, R = string> = TokenizerExtension | RendererExtension<P, R> | (TokenizerExtension & RendererExtension<P, R>);
 
-type HooksApi = Omit<_Hooks, 'constructor' | 'options' | 'block'>;
-type HooksObject = {
-  [K in keyof HooksApi]?: (this: _Hooks, ...args: Parameters<HooksApi[K]>) => ReturnType<HooksApi[K]> | Promise<ReturnType<HooksApi[K]>>
+type HooksApi<P = string, R = string> = Omit<_Hooks<P, R>, 'constructor' | 'options' | 'block'>;
+type HooksObject<P = string, R = string> = {
+  [K in keyof HooksApi<P, R>]?: (this: _Hooks<P, R>, ...args: Parameters<HooksApi<P, R>[K]>) => ReturnType<HooksApi<P, R>[K]> | Promise<ReturnType<HooksApi<P, R>[K]>>
 };
 
-type RendererApi = Omit<_Renderer, 'constructor' | 'options' | 'parser'>;
-type RendererObject = {
-  [K in keyof RendererApi]?: (this: _Renderer, ...args: Parameters<RendererApi[K]>) => ReturnType<RendererApi[K]> | false
+type RendererApi<P = string, R = string> = Omit<_Renderer<P, R>, 'constructor' | 'options' | 'parser'>;
+type RendererObject<P = string, R = string> = {
+  [K in keyof RendererApi<P, R>]?: (this: _Renderer<P, R>, ...args: Parameters<RendererApi<P, R>[K]>) => ReturnType<RendererApi<P, R>[K]> | false
 };
 
-type TokenizerApi = Omit<_Tokenizer, 'constructor' | 'options' | 'rules' | 'lexer'>;
-type TokenizerObject = {
-  [K in keyof TokenizerApi]?: (this: _Tokenizer, ...args: Parameters<TokenizerApi[K]>) => ReturnType<TokenizerApi[K]> | false
+type TokenizerApi<P = string, R = string> = Omit<_Tokenizer<P, R>, 'constructor' | 'options' | 'rules' | 'lexer'>;
+type TokenizerObject<P = string, R = string> = {
+  [K in keyof TokenizerApi<P, R>]?: (this: _Tokenizer<P, R>, ...args: Parameters<TokenizerApi<P, R>[K]>) => ReturnType<TokenizerApi<P, R>[K]> | false
 };
 
-export interface MarkedExtension {
+export interface MarkedExtension<P = string, R = string> {
   /**
    * True will tell marked to await any walkTokens functions before parsing the tokens and returning an HTML string.
    */
@@ -64,7 +64,7 @@ export interface MarkedExtension {
    * Add tokenizers and renderers to marked
    */
   extensions?:
-    | TokenizerAndRendererExtension[]
+    | TokenizerAndRendererExtension<P, R>[]
     | null;
 
   /**
@@ -80,7 +80,7 @@ export interface MarkedExtension {
    * provideLexer is called to provide a function to tokenize markdown.
    * provideParser is called to provide a function to parse tokens.
    */
-  hooks?: HooksObject | null;
+  hooks?: HooksObject<P, R> | null;
 
   /**
    * Conform to obscure parts of markdown.pl as much as possible. Don't fix any of the original markdown bugs or poor behavior.
@@ -92,7 +92,7 @@ export interface MarkedExtension {
    *
    * An object containing functions to render tokens to HTML.
    */
-  renderer?: RendererObject | null;
+  renderer?: RendererObject<P, R> | null;
 
   /**
    * Shows an HTML error message when rendering fails.
@@ -113,30 +113,30 @@ export interface MarkedExtension {
   walkTokens?: ((token: Token) => void | Promise<void>) | null;
 }
 
-export interface MarkedOptions extends Omit<MarkedExtension, 'hooks' | 'renderer' | 'tokenizer' | 'extensions' | 'walkTokens'> {
+export interface MarkedOptions<P = string, R = string> extends Omit<MarkedExtension<P, R>, 'hooks' | 'renderer' | 'tokenizer' | 'extensions' | 'walkTokens'> {
   /**
    * Hooks are methods that hook into some part of marked.
    */
-  hooks?: _Hooks | null;
+  hooks?: _Hooks<P, R> | null;
 
   /**
    * Type: object Default: new Renderer()
    *
    * An object containing functions to render tokens to HTML.
    */
-  renderer?: _Renderer | null;
+  renderer?: _Renderer<P, R> | null;
 
   /**
    * The tokenizer defines how to turn markdown text into tokens.
    */
-  tokenizer?: _Tokenizer | null;
+  tokenizer?: _Tokenizer<P, R> | null;
 
   /**
    * Custom extensions
    */
   extensions?: null | {
     renderers: {
-      [name: string]: RendererExtensionFunction;
+      [name: string]: RendererExtensionFunction<P, R>;
     };
     childTokens: {
       [name: string]: string[];

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -7,39 +7,39 @@ import type { MarkedOptions } from './MarkedOptions.ts';
 /**
  * Parsing & Compiling
  */
-export class _Parser<P = string, R = string> {
-  options: MarkedOptions<P, R>;
-  renderer: _Renderer<P, R>;
-  textRenderer: _TextRenderer<R>;
-  constructor(options?: MarkedOptions<P, R>) {
+export class _Parser<ParserOutput = string, RendererOutput = string> {
+  options: MarkedOptions<ParserOutput, RendererOutput>;
+  renderer: _Renderer<ParserOutput, RendererOutput>;
+  textRenderer: _TextRenderer<RendererOutput>;
+  constructor(options?: MarkedOptions<ParserOutput, RendererOutput>) {
     this.options = options || _defaults;
-    this.options.renderer = this.options.renderer || new _Renderer<P, R>();
+    this.options.renderer = this.options.renderer || new _Renderer<ParserOutput, RendererOutput>();
     this.renderer = this.options.renderer;
     this.renderer.options = this.options;
     this.renderer.parser = this;
-    this.textRenderer = new _TextRenderer<R>();
+    this.textRenderer = new _TextRenderer<RendererOutput>();
   }
 
   /**
    * Static Parse Method
    */
-  static parse<P = string, R = string>(tokens: Token[], options?: MarkedOptions<P, R>) {
-    const parser = new _Parser<P, R>(options);
+  static parse<ParserOutput = string, RendererOutput = string>(tokens: Token[], options?: MarkedOptions<ParserOutput, RendererOutput>) {
+    const parser = new _Parser<ParserOutput, RendererOutput>(options);
     return parser.parse(tokens);
   }
 
   /**
    * Static Parse Inline Method
    */
-  static parseInline<P = string, R = string>(tokens: Token[], options?: MarkedOptions<P, R>) {
-    const parser = new _Parser<P, R>(options);
+  static parseInline<ParserOutput = string, RendererOutput = string>(tokens: Token[], options?: MarkedOptions<ParserOutput, RendererOutput>) {
+    const parser = new _Parser<ParserOutput, RendererOutput>(options);
     return parser.parseInline(tokens);
   }
 
   /**
    * Parse Loop
    */
-  parse(tokens: Token[], top = true): P {
+  parse(tokens: Token[], top = true): ParserOutput {
     let out = '';
 
     for (let i = 0; i < tokens.length; i++) {
@@ -118,7 +118,7 @@ export class _Parser<P = string, R = string> {
           const errMsg = 'Token with "' + token.type + '" type was not found.';
           if (this.options.silent) {
             console.error(errMsg);
-            return '' as P;
+            return '' as ParserOutput;
           } else {
             throw new Error(errMsg);
           }
@@ -126,13 +126,13 @@ export class _Parser<P = string, R = string> {
       }
     }
 
-    return out as P;
+    return out as ParserOutput;
   }
 
   /**
    * Parse Inline Tokens
    */
-  parseInline(tokens: Token[], renderer: _Renderer<P, R> | _TextRenderer<R> = this.renderer): P {
+  parseInline(tokens: Token[], renderer: _Renderer<ParserOutput, RendererOutput> | _TextRenderer<RendererOutput> = this.renderer): ParserOutput {
     let out = '';
 
     for (let i = 0; i < tokens.length; i++) {
@@ -194,13 +194,13 @@ export class _Parser<P = string, R = string> {
           const errMsg = 'Token with "' + token.type + '" type was not found.';
           if (this.options.silent) {
             console.error(errMsg);
-            return '' as P;
+            return '' as ParserOutput;
           } else {
             throw new Error(errMsg);
           }
         }
       }
     }
-    return out as P;
+    return out as ParserOutput;
   }
 }

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -7,11 +7,11 @@ import type { MarkedOptions } from './MarkedOptions.ts';
 /**
  * Parsing & Compiling
  */
-export class _Parser {
-  options: MarkedOptions;
-  renderer: _Renderer;
-  textRenderer: _TextRenderer;
-  constructor(options?: MarkedOptions) {
+export class _Parser<P = string, R = string> {
+  options: MarkedOptions<P, R>;
+  renderer: _Renderer<P, R>;
+  textRenderer: _TextRenderer<R>;
+  constructor(options?: MarkedOptions<P, R>) {
     this.options = options || _defaults;
     this.options.renderer = this.options.renderer || new _Renderer();
     this.renderer = this.options.renderer;
@@ -23,23 +23,23 @@ export class _Parser {
   /**
    * Static Parse Method
    */
-  static parse(tokens: Token[], options?: MarkedOptions) {
-    const parser = new _Parser(options);
+  static parse<P = string, R = string>(tokens: Token[], options?: MarkedOptions<P, R>) {
+    const parser = new _Parser<P, R>(options);
     return parser.parse(tokens);
   }
 
   /**
    * Static Parse Inline Method
    */
-  static parseInline(tokens: Token[], options?: MarkedOptions) {
-    const parser = new _Parser(options);
+  static parseInline<P = string, R = string>(tokens: Token[], options?: MarkedOptions<P, R>) {
+    const parser = new _Parser<P, R>(options);
     return parser.parseInline(tokens);
   }
 
   /**
    * Parse Loop
    */
-  parse(tokens: Token[], top = true): string {
+  parse(tokens: Token[], top = true): P {
     let out = '';
 
     for (let i = 0; i < tokens.length; i++) {
@@ -96,10 +96,10 @@ export class _Parser {
         }
         case 'text': {
           let textToken = token;
-          let body = this.renderer.text(textToken);
+          let body = this.renderer.text(textToken) as string;
           while (i + 1 < tokens.length && tokens[i + 1].type === 'text') {
             textToken = tokens[++i] as Tokens.Text;
-            body += '\n' + this.renderer.text(textToken);
+            body += ('\n' + this.renderer.text(textToken));
           }
           if (top) {
             out += this.renderer.paragraph({
@@ -118,7 +118,7 @@ export class _Parser {
           const errMsg = 'Token with "' + token.type + '" type was not found.';
           if (this.options.silent) {
             console.error(errMsg);
-            return '';
+            return '' as P;
           } else {
             throw new Error(errMsg);
           }
@@ -126,13 +126,13 @@ export class _Parser {
       }
     }
 
-    return out;
+    return out as P;
   }
 
   /**
    * Parse Inline Tokens
    */
-  parseInline(tokens: Token[], renderer: _Renderer | _TextRenderer = this.renderer): string {
+  parseInline(tokens: Token[], renderer: _Renderer<P, R> | _TextRenderer<R> = this.renderer): P {
     let out = '';
 
     for (let i = 0; i < tokens.length; i++) {
@@ -194,13 +194,13 @@ export class _Parser {
           const errMsg = 'Token with "' + token.type + '" type was not found.';
           if (this.options.silent) {
             console.error(errMsg);
-            return '';
+            return '' as P;
           } else {
             throw new Error(errMsg);
           }
         }
       }
     }
-    return out;
+    return out as P;
   }
 }

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -13,11 +13,11 @@ export class _Parser<P = string, R = string> {
   textRenderer: _TextRenderer<R>;
   constructor(options?: MarkedOptions<P, R>) {
     this.options = options || _defaults;
-    this.options.renderer = this.options.renderer || new _Renderer();
+    this.options.renderer = this.options.renderer || new _Renderer<P, R>();
     this.renderer = this.options.renderer;
     this.renderer.options = this.options;
     this.renderer.parser = this;
-    this.textRenderer = new _TextRenderer();
+    this.textRenderer = new _TextRenderer<R>();
   }
 
   /**

--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -11,18 +11,18 @@ import type { _Parser } from './Parser.ts';
 /**
  * Renderer
  */
-export class _Renderer {
-  options: MarkedOptions;
-  parser!: _Parser; // set by the parser
-  constructor(options?: MarkedOptions) {
+export class _Renderer<P = string, R = string> {
+  options: MarkedOptions<P, R>;
+  parser!: _Parser<P, R>; // set by the parser
+  constructor(options?: MarkedOptions<P, R>) {
     this.options = options || _defaults;
   }
 
-  space(token: Tokens.Space): string {
-    return '';
+  space(token: Tokens.Space): R {
+    return '' as R;
   }
 
-  code({ text, lang, escaped }: Tokens.Code): string {
+  code({ text, lang, escaped }: Tokens.Code): R {
     const langString = (lang || '').match(other.notSpaceStart)?.[0];
 
     const code = text.replace(other.endingNewline, '') + '\n';
@@ -30,34 +30,34 @@ export class _Renderer {
     if (!langString) {
       return '<pre><code>'
         + (escaped ? code : escape(code, true))
-        + '</code></pre>\n';
+        + '</code></pre>\n' as R;
     }
 
     return '<pre><code class="language-'
       + escape(langString)
       + '">'
       + (escaped ? code : escape(code, true))
-      + '</code></pre>\n';
+      + '</code></pre>\n' as R;
   }
 
-  blockquote({ tokens }: Tokens.Blockquote): string {
+  blockquote({ tokens }: Tokens.Blockquote): R {
     const body = this.parser.parse(tokens);
-    return `<blockquote>\n${body}</blockquote>\n`;
+    return `<blockquote>\n${body}</blockquote>\n` as R;
   }
 
-  html({ text }: Tokens.HTML | Tokens.Tag) : string {
-    return text;
+  html({ text }: Tokens.HTML | Tokens.Tag): R {
+    return text as R;
   }
 
-  heading({ tokens, depth }: Tokens.Heading): string {
-    return `<h${depth}>${this.parser.parseInline(tokens)}</h${depth}>\n`;
+  heading({ tokens, depth }: Tokens.Heading): R {
+    return `<h${depth}>${this.parser.parseInline(tokens)}</h${depth}>\n` as R;
   }
 
-  hr(token: Tokens.Hr): string {
-    return '<hr>\n';
+  hr(token: Tokens.Hr): R {
+    return '<hr>\n' as R;
   }
 
-  list(token: Tokens.List): string {
+  list(token: Tokens.List): R {
     const ordered = token.ordered;
     const start = token.start;
 
@@ -69,10 +69,10 @@ export class _Renderer {
 
     const type = ordered ? 'ol' : 'ul';
     const startAttr = (ordered && start !== 1) ? (' start="' + start + '"') : '';
-    return '<' + type + startAttr + '>\n' + body + '</' + type + '>\n';
+    return '<' + type + startAttr + '>\n' + body + '</' + type + '>\n' as R;
   }
 
-  listitem(item: Tokens.ListItem): string {
+  listitem(item: Tokens.ListItem): R {
     let itemBody = '';
     if (item.task) {
       const checkbox = this.checkbox({ checked: !!item.checked });
@@ -98,20 +98,20 @@ export class _Renderer {
 
     itemBody += this.parser.parse(item.tokens, !!item.loose);
 
-    return `<li>${itemBody}</li>\n`;
+    return `<li>${itemBody}</li>\n` as R;
   }
 
-  checkbox({ checked }: Tokens.Checkbox): string {
+  checkbox({ checked }: Tokens.Checkbox): R {
     return '<input '
       + (checked ? 'checked="" ' : '')
-      + 'disabled="" type="checkbox">';
+      + 'disabled="" type="checkbox">' as R;
   }
 
-  paragraph({ tokens }: Tokens.Paragraph): string {
-    return `<p>${this.parser.parseInline(tokens)}</p>\n`;
+  paragraph({ tokens }: Tokens.Paragraph): R {
+    return `<p>${this.parser.parseInline(tokens)}</p>\n` as R;
   }
 
-  table(token: Tokens.Table): string {
+  table(token: Tokens.Table): R {
     let header = '';
 
     // header
@@ -139,50 +139,50 @@ export class _Renderer {
       + header
       + '</thead>\n'
       + body
-      + '</table>\n';
+      + '</table>\n' as R;
   }
 
-  tablerow({ text }: Tokens.TableRow): string {
-    return `<tr>\n${text}</tr>\n`;
+  tablerow({ text }: Tokens.TableRow): R {
+    return `<tr>\n${text}</tr>\n` as R;
   }
 
-  tablecell(token: Tokens.TableCell): string {
+  tablecell(token: Tokens.TableCell): R {
     const content = this.parser.parseInline(token.tokens);
     const type = token.header ? 'th' : 'td';
     const tag = token.align
       ? `<${type} align="${token.align}">`
       : `<${type}>`;
-    return tag + content + `</${type}>\n`;
+    return tag + content + `</${type}>\n` as R;
   }
 
   /**
    * span level renderer
    */
-  strong({ tokens }: Tokens.Strong): string {
-    return `<strong>${this.parser.parseInline(tokens)}</strong>`;
+  strong({ tokens }: Tokens.Strong): R {
+    return `<strong>${this.parser.parseInline(tokens)}</strong>` as R;
   }
 
-  em({ tokens }: Tokens.Em): string {
-    return `<em>${this.parser.parseInline(tokens)}</em>`;
+  em({ tokens }: Tokens.Em): R {
+    return `<em>${this.parser.parseInline(tokens)}</em>` as R;
   }
 
-  codespan({ text }: Tokens.Codespan): string {
-    return `<code>${escape(text, true)}</code>`;
+  codespan({ text }: Tokens.Codespan): R {
+    return `<code>${escape(text, true)}</code>` as R;
   }
 
-  br(token: Tokens.Br): string {
-    return '<br>';
+  br(token: Tokens.Br): R {
+    return '<br>' as R;
   }
 
-  del({ tokens }: Tokens.Del): string {
-    return `<del>${this.parser.parseInline(tokens)}</del>`;
+  del({ tokens }: Tokens.Del): R {
+    return `<del>${this.parser.parseInline(tokens)}</del>` as R;
   }
 
-  link({ href, title, tokens }: Tokens.Link): string {
-    const text = this.parser.parseInline(tokens);
+  link({ href, title, tokens }: Tokens.Link): R {
+    const text = this.parser.parseInline(tokens) as string;
     const cleanHref = cleanUrl(href);
     if (cleanHref === null) {
-      return text;
+      return text as R;
     }
     href = cleanHref;
     let out = '<a href="' + href + '"';
@@ -190,16 +190,16 @@ export class _Renderer {
       out += ' title="' + (escape(title)) + '"';
     }
     out += '>' + text + '</a>';
-    return out;
+    return out as R;
   }
 
-  image({ href, title, text, tokens }: Tokens.Image): string {
+  image({ href, title, text, tokens }: Tokens.Image): R {
     if (tokens) {
-      text = this.parser.parseInline(tokens, this.parser.textRenderer);
+      text = this.parser.parseInline(tokens, this.parser.textRenderer) as string;
     }
     const cleanHref = cleanUrl(href);
     if (cleanHref === null) {
-      return escape(text);
+      return escape(text) as R;
     }
     href = cleanHref;
 
@@ -208,12 +208,12 @@ export class _Renderer {
       out += ` title="${escape(title)}"`;
     }
     out += '>';
-    return out;
+    return out as R;
   }
 
-  text(token: Tokens.Text | Tokens.Escape) : string {
+  text(token: Tokens.Text | Tokens.Escape): R {
     return 'tokens' in token && token.tokens
-      ? this.parser.parseInline(token.tokens)
-      : ('escaped' in token && token.escaped ? token.text : escape(token.text));
+      ? this.parser.parseInline(token.tokens) as unknown as R
+      : ('escaped' in token && token.escaped ? token.text as R : escape(token.text) as R);
   }
 }

--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -119,7 +119,7 @@ export class _Renderer<P = string, R = string> {
     for (let j = 0; j < token.header.length; j++) {
       cell += this.tablecell(token.header[j]);
     }
-    header += this.tablerow({ text: cell });
+    header += this.tablerow({ text: cell as P });
 
     let body = '';
     for (let j = 0; j < token.rows.length; j++) {
@@ -130,7 +130,7 @@ export class _Renderer<P = string, R = string> {
         cell += this.tablecell(row[k]);
       }
 
-      body += this.tablerow({ text: cell });
+      body += this.tablerow({ text: cell as P });
     }
     if (body) body = `<tbody>${body}</tbody>`;
 
@@ -142,7 +142,7 @@ export class _Renderer<P = string, R = string> {
       + '</table>\n' as R;
   }
 
-  tablerow({ text }: Tokens.TableRow): R {
+  tablerow({ text }: Tokens.TableRow<P>): R {
     return `<tr>\n${text}</tr>\n` as R;
   }
 

--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -11,18 +11,18 @@ import type { _Parser } from './Parser.ts';
 /**
  * Renderer
  */
-export class _Renderer<P = string, R = string> {
-  options: MarkedOptions<P, R>;
-  parser!: _Parser<P, R>; // set by the parser
-  constructor(options?: MarkedOptions<P, R>) {
+export class _Renderer<ParserOutput = string, RendererOutput = string> {
+  options: MarkedOptions<ParserOutput, RendererOutput>;
+  parser!: _Parser<ParserOutput, RendererOutput>; // set by the parser
+  constructor(options?: MarkedOptions<ParserOutput, RendererOutput>) {
     this.options = options || _defaults;
   }
 
-  space(token: Tokens.Space): R {
-    return '' as R;
+  space(token: Tokens.Space): RendererOutput {
+    return '' as RendererOutput;
   }
 
-  code({ text, lang, escaped }: Tokens.Code): R {
+  code({ text, lang, escaped }: Tokens.Code): RendererOutput {
     const langString = (lang || '').match(other.notSpaceStart)?.[0];
 
     const code = text.replace(other.endingNewline, '') + '\n';
@@ -30,34 +30,34 @@ export class _Renderer<P = string, R = string> {
     if (!langString) {
       return '<pre><code>'
         + (escaped ? code : escape(code, true))
-        + '</code></pre>\n' as R;
+        + '</code></pre>\n' as RendererOutput;
     }
 
     return '<pre><code class="language-'
       + escape(langString)
       + '">'
       + (escaped ? code : escape(code, true))
-      + '</code></pre>\n' as R;
+      + '</code></pre>\n' as RendererOutput;
   }
 
-  blockquote({ tokens }: Tokens.Blockquote): R {
+  blockquote({ tokens }: Tokens.Blockquote): RendererOutput {
     const body = this.parser.parse(tokens);
-    return `<blockquote>\n${body}</blockquote>\n` as R;
+    return `<blockquote>\n${body}</blockquote>\n` as RendererOutput;
   }
 
-  html({ text }: Tokens.HTML | Tokens.Tag): R {
-    return text as R;
+  html({ text }: Tokens.HTML | Tokens.Tag): RendererOutput {
+    return text as RendererOutput;
   }
 
-  heading({ tokens, depth }: Tokens.Heading): R {
-    return `<h${depth}>${this.parser.parseInline(tokens)}</h${depth}>\n` as R;
+  heading({ tokens, depth }: Tokens.Heading): RendererOutput {
+    return `<h${depth}>${this.parser.parseInline(tokens)}</h${depth}>\n` as RendererOutput;
   }
 
-  hr(token: Tokens.Hr): R {
-    return '<hr>\n' as R;
+  hr(token: Tokens.Hr): RendererOutput {
+    return '<hr>\n' as RendererOutput;
   }
 
-  list(token: Tokens.List): R {
+  list(token: Tokens.List): RendererOutput {
     const ordered = token.ordered;
     const start = token.start;
 
@@ -69,10 +69,10 @@ export class _Renderer<P = string, R = string> {
 
     const type = ordered ? 'ol' : 'ul';
     const startAttr = (ordered && start !== 1) ? (' start="' + start + '"') : '';
-    return '<' + type + startAttr + '>\n' + body + '</' + type + '>\n' as R;
+    return '<' + type + startAttr + '>\n' + body + '</' + type + '>\n' as RendererOutput;
   }
 
-  listitem(item: Tokens.ListItem): R {
+  listitem(item: Tokens.ListItem): RendererOutput {
     let itemBody = '';
     if (item.task) {
       const checkbox = this.checkbox({ checked: !!item.checked });
@@ -98,20 +98,20 @@ export class _Renderer<P = string, R = string> {
 
     itemBody += this.parser.parse(item.tokens, !!item.loose);
 
-    return `<li>${itemBody}</li>\n` as R;
+    return `<li>${itemBody}</li>\n` as RendererOutput;
   }
 
-  checkbox({ checked }: Tokens.Checkbox): R {
+  checkbox({ checked }: Tokens.Checkbox): RendererOutput {
     return '<input '
       + (checked ? 'checked="" ' : '')
-      + 'disabled="" type="checkbox">' as R;
+      + 'disabled="" type="checkbox">' as RendererOutput;
   }
 
-  paragraph({ tokens }: Tokens.Paragraph): R {
-    return `<p>${this.parser.parseInline(tokens)}</p>\n` as R;
+  paragraph({ tokens }: Tokens.Paragraph): RendererOutput {
+    return `<p>${this.parser.parseInline(tokens)}</p>\n` as RendererOutput;
   }
 
-  table(token: Tokens.Table): R {
+  table(token: Tokens.Table): RendererOutput {
     let header = '';
 
     // header
@@ -119,7 +119,7 @@ export class _Renderer<P = string, R = string> {
     for (let j = 0; j < token.header.length; j++) {
       cell += this.tablecell(token.header[j]);
     }
-    header += this.tablerow({ text: cell as P });
+    header += this.tablerow({ text: cell as ParserOutput });
 
     let body = '';
     for (let j = 0; j < token.rows.length; j++) {
@@ -130,7 +130,7 @@ export class _Renderer<P = string, R = string> {
         cell += this.tablecell(row[k]);
       }
 
-      body += this.tablerow({ text: cell as P });
+      body += this.tablerow({ text: cell as ParserOutput });
     }
     if (body) body = `<tbody>${body}</tbody>`;
 
@@ -139,50 +139,50 @@ export class _Renderer<P = string, R = string> {
       + header
       + '</thead>\n'
       + body
-      + '</table>\n' as R;
+      + '</table>\n' as RendererOutput;
   }
 
-  tablerow({ text }: Tokens.TableRow<P>): R {
-    return `<tr>\n${text}</tr>\n` as R;
+  tablerow({ text }: Tokens.TableRow<ParserOutput>): RendererOutput {
+    return `<tr>\n${text}</tr>\n` as RendererOutput;
   }
 
-  tablecell(token: Tokens.TableCell): R {
+  tablecell(token: Tokens.TableCell): RendererOutput {
     const content = this.parser.parseInline(token.tokens);
     const type = token.header ? 'th' : 'td';
     const tag = token.align
       ? `<${type} align="${token.align}">`
       : `<${type}>`;
-    return tag + content + `</${type}>\n` as R;
+    return tag + content + `</${type}>\n` as RendererOutput;
   }
 
   /**
    * span level renderer
    */
-  strong({ tokens }: Tokens.Strong): R {
-    return `<strong>${this.parser.parseInline(tokens)}</strong>` as R;
+  strong({ tokens }: Tokens.Strong): RendererOutput {
+    return `<strong>${this.parser.parseInline(tokens)}</strong>` as RendererOutput;
   }
 
-  em({ tokens }: Tokens.Em): R {
-    return `<em>${this.parser.parseInline(tokens)}</em>` as R;
+  em({ tokens }: Tokens.Em): RendererOutput {
+    return `<em>${this.parser.parseInline(tokens)}</em>` as RendererOutput;
   }
 
-  codespan({ text }: Tokens.Codespan): R {
-    return `<code>${escape(text, true)}</code>` as R;
+  codespan({ text }: Tokens.Codespan): RendererOutput {
+    return `<code>${escape(text, true)}</code>` as RendererOutput;
   }
 
-  br(token: Tokens.Br): R {
-    return '<br>' as R;
+  br(token: Tokens.Br): RendererOutput {
+    return '<br>' as RendererOutput;
   }
 
-  del({ tokens }: Tokens.Del): R {
-    return `<del>${this.parser.parseInline(tokens)}</del>` as R;
+  del({ tokens }: Tokens.Del): RendererOutput {
+    return `<del>${this.parser.parseInline(tokens)}</del>` as RendererOutput;
   }
 
-  link({ href, title, tokens }: Tokens.Link): R {
+  link({ href, title, tokens }: Tokens.Link): RendererOutput {
     const text = this.parser.parseInline(tokens) as string;
     const cleanHref = cleanUrl(href);
     if (cleanHref === null) {
-      return text as R;
+      return text as RendererOutput;
     }
     href = cleanHref;
     let out = '<a href="' + href + '"';
@@ -190,16 +190,16 @@ export class _Renderer<P = string, R = string> {
       out += ' title="' + (escape(title)) + '"';
     }
     out += '>' + text + '</a>';
-    return out as R;
+    return out as RendererOutput;
   }
 
-  image({ href, title, text, tokens }: Tokens.Image): R {
+  image({ href, title, text, tokens }: Tokens.Image): RendererOutput {
     if (tokens) {
       text = this.parser.parseInline(tokens, this.parser.textRenderer) as string;
     }
     const cleanHref = cleanUrl(href);
     if (cleanHref === null) {
-      return escape(text) as R;
+      return escape(text) as RendererOutput;
     }
     href = cleanHref;
 
@@ -208,12 +208,12 @@ export class _Renderer<P = string, R = string> {
       out += ` title="${escape(title)}"`;
     }
     out += '>';
-    return out as R;
+    return out as RendererOutput;
   }
 
-  text(token: Tokens.Text | Tokens.Escape): R {
+  text(token: Tokens.Text | Tokens.Escape): RendererOutput {
     return 'tokens' in token && token.tokens
-      ? this.parser.parseInline(token.tokens) as unknown as R
-      : ('escaped' in token && token.escaped ? token.text as R : escape(token.text) as R);
+      ? this.parser.parseInline(token.tokens) as unknown as RendererOutput
+      : ('escaped' in token && token.escaped ? token.text as RendererOutput : escape(token.text) as RendererOutput);
   }
 }

--- a/src/TextRenderer.ts
+++ b/src/TextRenderer.ts
@@ -4,41 +4,41 @@ import type { Tokens } from './Tokens.ts';
  * TextRenderer
  * returns only the textual part of the token
  */
-export class _TextRenderer<R = string> {
+export class _TextRenderer<RendererOutput = string> {
   // no need for block level renderers
-  strong({ text }: Tokens.Strong): R {
-    return text as R;
+  strong({ text }: Tokens.Strong): RendererOutput {
+    return text as RendererOutput;
   }
 
-  em({ text }: Tokens.Em): R {
-    return text as R;
+  em({ text }: Tokens.Em): RendererOutput {
+    return text as RendererOutput;
   }
 
-  codespan({ text }: Tokens.Codespan): R {
-    return text as R;
+  codespan({ text }: Tokens.Codespan): RendererOutput {
+    return text as RendererOutput;
   }
 
-  del({ text }: Tokens.Del): R {
-    return text as R;
+  del({ text }: Tokens.Del): RendererOutput {
+    return text as RendererOutput;
   }
 
-  html({ text }: Tokens.HTML | Tokens.Tag): R {
-    return text as R;
+  html({ text }: Tokens.HTML | Tokens.Tag): RendererOutput {
+    return text as RendererOutput;
   }
 
-  text({ text }: Tokens.Text | Tokens.Escape | Tokens.Tag): R {
-    return text as R;
+  text({ text }: Tokens.Text | Tokens.Escape | Tokens.Tag): RendererOutput {
+    return text as RendererOutput;
   }
 
-  link({ text }: Tokens.Link): R {
-    return '' + text as R;
+  link({ text }: Tokens.Link): RendererOutput {
+    return '' + text as RendererOutput;
   }
 
-  image({ text }: Tokens.Image): R {
-    return '' + text as R;
+  image({ text }: Tokens.Image): RendererOutput {
+    return '' + text as RendererOutput;
   }
 
-  br(): R {
-    return '' as R;
+  br(): RendererOutput {
+    return '' as RendererOutput;
   }
 }

--- a/src/TextRenderer.ts
+++ b/src/TextRenderer.ts
@@ -4,41 +4,41 @@ import type { Tokens } from './Tokens.ts';
  * TextRenderer
  * returns only the textual part of the token
  */
-export class _TextRenderer {
+export class _TextRenderer<R = string> {
   // no need for block level renderers
-  strong({ text }: Tokens.Strong) {
-    return text;
+  strong({ text }: Tokens.Strong): R {
+    return text as R;
   }
 
-  em({ text }: Tokens.Em) {
-    return text;
+  em({ text }: Tokens.Em): R {
+    return text as R;
   }
 
-  codespan({ text }: Tokens.Codespan) {
-    return text;
+  codespan({ text }: Tokens.Codespan): R {
+    return text as R;
   }
 
-  del({ text }: Tokens.Del) {
-    return text;
+  del({ text }: Tokens.Del): R {
+    return text as R;
   }
 
-  html({ text }: Tokens.HTML | Tokens.Tag) {
-    return text;
+  html({ text }: Tokens.HTML | Tokens.Tag): R {
+    return text as R;
   }
 
-  text({ text }: Tokens.Text | Tokens.Escape | Tokens.Tag) {
-    return text;
+  text({ text }: Tokens.Text | Tokens.Escape | Tokens.Tag): R {
+    return text as R;
   }
 
-  link({ text }: Tokens.Link) {
-    return '' + text;
+  link({ text }: Tokens.Link): R {
+    return '' + text as R;
   }
 
-  image({ text }: Tokens.Image) {
-    return '' + text;
+  image({ text }: Tokens.Image): R {
+    return '' + text as R;
   }
 
-  br() {
-    return '';
+  br(): R {
+    return '' as R;
   }
 }

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -58,12 +58,12 @@ function indentCodeCompensation(raw: string, text: string, rules: Rules) {
 /**
  * Tokenizer
  */
-export class _Tokenizer<P = string, R = string> {
-  options: MarkedOptions<P, R>;
+export class _Tokenizer<ParserOutput = string, RendererOutput = string> {
+  options: MarkedOptions<ParserOutput, RendererOutput>;
   rules!: Rules; // set by the lexer
-  lexer!: _Lexer<P, R>; // set by the lexer
+  lexer!: _Lexer<ParserOutput, RendererOutput>; // set by the lexer
 
-  constructor(options?: MarkedOptions<P, R>) {
+  constructor(options?: MarkedOptions<ParserOutput, RendererOutput>) {
     this.options = options || _defaults;
   }
 

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -58,12 +58,12 @@ function indentCodeCompensation(raw: string, text: string, rules: Rules) {
 /**
  * Tokenizer
  */
-export class _Tokenizer {
-  options: MarkedOptions;
+export class _Tokenizer<P = string, R = string> {
+  options: MarkedOptions<P, R>;
   rules!: Rules; // set by the lexer
-  lexer!: _Lexer; // set by the lexer
+  lexer!: _Lexer<P, R>; // set by the lexer
 
-  constructor(options?: MarkedOptions) {
+  constructor(options?: MarkedOptions<P, R>) {
     this.options = options || _defaults;
   }
 

--- a/src/Tokens.ts
+++ b/src/Tokens.ts
@@ -189,8 +189,8 @@ export namespace Tokens {
     align: 'center' | 'left' | 'right' | null;
   }
 
-  export interface TableRow<R = string> {
-    text: R;
+  export interface TableRow<P = string> {
+    text: P;
   }
 
   export interface Tag {

--- a/src/Tokens.ts
+++ b/src/Tokens.ts
@@ -189,8 +189,8 @@ export namespace Tokens {
     align: 'center' | 'left' | 'right' | null;
   }
 
-  export interface TableRow {
-    text: string;
+  export interface TableRow<R = string> {
+    text: R;
   }
 
   export interface Tag {

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -3,7 +3,7 @@ import type { MarkedOptions } from './MarkedOptions.ts';
 /**
  * Gets the original marked default options.
  */
-export function _getDefaults(): MarkedOptions {
+export function _getDefaults<P = string, R = string>(): MarkedOptions<P, R> {
   return {
     async: false,
     breaks: false,
@@ -17,9 +17,9 @@ export function _getDefaults(): MarkedOptions {
     walkTokens: null,
   };
 }
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export let _defaults: MarkedOptions<any, any> = _getDefaults();
 
-export let _defaults = _getDefaults();
-
-export function changeDefaults(newDefaults: MarkedOptions) {
+export function changeDefaults<P = string, R = string>(newDefaults: MarkedOptions<P, R>) {
   _defaults = newDefaults;
 }

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -3,7 +3,7 @@ import type { MarkedOptions } from './MarkedOptions.ts';
 /**
  * Gets the original marked default options.
  */
-export function _getDefaults<P = string, R = string>(): MarkedOptions<P, R> {
+export function _getDefaults<ParserOutput = string, RendererOutput = string>(): MarkedOptions<ParserOutput, RendererOutput> {
   return {
     async: false,
     breaks: false,
@@ -20,6 +20,6 @@ export function _getDefaults<P = string, R = string>(): MarkedOptions<P, R> {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export let _defaults: MarkedOptions<any, any> = _getDefaults();
 
-export function changeDefaults<P = string, R = string>(newDefaults: MarkedOptions<P, R>) {
+export function changeDefaults<ParserOutput = string, RendererOutput = string>(newDefaults: MarkedOptions<ParserOutput, RendererOutput>) {
   _defaults = newDefaults;
 }


### PR DESCRIPTION
**Marked version:** 16.0.0

## Description

Add Generic types for parser and renderer output.


## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
