### PR TITLE
fix: Handle case-insensitive `www.` prefix

### DIFF
--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -840,7 +840,7 @@ export class _Tokenizer<ParserOutput = string, RendererOutput = string> {
           cap[0] = this.rules.inline._backpedal.exec(cap[0])?.[0] ?? '';
         } while (prevCapZero !== cap[0]);
         text = cap[0];
-        if (cap[1] === 'www.') {
+        if (cap[1]?.toLowerCase() === 'www.') {
           href = 'http://' + cap[0];
         } else {
           href = cap[0];

--- a/test/specs/new/autolinks.html
+++ b/test/specs/new/autolinks.html
@@ -8,6 +8,10 @@
 
 <p><a href="hTtP://fOo.CoM">hTtP://fOo.CoM</a></p>
 
+<p><a href="http://www.foo.com">www.foo.com</a></p>
+
+<p><a href="http://Www.foo.com">Www.foo.com</a></p>
+
 <p><del><a href="mailto:hello@email.com">hello@email.com</a></del></p>
 
 <p><strong><a href="mailto:me@example.com">me@example.com</a></strong></p>

--- a/test/specs/new/autolinks.md
+++ b/test/specs/new/autolinks.md
@@ -8,6 +8,10 @@ HTTP://FOO.COM
 
 hTtP://fOo.CoM
 
+www.foo.com
+
+Www.foo.com
+
 ~~hello@email.com~~
 
 **me@example.com**


### PR DESCRIPTION
**Marked version:**

16.3.0

**Markdown flavor:** Markdown.pl|CommonMark|GitHub Flavored Markdown|n/a

## Description

## Expectation

When a link starts with `www.` (in any case combination like `Www.`, `WWW.`, etc.), it should be automatically converted to a clickable link with `http://` prepended.

## Result

Before the fix, only lowercase `www.` was being prepended with `http://`. Links starting with `Www.` or other case variations were being processed as autolinks but did not have `http://` prepended, which caused the links to redirect to `http://mainwebsite/Www.foo.com`.

After the fix, both `www.foo.com` and `Www.foo.com` are now properly converted to `<a href="http://www.foo.com">www.foo.com</a>` and `<a href="http://Www.foo.com">Www.foo.com</a>` respectively.

## What was attempted

The fix was implemented in `src/Tokenizer.ts:843` by changing the strict equality check from:
```ts
if (cap[1] === 'www.') {
```
to a case-insensitive comparison:
```ts
if (cap[1]?.toLowerCase() === 'www.') {
```

## Contributor

- [X] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR): Added cases to autolinks.md

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
