### PR TITLE
fix: fix multiline list item adds extra newline to raw

### DIFF
--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -244,7 +244,7 @@ export class _Lexer<ParserOutput = string, RendererOutput = string> {
       if (this.state.top && (token = this.tokenizer.paragraph(cutSrc))) {
         const lastToken = tokens.at(-1);
         if (lastParagraphClipped && lastToken?.type === 'paragraph') {
-          lastToken.raw += '\n' + token.raw;
+          lastToken.raw += (lastToken.raw.endsWith('\n') ? '' : '\n') + token.raw;
           lastToken.text += '\n' + token.text;
           this.inlineQueue.pop();
           this.inlineQueue.at(-1)!.src = lastToken.text;
@@ -261,7 +261,7 @@ export class _Lexer<ParserOutput = string, RendererOutput = string> {
         src = src.substring(token.raw.length);
         const lastToken = tokens.at(-1);
         if (lastToken?.type === 'text') {
-          lastToken.raw += '\n' + token.raw;
+          lastToken.raw += (lastToken.raw.endsWith('\n') ? '' : '\n') + token.raw;
           lastToken.text += '\n' + token.text;
           this.inlineQueue.pop();
           this.inlineQueue.at(-1)!.src = lastToken.text;

--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -142,7 +142,7 @@ export class _Lexer<ParserOutput = string, RendererOutput = string> {
         const lastToken = tokens.at(-1);
         // An indented code block cannot interrupt a paragraph.
         if (lastToken?.type === 'paragraph' || lastToken?.type === 'text') {
-          lastToken.raw += '\n' + token.raw;
+          lastToken.raw += (lastToken.raw.endsWith('\n') ? '' : '\n') + token.raw;
           lastToken.text += '\n' + token.text;
           this.inlineQueue.at(-1)!.src = lastToken.text;
         } else {
@@ -198,7 +198,7 @@ export class _Lexer<ParserOutput = string, RendererOutput = string> {
         src = src.substring(token.raw.length);
         const lastToken = tokens.at(-1);
         if (lastToken?.type === 'paragraph' || lastToken?.type === 'text') {
-          lastToken.raw += '\n' + token.raw;
+          lastToken.raw += (lastToken.raw.endsWith('\n') ? '' : '\n') + token.raw;
           lastToken.text += '\n' + token.raw;
           this.inlineQueue.at(-1)!.src = lastToken.text;
         } else if (!this.tokens.links[token.tag]) {

--- a/test/unit/Lexer.test.js
+++ b/test/unit/Lexer.test.js
@@ -1174,7 +1174,7 @@ paragraph
       });
     });
 
-    it.only('multiline', () => {
+    it('multiline', () => {
       expectTokens({
         md: `
 - line 1

--- a/test/unit/Lexer.test.js
+++ b/test/unit/Lexer.test.js
@@ -1209,6 +1209,47 @@ paragraph
           },
         ],
       });
+
+      it('indented code after text', () => {
+        expectTokens({
+          md: `
+- a
+      - b
+`,
+          tokens: [{
+            type: 'space',
+            raw: '\n',
+          },
+          {
+            type: 'list',
+            raw: '- a\n      - b\n',
+            ordered: false,
+            start: '',
+            loose: false,
+            items: [
+              {
+                type: 'list_item',
+                raw: '- a\n      - b',
+                task: false,
+                checked: undefined,
+                loose: false,
+                text: 'a\n    - b',
+                tokens: [
+                  {
+                    type: 'text',
+                    raw: 'a\n    - b',
+                    text: 'a\n- b',
+                    tokens: [
+                      { type: 'text', raw: 'a\n- b', text: 'a\n- b', escaped: false },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          ],
+        });
+      });
     });
   });
 

--- a/test/unit/Lexer.test.js
+++ b/test/unit/Lexer.test.js
@@ -1209,46 +1209,85 @@ paragraph
           },
         ],
       });
+    });
 
-      it('indented code after text', () => {
-        expectTokens({
-          md: `
+    it('indented code after paragraph', () => {
+      expectTokens({
+        md: `
 - a
       - b
 `,
-          tokens: [{
-            type: 'space',
-            raw: '\n',
-          },
+        tokens: [{
+          type: 'space',
+          raw: '\n',
+        },
+        {
+          type: 'list',
+          raw: '- a\n      - b\n',
+          ordered: false,
+          start: '',
+          loose: false,
+          items: [
+            {
+              type: 'list_item',
+              raw: '- a\n      - b',
+              task: false,
+              checked: undefined,
+              loose: false,
+              text: 'a\n    - b',
+              tokens: [
+                {
+                  type: 'text',
+                  raw: 'a\n    - b',
+                  text: 'a\n- b',
+                  tokens: [
+                    { type: 'text', raw: 'a\n- b', text: 'a\n- b', escaped: false },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        ],
+      });
+    });
+
+    it('def after paragraph', () => {
+      expectTokens({
+        md: `
+- hello
+[1]: hello
+`,
+        tokens: [
+          { type: 'space', raw: '\n' },
           {
             type: 'list',
-            raw: '- a\n      - b\n',
+            raw: '- hello\n[1]: hello\n',
             ordered: false,
             start: '',
             loose: false,
             items: [
               {
                 type: 'list_item',
-                raw: '- a\n      - b',
+                raw: '- hello\n[1]: hello',
                 task: false,
                 checked: undefined,
                 loose: false,
-                text: 'a\n    - b',
+                text: 'hello\n[1]: hello',
                 tokens: [
                   {
                     type: 'text',
-                    raw: 'a\n    - b',
-                    text: 'a\n- b',
+                    raw: 'hello\n[1]: hello',
+                    text: 'hello\n[1]: hello',
                     tokens: [
-                      { type: 'text', raw: 'a\n- b', text: 'a\n- b', escaped: false },
+                      { type: 'text', raw: 'hello\n[1]: hello', text: 'hello\n[1]: hello', escaped: false },
                     ],
                   },
                 ],
               },
             ],
           },
-          ],
-        });
+        ],
       });
     });
   });

--- a/test/unit/Lexer.test.js
+++ b/test/unit/Lexer.test.js
@@ -1173,6 +1173,43 @@ paragraph
         ],
       });
     });
+
+    it.only('multiline', () => {
+      expectTokens({
+        md: `
+- line 1
+  line 2
+`,
+        tokens: [
+          {
+            type: 'space',
+            raw: '\n',
+          }, {
+            type: 'list',
+            raw: '- line 1\n  line 2\n',
+            ordered: false,
+            start: '',
+            loose: false,
+            items: [
+              {
+                type: 'list_item',
+                raw: '- line 1\n  line 2',
+                task: false,
+                checked: undefined,
+                loose: false,
+                text: 'line 1\nline 2',
+                tokens: [{
+                  type: 'text',
+                  raw: 'line 1\nline 2',
+                  text: 'line 1\nline 2',
+                  tokens: [{ type: 'text', raw: 'line 1\nline 2', text: 'line 1\nline 2', escaped: false }],
+                }],
+              },
+            ],
+          },
+        ],
+      });
+    });
   });
 
   describe('html', () => {


### PR DESCRIPTION
**Marked version:** 16.1.1

## Description

A multiline list item currently gets an extra newline in the raw property

```md
- line 1
  line 2
```

Tokens:

```diff
  {
    type: 'list',
    raw: '- line 1\n  line 2\n',
    ordered: false,
    start: '',
    loose: false,
    items: [
      {
        type: 'list_item',
        raw: '- line 1\n  line 2',
        task: false,
        checked: undefined,
        loose: false,
        text: 'line 1\nline 2',
        tokens: [{
          type: 'text',
-         raw: 'line 1\n\nline 2',
+         raw: 'line 1\nline 2',
          text: 'line 1\nline 2',
          tokens: [{ type: 'text', raw: 'line 1\nline 2', text: 'line 1\nline 2', escaped: false }],
        }],
      },
    ],
  },
```

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
