### PR TITLE
fix: handle backticks in link text for emphasis processing

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -267,7 +267,7 @@ const _punctuationOrSpaceGfmStrongEm = /(?!~)[\s\p{P}\p{S}]/u;
 const _notPunctuationOrSpaceGfmStrongEm = /(?:[^\s\p{P}\p{S}]|~)/u;
 
 // sequences em should skip over [title](link), `code`, <html>
-const blockSkip = /\[[^\[\]]*?\]\((?:\\[\s\S]|[^\\\(\)]|\((?:\\[\s\S]|[^\\\(\)])*\))*\)|`[^`]*?`|<(?! )[^<>]*?>/g;
+const blockSkip = /\[(?:[^\[\]\\`]|\\.|`[^`]*`)*?\]\((?:\\.|[^\\\(\)]|\((?:\\.|[^\\\(\)])*\))*\)|`[^`]*?`|<(?! )[^<>]*?>/g;
 
 const emStrongLDelimCore = /^(?:\*+(?:((?!\*)punct)|[^\s*]))|^_+(?:((?!_)punct)|([^\s_]))/;
 


### PR DESCRIPTION
<!--

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->
[PR] fix: handle backticks in link-like bracket text during emphasis parsing

**Marked version:** 16.3.0  
**Markdown flavor:** CommonMark | GitHub Flavored Markdown

## Description
- Fixes #3777 by updating the `blockSkip` regex to correctly mask backticks inside link-like bracket text before emphasis processing.

## Expectation
Bold/italic should close correctly even when the text includes bracketed segments that look like links and contain code spans:

```markdown
**Really weird edge case: bold around what looks like it might be a link, but is actually a link-looking thing with a code specifier in. [Like `this](https://github.com)`. It's now impossible to close the bold**
```

Expected output:
```html
<p><strong>Really weird edge case: bold around what looks like it might be a link, but is actually a link-looking thing with a code specifier in. [Like <code>this](https://github.com)</code>. It's now impossible to close the bold</strong></p>
```

## Result (before fix)
Emphasis remained unclosed because backticks within the bracketed segment were not masked, interfering with strong/em parsing.

## Technical summary
- The `blockSkip` regex (used to mask links/code/HTML before emphasis) didn’t handle backticks inside the bracket text `[...]`.
- Updated pattern for link text to:
  - Exclude backticks from the generic char class.
  - Explicitly match inline code spans within brackets.
  - Simplify escape handling with `\\.`.

New `blockSkip`:
```
\[(?:[^\[\]\\`]|\\.|`[^`]*`)*?\]\((?:\\.|[^\\\(\)]|\((?:\\.|[^\\\(\)])*\))*\)|`[^`]*?`|<(?!)[^<>]*?>
```

## Contributor
- [x] Tests: existing suite passes (1705 tests), including:
  - `angle_brackets` (ensures `<` and `>` don’t break emphasis)
  - `link_tick_redos` (guards against ReDOS)

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
