### PR TITLE
refactor(test): move task list output coverage to specs

### DIFF
--- a/test/specs/new/tasklist_basic.html
+++ b/test/specs/new/tasklist_basic.html
@@ -1,0 +1,11 @@
+<h1>tight</h1>
+<ul>
+<li><input disabled="" type="checkbox"> item</li>
+</ul>
+<h1>loose</h1>
+<ul>
+<li><p><input disabled="" type="checkbox"> item 1</p>
+</li>
+<li><p><input disabled="" type="checkbox"> item 2</p>
+</li>
+</ul>

--- a/test/specs/new/tasklist_basic.md
+++ b/test/specs/new/tasklist_basic.md
@@ -1,0 +1,9 @@
+# tight
+
+- [ ] item
+
+# loose
+
+- [ ] item 1
+
+- [ ] item 2

--- a/test/unit/marked.test.js
+++ b/test/unit/marked.test.js
@@ -42,20 +42,6 @@ describe('marked unit', () => {
     });
   });
 
-  describe('task', () => {
-    it('space after checkbox', () => {
-      const html = marked.parse('- [ ] item');
-
-      assert.strictEqual(html, '<ul>\n<li><input disabled="" type="checkbox"> item</li>\n</ul>\n');
-    });
-
-    it('space after loose checkbox', () => {
-      const html = marked.parse('- [ ] item 1\n\n- [ ] item 2');
-
-      assert.strictEqual(html, '<ul>\n<li><p><input disabled="" type="checkbox"> item 1</p>\n</li>\n<li><p><input disabled="" type="checkbox"> item 2</p>\n</li>\n</ul>\n');
-    });
-  });
-
   describe('parseInline', () => {
     it('should parse inline tokens', () => {
       const md = '**strong** _em_';


### PR DESCRIPTION
**Marked version:** 18.0.3

**Markdown flavor:** GitHub Flavored Markdown

## Description

re https://github.com/markedjs/marked/pull/3960#pullrequestreview-4202807360.

Moves basic task-list Markdown-to-HTML coverage from `test/unit/marked.test.js` to `test/specs/new`, matching the review comment above.

Kept the scope narrow after a project-wide scan. Other HTML assertions remain in unit tests because they cover API behavior.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
