### PR TITLE
fix: use emoji regex to correctly mask pair emojis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "commonmark": "0.31.2",
         "cross-env": "^10.1.0",
         "dts-bundle-generator": "^9.5.1",
+        "emoji-regex": "^10.6.0",
         "esbuild": "^0.27.0",
         "esbuild-plugin-umd-wrapper": "^3.0.0",
         "eslint": "^9.39.1",
@@ -3032,9 +3033,9 @@
       }
     },
     "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
     },
@@ -8613,13 +8614,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/semantic-release/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/semantic-release/node_modules/escape-string-regexp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -9264,6 +9258,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/string-width/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "commonmark": "0.31.2",
     "cross-env": "^10.1.0",
     "dts-bundle-generator": "^9.5.1",
+    "emoji-regex": "^10.6.0",
     "esbuild": "^0.27.0",
     "esbuild-plugin-umd-wrapper": "^3.0.0",
     "eslint": "^9.39.1",

--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -1,8 +1,11 @@
+import emojiRegex from 'emoji-regex';
 import { _Tokenizer } from './Tokenizer.ts';
 import { _defaults } from './defaults.ts';
 import { other, block, inline } from './rules.ts';
 import type { Token, TokensList, Tokens } from './Tokens.ts';
 import type { MarkedOptions } from './MarkedOptions.ts';
+
+const emojiMatcher = emojiRegex();
 
 /**
  * Block Lexer
@@ -329,6 +332,8 @@ export class _Lexer<ParserOutput = string, RendererOutput = string> {
 
     // Mask out blocks from extensions
     maskedSrc = this.options.hooks?.emStrongMask?.call({ lexer: this }, maskedSrc) ?? maskedSrc;
+
+    maskedSrc = maskedSrc.replace(emojiMatcher, (m) => 'a'.repeat(m.length));
 
     let keepPrevChar = false;
     let prevChar = '';


### PR DESCRIPTION
<!--

	If badging PR, add ?template=badges.md to the PR url to use the badges PR template.

	Otherwise, you are stating this PR fixes an issue that has been submitted; or,
	describes the issue or proposal under consideration and contains the project-related code to implement.

-->

**Marked version:** 17.0.1

<!-- The NPM version or commit hash having the issue -->

**Markdown flavor:** n/a

## Description

- Fixes: https://github.com/markedjs/marked/issues/3852

This PR worked for me to fix the above issue, I'm not sure if I need to update more tests or whatever, I'm not even sure why it works in the `Marked Demo` Website but not in the codesandbox mentioned in the issue, would love if I get some help pointing out how we can get this fixed asap

<!--

	If no issue exists that you're aware of. The maintainers should be able to figure out if it's a duplicate.

## Expectation

Describe the output you are expecting from marked

## Result

Describe the output you received from marked

## What was attempted

Used `emoji-regex` to mask emojis correctly with eachone's length.

-->

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
