### PR TITLE
Update repository metadata URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/markedjs/marked.git"
+    "url": "git+https://github.com/markedjs/marked.git"
   },
   "homepage": "https://marked.js.org",
   "bugs": {
-    "url": "http://github.com/markedjs/marked/issues"
+    "url": "https://github.com/markedjs/marked/issues"
   },
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Summary:
- update the package repository URL from the legacy `git://` protocol to `git+https://`
- update the issue tracker URL from `http://` to `https://`
- keep existing homepage and license metadata unchanged

Validation:
- fetched `package.json` from the default branch and parsed it as JSON
- asserted `repository.url` is `git+https://github.com/markedjs/marked.git`
- asserted `bugs.url` is `https://github.com/markedjs/marked/issues`
- asserted `homepage` remains `https://marked.js.org`