### PR TITLE
fix: apply Unicode full case fold in link reference label normalization

### DIFF
--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -5,6 +5,7 @@ import {
   findClosingBracket,
   expandTabs,
   trimTrailingBlankLines,
+  normalizeLabel,
 } from './helpers.ts';
 import type { Rules } from './rules.ts';
 import type { _Lexer } from './Lexer.ts';
@@ -499,7 +500,7 @@ export class _Tokenizer<ParserOutput = string, RendererOutput = string> {
   def(src: string): Tokens.Def | undefined {
     const cap = this.rules.block.def.exec(src);
     if (cap) {
-      const tag = cap[1].toLowerCase().replace(this.rules.other.multipleSpaceGlobal, ' ');
+      const tag = normalizeLabel(cap[1]).replace(this.rules.other.multipleSpaceGlobal, ' ');
       const href = cap[2] ? cap[2].replace(this.rules.other.hrefBrackets, '$1').replace(this.rules.inline.anyPunctuation, '$1') : '';
       const title = cap[3] ? cap[3].substring(1, cap[3].length - 1).replace(this.rules.inline.anyPunctuation, '$1') : cap[3];
       return {
@@ -717,8 +718,8 @@ export class _Tokenizer<ParserOutput = string, RendererOutput = string> {
     let cap;
     if ((cap = this.rules.inline.reflink.exec(src))
       || (cap = this.rules.inline.nolink.exec(src))) {
-      const linkString = (cap[2] || cap[1]).replace(this.rules.other.multipleSpaceGlobal, ' ');
-      const link = links[linkString.toLowerCase()];
+      const linkString = normalizeLabel(cap[2] || cap[1]).replace(this.rules.other.multipleSpaceGlobal, ' ');
+      const link = links[linkString];
       if (!link) {
         const text = cap[0].charAt(0);
         return {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -164,3 +164,25 @@ export function expandTabs(line: string, indent = 0) {
 
   return expanded;
 }
+
+/**
+ * Normalize a link reference label per CommonMark spec:
+ * perform Unicode full case fold (covering multi-char expansions that
+ * String.prototype.toLowerCase() misses, e.g. ẞ→ss, ligatures→letters),
+ * then collapse runs of whitespace to a single space.
+ *
+ * @see https://spec.commonmark.org/0.31.2/#matches
+ */
+export function normalizeLabel(label: string): string {
+  return label
+    // Apply Unicode full case fold before toLowerCase so that
+    // ẞ (U+1E9E) → ss and ß (U+00DF) → ss (simple fold maps ẞ to ß first).
+    .toLowerCase()
+    .replace(/ß/g, 'ss') // U+00DF + folded U+1E9E
+    .replace(/ﬀ/g, 'ff') // U+FB00
+    .replace(/ﬁ/g, 'fi') // U+FB01
+    .replace(/ﬂ/g, 'fl') // U+FB02
+    .replace(/ﬃ/g, 'ffi') // U+FB03
+    .replace(/ﬄ/g, 'ffl') // U+FB04
+    .replace(/ﬅ|ﬆ/g, 'st'); // U+FB05, U+FB06
+}

--- a/test/specs/commonmark/commonmark.0.31.2.json
+++ b/test/specs/commonmark/commonmark.0.31.2.json
@@ -4331,8 +4331,7 @@
     "example": 540,
     "start_line": 8129,
     "end_line": 8135,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "[Foo\n  bar]: /url\n\n[Baz][Foo bar]\n",

--- a/test/specs/gfm/commonmark.0.31.2.json
+++ b/test/specs/gfm/commonmark.0.31.2.json
@@ -4331,8 +4331,7 @@
     "example": 540,
     "start_line": 8129,
     "end_line": 8135,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "[Foo\n  bar]: /url\n\n[Baz][Foo bar]\n",


### PR DESCRIPTION
## Bug

JavaScript's `String.prototype.toLowerCase()` implements Unicode simple case mapping, not full case folding. The CommonMark spec §5.6 requires Unicode case folding when matching link reference labels:

> One label matches another just if their normalized forms are equal. To normalize a label, perform the Unicode case fold on the label, and collapse consecutive spaces, tabs, and line endings to a single space.

The key difference: full case folding allows a single character to expand to multiple characters. For example:

| Character | `toLowerCase()` | Full case fold |
|-----------|-----------------|----------------|
| ẞ (U+1E9E) | ß | ss |
| ß (U+00DF) | ß | ss |
| ﬁ (U+FB01) | ﬁ | fi |

This means **CommonMark spec example 540** fails:

```markdown
[ẞ]

[SS]: /url
```

Expected: `<p><a href="/url">ẞ</a></p>`
Got: `<p>[ẞ]</p>` (unresolved reference)

## Fix

Add `normalizeLabel()` to `src/helpers.ts` that chains `toLowerCase()` with replacements for the Unicode F-status (full) case fold pairs that expand to multiple characters. Update `Tokenizer.def` and `Tokenizer.reflink` to use it instead of plain `toLowerCase()`.

## Verification

```
npm test
```

- CommonMark Links: 77/90 → 78/90 (example 540 now passes)
- GFM Links: same improvement
- All 1743 spec tests pass; all 188 unit tests pass; lint clean

> **AI assistance disclosure:** This fix was developed with AI-assisted tooling.