### PR TITLE
feat: Add async provideParser provideLexer

### DIFF
--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -217,6 +217,15 @@ export class Marked<ParserOutput = string, RendererOutput = string> {
           } else {
             // @ts-expect-error cannot type hook function dynamically
             hooks[hooksProp] = (...args: unknown[]) => {
+              if (this.defaults.async) {
+                return Promise.resolve(hooksFunc.apply(hooks, args)).then(ret => {
+                  if (ret === false) {
+                    ret = prevHook.apply(hooks, args);
+                  }
+                  return ret;
+                });
+              }
+
               let ret = hooksFunc.apply(hooks, args);
               if (ret === false) {
                 ret = prevHook.apply(hooks, args);

--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -307,7 +307,7 @@ export class Marked<ParserOutput = string, RendererOutput = string> {
 
       if (opt.async) {
         return (async() => {
-          const processedSrc = await Promise.resolve(opt.hooks ? opt.hooks.preprocess(src) : src);
+          const processedSrc = opt.hooks ? await opt.hooks.preprocess(src) : src;
           const lexer = opt.hooks ? await opt.hooks.provideLexer() : (blockType ? _Lexer.lex : _Lexer.lexInline);
           const tokens = await lexer(processedSrc, opt);
           const processedTokens = opt.hooks ? await opt.hooks.processAllTokens(tokens) : tokens;
@@ -316,7 +316,7 @@ export class Marked<ParserOutput = string, RendererOutput = string> {
           }
           const parser = opt.hooks ? await opt.hooks.provideParser() : (blockType ? _Parser.parse : _Parser.parseInline);
           const html = await parser(processedTokens, opt);
-          return opt.hooks ? opt.hooks.postprocess(html) : html;
+          return opt.hooks ? await opt.hooks.postprocess(html) : html;
         })().catch(throwError);
       }
 

--- a/test/unit/Hooks.test.js
+++ b/test/unit/Hooks.test.js
@@ -235,6 +235,23 @@ describe('Hooks', () => {
     assert.strictEqual(html.trim(), '<h1>text</h1>');
   });
 
+  it('should provide async lexer from async hook', async() => {
+    marked.use({
+      async: true,
+      hooks: {
+        async provideLexer() {
+          await timeout();
+          return async(src) => {
+            await timeout();
+            return [createHeadingToken(src)];
+          };
+        },
+      },
+    });
+    const html = await marked.parse('text');
+    assert.strictEqual(html.trim(), '<h1>text</h1>');
+  });
+
   it('should provide parser return object', () => {
     marked.use({
       hooks: {
@@ -282,6 +299,23 @@ describe('Hooks', () => {
         async provideParser() {
           await timeout();
           return (tokens) => {
+            return 'test parser';
+          };
+        },
+      },
+    });
+    const html = await marked.parse('text');
+    assert.strictEqual(html.trim(), 'test parser');
+  });
+
+  it('should provide async parser from async hook', async() => {
+    marked.use({
+      async: true,
+      hooks: {
+        async provideParser() {
+          await timeout();
+          return async(tokens) => {
+            await timeout();
             return 'test parser';
           };
         },

--- a/test/unit/Hooks.test.js
+++ b/test/unit/Hooks.test.js
@@ -219,6 +219,22 @@ describe('Hooks', () => {
     assert.strictEqual(html.trim(), '<h1>text</h1>');
   });
 
+  it('should provide lexer async hook', async() => {
+    marked.use({
+      async: true,
+      hooks: {
+        async provideLexer() {
+          await timeout();
+          return (src) => {
+            return [createHeadingToken(src)];
+          };
+        },
+      },
+    });
+    const html = await marked.parse('text');
+    assert.strictEqual(html.trim(), '<h1>text</h1>');
+  });
+
   it('should provide parser return object', () => {
     marked.use({
       hooks: {
@@ -250,6 +266,22 @@ describe('Hooks', () => {
         provideParser() {
           return async(tokens) => {
             await timeout();
+            return 'test parser';
+          };
+        },
+      },
+    });
+    const html = await marked.parse('text');
+    assert.strictEqual(html.trim(), 'test parser');
+  });
+
+  it('should provide parser async hook', async() => {
+    marked.use({
+      async: true,
+      hooks: {
+        async provideParser() {
+          await timeout();
+          return (tokens) => {
             return 'test parser';
           };
         },


### PR DESCRIPTION
**Marked version:** 16.2.1

## Description

Allow provideParser and provideLexer to be async functions.

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
