### PR TITLE
docs: browser example for marked on page data

### DIFF
--- a/docs/USING_ADVANCED.md
+++ b/docs/USING_ADVANCED.md
@@ -114,6 +114,7 @@ Marked can be extended using [custom extensions](/using_pro#extensions). This is
 <h2 id="user-examples">User Examples</h2>
 
 <details>
+
 <summary>Marked can render on-page content as markdown in the browser.</summary>
 
 ```html
@@ -145,6 +146,9 @@ Lots of text using **markdown syntax.**
   </script>
  </body>
 </html>
+```
+</details>
+
 <h2 id="inline">Inline Markdown</h2>
 
 You can parse inline markdown by running markdown through `marked.parseInline`.

--- a/docs/_document.html
+++ b/docs/_document.html
@@ -236,6 +236,13 @@
               <li>
                 <a
                   class="block hover:text-primary dark:hover:text-primary"
+                  href="/using_advanced#user-examples"
+                  >User Examples</a
+                >
+              </li>
+              <li>
+                <a
+                  class="block hover:text-primary dark:hover:text-primary"
                   href="/using_advanced#inline"
                   >Inline Markdown</a
                 >


### PR DESCRIPTION
**Marked version:**

**Markdown flavor:** `https://cdn.jsdelivr.net/npm/marked/lib/marked.umd.js`

## Description

This is a simple PR to the documentations. It proposes an additional example for usage in the browser. A `details` tag was used so the example can be toggled, as to not break the flow of the current documentation.

The example shows how this tool could be used to render html elements as if markdown. See [support-repo](https://github.com/jhauga/support-repo/tree/marked-browser-ex?tab=readme-ov-file) for an illustration of the example with markdown data. Click on the `index.html` link to view the GitHub page. The essentials from the example were carried over to the example `index.html` page.

Tested with `npm run build:docs`. All was good. And for fun ran `npm run test`. All was good.

## Expectation

An additional example for browser use in the documentation.

## Result

Someone first visiting the documentation will see how easy it is to use `marked` on an html page, using inline page data and how to render it as if markdown.

## What was attempted

- `php -S localhost` with a test file with lots of data, and the elements from the proposed example. The rendered page was output as if markdown.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
