### PR TITLE
fix: parse pedantic strong punctuation

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -311,6 +311,20 @@ const emStrongRDelimAst = edit(emStrongRDelimAstCore, 'gu')
   .replace(/punct/g, _punctuation)
   .getRegex();
 
+const emStrongRDelimAstPedantic = edit(
+  '^[^_*]*?__[^_*]*?\\*[^_*]*?(?=__)' // Skip orphan inside strong
++ '|[^*]+(?=[^*])' // Consume to delim
++ '|(?!\\*)punct(\\*+)(?=[\\s]|$)' // (1) #*** can only be a Right Delimiter
++ '|notPunctSpace(\\*+)(?!\\*)(?=punctSpace|$)' // (2) a***#, a*** can only be a Right Delimiter
++ '|(?!\\*)[\\s](\\*+)(?=notPunctSpace)' // (3) ***a can only be Left Delimiter
++ '|[\\s](\\*+)(?!\\*)(?=punct)' // (4) ***# can only be Left Delimiter
++ '|(?!\\*)punct(\\*+)(?!\\*)(?=punct)' // (5) #***# can be either Left or Right Delimiter
++ '|(?:(?!\\*)punct|notPunctSpace)(\\*+)(?!\\*)(?=notPunctSpace)', 'gu') // (6) #***a and a***a can be either Left or Right Delimiter
+  .replace(/notPunctSpace/g, _notPunctuationOrSpace)
+  .replace(/punctSpace/g, _punctuationOrSpace)
+  .replace(/punct/g, _punctuation)
+  .getRegex();
+
 const emStrongRDelimAstGfm = edit(emStrongRDelimAstCore, 'gu')
   .replace(/notPunctSpace/g, _notPunctuationOrSpaceGfmStrongEm)
   .replace(/punctSpace/g, _punctuationOrSpaceGfmStrongEm)
@@ -433,6 +447,7 @@ type InlineKeys = keyof typeof inlineNormal;
 
 const inlinePedantic: Record<InlineKeys, RegExp> = {
   ...inlineNormal,
+  emStrongRDelimAst: emStrongRDelimAstPedantic,
   link: edit(/^!?\[(label)\]\((.*?)\)/)
     .replace('label', _inlineLabel)
     .getRegex(),

--- a/test/specs/original/strong_punctuation.html
+++ b/test/specs/original/strong_punctuation.html
@@ -1,0 +1,3 @@
+<p><strong>foo:</strong>bar</p>
+
+<p><strong>foo</strong>bar</p>

--- a/test/specs/original/strong_punctuation.md
+++ b/test/specs/original/strong_punctuation.md
@@ -1,0 +1,7 @@
+---
+pedantic: true
+---
+
+**foo:**bar
+
+**foo**bar


### PR DESCRIPTION
**Marked version:**

18.0.2 / master

**Markdown flavor:** Markdown.pl / pedantic

## Description

Fixes #3938.

In pedantic mode, `**foo:**bar` was still parsed with CommonMark delimiter rules and rendered as literal asterisks:

```html
<p>**foo:**bar</p>
```

Markdown.pl renders the same input as:

```html
<p><strong>foo:</strong>bar</p>
```

This adds a pedantic-only asterisk delimiter rule so punctuation before a closing `**` can end strong text when the next character is not whitespace. The normal and GFM delimiter rules are unchanged.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

Validation:
- `npm run build:esbuild && node --test --test-reporter=spec test/run-spec-tests.js`
- `npm run test:lint`
- `npm test`
- `npm run build:reset`
