### PR TITLE
Add Node.js usage example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ $ cat hello.html
 $ marked --help
 ```
 
+**Node.js**
+
+```js
+import { marked } from 'marked';
+const html = marked.parse('# Marked in Node.js');
+console.log(html);
+```
+
 **Browser**
 
 ```html


### PR DESCRIPTION
**Marked version:** master

**Markdown flavor:** n/a

## Description

- Fixes 3982

This PR adds a short Node.js usage example to the README. The README already includes CLI and Browser examples, but it did not include a small Node.js package usage example. Since Marked can be used on a server, this adds a simple example showing how to import marked, parse a Markdown string, and use the resulting HTML.

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [X] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
