### PR TITLE
fix: avoid task checkbox for setext heading text

### DIFF
--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -414,16 +414,12 @@ export class _Tokenizer<ParserOutput = string, RendererOutput = string> {
       for (const item of list.items) {
         this.lexer.state.top = false;
         item.tokens = this.lexer.blockTokens(item.text, []);
-        if (item.task) {
-          if (item.tokens[0]?.type !== 'text' && item.tokens[0]?.type !== 'paragraph') {
-            item.task = false;
-            continue;
-          }
-
+        const itemToken = item.tokens[0];
+        if (item.task && (itemToken?.type === 'text' || itemToken?.type === 'paragraph')) {
           // Remove checkbox markdown from item tokens
           item.text = item.text.replace(this.rules.other.listReplaceTask, '');
-          item.tokens[0].raw = item.tokens[0].raw.replace(this.rules.other.listReplaceTask, '');
-          item.tokens[0].text = item.tokens[0].text.replace(this.rules.other.listReplaceTask, '');
+          itemToken.raw = itemToken.raw.replace(this.rules.other.listReplaceTask, '');
+          itemToken.text = itemToken.text.replace(this.rules.other.listReplaceTask, '');
           for (let i = this.lexer.inlineQueue.length - 1; i >= 0; i--) {
             if (this.rules.other.listIsTask.test(this.lexer.inlineQueue[i].src)) {
               this.lexer.inlineQueue[i].src = this.lexer.inlineQueue[i].src.replace(this.rules.other.listReplaceTask, '');
@@ -456,6 +452,8 @@ export class _Tokenizer<ParserOutput = string, RendererOutput = string> {
               item.tokens.unshift(checkboxToken);
             }
           }
+        } else if (item.task) {
+          item.task = false;
         }
 
         if (!list.loose) {

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -415,16 +415,19 @@ export class _Tokenizer<ParserOutput = string, RendererOutput = string> {
         this.lexer.state.top = false;
         item.tokens = this.lexer.blockTokens(item.text, []);
         if (item.task) {
+          if (item.tokens[0]?.type !== 'text' && item.tokens[0]?.type !== 'paragraph') {
+            item.task = false;
+            continue;
+          }
+
           // Remove checkbox markdown from item tokens
           item.text = item.text.replace(this.rules.other.listReplaceTask, '');
-          if (item.tokens[0]?.type === 'text' || item.tokens[0]?.type === 'paragraph') {
-            item.tokens[0].raw = item.tokens[0].raw.replace(this.rules.other.listReplaceTask, '');
-            item.tokens[0].text = item.tokens[0].text.replace(this.rules.other.listReplaceTask, '');
-            for (let i = this.lexer.inlineQueue.length - 1; i >= 0; i--) {
-              if (this.rules.other.listIsTask.test(this.lexer.inlineQueue[i].src)) {
-                this.lexer.inlineQueue[i].src = this.lexer.inlineQueue[i].src.replace(this.rules.other.listReplaceTask, '');
-                break;
-              }
+          item.tokens[0].raw = item.tokens[0].raw.replace(this.rules.other.listReplaceTask, '');
+          item.tokens[0].text = item.tokens[0].text.replace(this.rules.other.listReplaceTask, '');
+          for (let i = this.lexer.inlineQueue.length - 1; i >= 0; i--) {
+            if (this.rules.other.listIsTask.test(this.lexer.inlineQueue[i].src)) {
+              this.lexer.inlineQueue[i].src = this.lexer.inlineQueue[i].src.replace(this.rules.other.listReplaceTask, '');
+              break;
             }
           }
 

--- a/test/specs/new/tasklist_setext_heading.html
+++ b/test/specs/new/tasklist_setext_heading.html
@@ -1,0 +1,18 @@
+<h1>tight</h1>
+<ul>
+<li><h2>[x] title</h2>
+</li>
+</ul>
+<h1>unchecked</h1>
+<ul>
+<li><h2>[ ] title</h2>
+</li>
+</ul>
+<h1>loose</h1>
+<ul>
+<li><h2>[x] title</h2>
+<p>body</p>
+</li>
+<li><p>second</p>
+</li>
+</ul>

--- a/test/specs/new/tasklist_setext_heading.md
+++ b/test/specs/new/tasklist_setext_heading.md
@@ -1,0 +1,17 @@
+# tight
+
+- [x] title
+  ---
+
+# unchecked
+
+- [ ] title
+  ---
+
+# loose
+
+- [x] title
+  ---
+
+  body
+- second

--- a/test/unit/Lexer.test.js
+++ b/test/unit/Lexer.test.js
@@ -1297,6 +1297,45 @@ paragraph
       });
     });
 
+    it('does not parse setext heading text as a task checkbox', () => {
+      expectTokens({
+        md: '- [x] title\n  ---',
+        tokens: [
+          {
+            type: 'list',
+            raw: '- [x] title\n  ---',
+            ordered: false,
+            start: '',
+            loose: false,
+            items: [
+              {
+                type: 'list_item',
+                raw: '- [x] title\n  ---',
+                task: false,
+                loose: false,
+                text: '[x] title\n---',
+                tokens: [
+                  {
+                    type: 'heading',
+                    raw: '[x] title\n---',
+                    depth: 2,
+                    text: '[x] title',
+                    tokens: [
+                      {
+                        type: 'text',
+                        raw: '[x] title',
+                        text: '[x] title',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+    });
+
     it('multiline', () => {
       expectTokens({
         md: `

--- a/test/unit/Lexer.test.js
+++ b/test/unit/Lexer.test.js
@@ -1336,6 +1336,84 @@ paragraph
       });
     });
 
+    it('keeps setext heading task candidates loose when separated by blank lines', () => {
+      expectTokens({
+        md: '- [x] title\n  ---\n\n  body\n- second',
+        tokens: [
+          {
+            type: 'list',
+            raw: '- [x] title\n  ---\n\n  body\n- second',
+            ordered: false,
+            start: '',
+            loose: true,
+            items: [
+              {
+                type: 'list_item',
+                raw: '- [x] title\n  ---\n\n  body\n',
+                task: false,
+                loose: true,
+                text: '[x] title\n---\n\nbody',
+                tokens: [
+                  {
+                    type: 'heading',
+                    raw: '[x] title\n---',
+                    depth: 2,
+                    text: '[x] title',
+                    tokens: [
+                      {
+                        type: 'text',
+                        raw: '[x] title',
+                        text: '[x] title',
+                      },
+                    ],
+                  },
+                  {
+                    type: 'space',
+                    raw: '\n\n',
+                  },
+                  {
+                    type: 'paragraph',
+                    raw: 'body',
+                    text: 'body',
+                    tokens: [
+                      {
+                        type: 'text',
+                        raw: 'body',
+                        text: 'body',
+                        escaped: false,
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: 'list_item',
+                raw: '- second',
+                task: false,
+                loose: true,
+                text: 'second',
+                tokens: [
+                  {
+                    type: 'paragraph',
+                    raw: 'second',
+                    text: 'second',
+                    tokens: [
+                      {
+                        type: 'text',
+                        raw: 'second',
+                        text: 'second',
+                        escaped: false,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+    });
+
     it('multiline', () => {
       expectTokens({
         md: `

--- a/test/unit/marked.test.js
+++ b/test/unit/marked.test.js
@@ -54,18 +54,6 @@ describe('marked unit', () => {
 
       assert.strictEqual(html, '<ul>\n<li><p><input disabled="" type="checkbox"> item 1</p>\n</li>\n<li><p><input disabled="" type="checkbox"> item 2</p>\n</li>\n</ul>\n');
     });
-
-    it('does not parse setext heading text as a task checkbox', () => {
-      const html = marked.parse('- [x] title\n  ---');
-
-      assert.strictEqual(html, '<ul>\n<li><h2>[x] title</h2>\n</li>\n</ul>\n');
-    });
-
-    it('keeps setext heading task candidates loose when separated by blank lines', () => {
-      const html = marked.parse('- [x] title\n  ---\n\n  body\n- second');
-
-      assert.strictEqual(html, '<ul>\n<li><h2>[x] title</h2>\n<p>body</p>\n</li>\n<li><p>second</p>\n</li>\n</ul>\n');
-    });
   });
 
   describe('parseInline', () => {

--- a/test/unit/marked.test.js
+++ b/test/unit/marked.test.js
@@ -54,6 +54,12 @@ describe('marked unit', () => {
 
       assert.strictEqual(html, '<ul>\n<li><p><input disabled="" type="checkbox"> item 1</p>\n</li>\n<li><p><input disabled="" type="checkbox"> item 2</p>\n</li>\n</ul>\n');
     });
+
+    it('does not parse setext heading text as a task checkbox', () => {
+      const html = marked.parse('- [x] title\n  ---');
+
+      assert.strictEqual(html, '<ul>\n<li><h2>[x] title</h2>\n</li>\n</ul>\n');
+    });
   });
 
   describe('parseInline', () => {

--- a/test/unit/marked.test.js
+++ b/test/unit/marked.test.js
@@ -60,6 +60,12 @@ describe('marked unit', () => {
 
       assert.strictEqual(html, '<ul>\n<li><h2>[x] title</h2>\n</li>\n</ul>\n');
     });
+
+    it('keeps setext heading task candidates loose when separated by blank lines', () => {
+      const html = marked.parse('- [x] title\n  ---\n\n  body\n- second');
+
+      assert.strictEqual(html, '<ul>\n<li><h2>[x] title</h2>\n<p>body</p>\n</li>\n<li><p>second</p>\n</li>\n</ul>\n');
+    });
   });
 
   describe('parseInline', () => {


### PR DESCRIPTION
**Marked version:** 18.0.2

**Markdown flavor:** GitHub Flavored Markdown

## Description
re #3828
Setext headings inside list items that start with `[x]` or `[ ]` were parsed as task list items, so the marker was removed and a disabled checkbox was inserted.

## Expectation

```md
- [x] title
  ---
```

renders as a list item containing `<h2>[x] title</h2>`.

## Result

[Demo](https://marked.js.org/demo/?text=-%20%5Bx%5D%20title%0A%20%20---%0A&options=%7B%0A%20%22async%22%3A%20false%2C%0A%20%22breaks%22%3A%20false%2C%0A%20%22extensions%22%3A%20null%2C%0A%20%22gfm%22%3A%20true%2C%0A%20%22hooks%22%3A%20null%2C%0A%20%22pedantic%22%3A%20false%2C%0A%20%22silent%22%3A%20false%2C%0A%20%22tokenizer%22%3A%20null%2C%0A%20%22walkTokens%22%3A%20null%0A%7D&version=18.0.2)
Marked rendered the same input as a checked task list item with a heading.


## What was attempted

Only finalize task-list parsing when the preserved checkbox marker belongs to a text-like first child token. Added unit coverage for the rendered HTML and lexer token shape.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).