### PR TITLE
fix: fix infinite loop for indented code blank line

### DIFF
--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -110,7 +110,15 @@ export class _Lexer<ParserOutput = string, RendererOutput = string> {
       src = src.replace(other.tabCharGlobal, '    ').replace(other.spaceLine, '');
     }
 
+    let srcLength = Infinity;
     while (src) {
+      if (src.length < srcLength) {
+        srcLength = src.length;
+      } else {
+        this.infiniteLoopError(src.charCodeAt(0));
+        break;
+      }
+
       let token: Tokens.Generic | undefined;
 
       if (this.options.extensions?.block?.some((extTokenizer) => {
@@ -275,13 +283,8 @@ export class _Lexer<ParserOutput = string, RendererOutput = string> {
       }
 
       if (src) {
-        const errMsg = 'Infinite loop on byte: ' + src.charCodeAt(0);
-        if (this.options.silent) {
-          console.error(errMsg);
-          break;
-        } else {
-          throw new Error(errMsg);
-        }
+        this.infiniteLoopError(src.charCodeAt(0));
+        break;
       }
     }
 
@@ -334,7 +337,15 @@ export class _Lexer<ParserOutput = string, RendererOutput = string> {
 
     let keepPrevChar = false;
     let prevChar = '';
+    let srcLength = Infinity;
     while (src) {
+      if (src.length < srcLength) {
+        srcLength = src.length;
+      } else {
+        this.infiniteLoopError(src.charCodeAt(0));
+        break;
+      }
+
       if (!keepPrevChar) {
         prevChar = '';
       }
@@ -464,16 +475,20 @@ export class _Lexer<ParserOutput = string, RendererOutput = string> {
       }
 
       if (src) {
-        const errMsg = 'Infinite loop on byte: ' + src.charCodeAt(0);
-        if (this.options.silent) {
-          console.error(errMsg);
-          break;
-        } else {
-          throw new Error(errMsg);
-        }
+        this.infiniteLoopError(src.charCodeAt(0));
+        break;
       }
     }
 
     return tokens;
+  }
+
+  private infiniteLoopError(byte: number) {
+    const errMsg = 'Infinite loop on byte: ' + byte;
+    if (this.options.silent) {
+      console.error(errMsg);
+    } else {
+      throw new Error(errMsg);
+    }
   }
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -112,7 +112,7 @@ export function rtrim(str: string, c: string, invert?: boolean) {
 export function trimTrailingBlankLines(str: string) {
   const lines = str.split('\n');
   let end = lines.length - 1;
-  while (end >= 0 && !lines[end].trim()) {
+  while (end >= 0 && other.blankLine.test(lines[end])) {
     end--;
   }
   if (lines.length - end <= 2) {

--- a/test/run-spec-tests.js
+++ b/test/run-spec-tests.js
@@ -47,4 +47,5 @@ runTests({
 runTests({
   tests: redosTests,
   parse,
+  defaultMarkedOptions: { silent: false },
 });

--- a/test/specs/redos/code_blank_line.cjs
+++ b/test/specs/redos/code_blank_line.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  markdown: '\x09\x0b\n',
+  html: '<pre><code>\x0b</code></pre>',
+};

--- a/test/specs/redos/code_blank_line.cjs
+++ b/test/specs/redos/code_blank_line.cjs
@@ -1,4 +1,4 @@
 module.exports = {
-  markdown: '\x09\x0b\n',
+  markdown: '\t\v\n',
   html: '<pre><code>\x0b</code></pre>',
 };

--- a/test/specs/redos/code_blank_line.cjs
+++ b/test/specs/redos/code_blank_line.cjs
@@ -1,4 +1,4 @@
 module.exports = {
   markdown: '\t\v\n',
-  html: '<pre><code>\x0b</code></pre>',
+  html: '<pre><code>\v</code></pre>\n',
 };


### PR DESCRIPTION
**Marked version:** v18.0.1

## Description

Fix infinite loop in indented code with only whitespace.

In v18 we introduced a change to indented code that removes trailing blank lines, but the way we detect blank lines as any whitespace we can create empty token if the code is only whitespace (e.g. '\v' vertical tab). Currently we will just keep creating empty indented code tokens until we run out of memory. 

Thanks for finding this @MaanVader

This PR checks for infinite loops and throws an error if found. It also defines a blank line in indented code tokens as only containing space or tab like it should. If the indented code block only has tabs or spaces it is not an indented code block according to CommonMark.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
