### PR TITLE
fix(rules): ensure lookbehind regex is evaluated correctly by minifiers

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -19,7 +19,6 @@ function edit(regex: string | RegExp, opt = '') {
 // use a default variable to ensure the regex is evaluated on client an not removed by minifiers
 const supportsLookbehind = ((a = '') => {
 try {
-  // eslint-disable-next-line prefer-regex-literals
   return !!new RegExp('(?<=1)(?<!1)' + a);
 } catch {
   // See browser support here:

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -16,10 +16,11 @@ function edit(regex: string | RegExp, opt = '') {
   return obj;
 }
 
-const supportsLookbehind = (() => {
+// use a default variable to ensure the regex is evaluated on client an not removed by minifiers
+const supportsLookbehind = ((a = '') => {
 try {
   // eslint-disable-next-line prefer-regex-literals
-  return !!new RegExp('(?<=1)(?<!1)');
+  return !!new RegExp('(?<=1)(?<!1)' + a);
 } catch {
   // See browser support here:
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookbehind_assertion


### PR DESCRIPTION
Use a default variable in the regex to prevent removal by minifiers. 

This is a very minor change that fix  #3944 downstream




