### PR TITLE
bug: fix links with square brackets in inline code break wrapping italics

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -267,7 +267,7 @@ const _punctuationOrSpaceGfmStrongEm = /(?!~)[\s\p{P}\p{S}]/u;
 const _notPunctuationOrSpaceGfmStrongEm = /(?:[^\s\p{P}\p{S}]|~)/u;
 
 // sequences em should skip over [title](link), `code`, <html>
-const blockSkip = /\[[^\[\]]*?\]\((?:\\[\s\S]|[^\\\(\)]|\((?:\\[\s\S]|[^\\\(\)])*\))*\)|`[^`]*?`|<(?! )[^<>]*?>/g;
+const blockSkip = /\[(?:[^\[\]`]|`[^`]*?`)*?\]\((?:\\[\s\S]|[^\\\(\)]|\((?:\\[\s\S]|[^\\\(\)])*\))*\)|`[^`]*?`|<(?! )[^<>]*?>/g;
 
 const emStrongLDelimCore = /^(?:\*+(?:((?!\*)punct)|[^\s*]))|^_+(?:((?!_)punct)|([^\s_]))/;
 

--- a/test/specs/new/em_link_brackets.html
+++ b/test/specs/new/em_link_brackets.html
@@ -1,0 +1,1 @@
+<p><em><a href="http://example.com/_/path"><code>a[b]c</code></a></em></p>

--- a/test/specs/new/em_link_brackets.md
+++ b/test/specs/new/em_link_brackets.md
@@ -1,0 +1,1 @@
+_[`a[b]c`](http://example.com/_/path)_


### PR DESCRIPTION
<!--

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->

**Marked version:** 16.3.0 / master

<!-- The NPM version or commit hash having the issue -->

**Markdown flavor:** CommonMark

## Description

- Fixes #3774 

## Expectation
The following Markdown:

`_[`a[b]c`](http://example.com/_/path)_`

to be parsed into an emphasized link whose text is a codespan. In HTML this should be:

`<p><em><a href="http://example.com/_/path"><code>a[b]c</code></a></em></p>`

## Result

Before the change Marked produced a broken output where the emphasis was split and the link text/URL were parsed separately. The produced HTML looked like:

`<p><em>[<code>a[b]c</code>](http://example.com/</em>/path)_</p>`

## What was attempted

Updated the em/strong masking pattern so link text that contains a codespan is treated as a single block to be skipped by the em/strong tokenizer.

- Changed the `blockSkip` regex in `marked/src/rules.ts` so bracketed link text may include backtick codespans (allowing patterns like ``[`a[b]c`]`` inside `[]`) and thus be masked as a unit for em parsing.

- Added spec tests:
  - `test/specs/new/em_link_brackets.md`
  - `test/specs/new/em_link_brackets.html`

With that change, the inline tokenizer no longer sees the `_` delimiter split across the link and URL, so the emphasis wrapping the link is preserved and the output matches the expectation.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,

