### PR TITLE
fix: Fix ordered lists after blockquotes

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -163,20 +163,25 @@ const html = edit(
   .replace('attribute', / +[a-zA-Z:_][\w.:-]*(?: *= *"[^"\n]*"| *= *'[^'\n]*'| *= *[^\s"'=<>`]+)?/)
   .getRegex();
 
-const paragraph = edit(_paragraph)
+const createParagraph = (listInterrupt: RegExp) => edit(_paragraph)
   .replace('hr', hr)
   .replace('heading', ' {0,3}#{1,6}(?:\\s|$)')
   .replace('|lheading', '') // setext headings don't interrupt commonmark paragraphs
   .replace('|table', '')
   .replace('blockquote', ' {0,3}>')
   .replace('fences', ' {0,3}(?:`{3,}(?=[^`\\n]*\\n)|~{3,})[^\\n]*\\n')
-  .replace('list', ' {0,3}(?:[*+-]|1[.)])[ \\t]+[^ \\t\\n]') // only non-empty lists starting from 1 can interrupt
+  .replace('list', listInterrupt)
   .replace('html', '</?(?:tag)(?: +|\\n|/?>)|<(?:script|pre|style|textarea|!--)')
   .replace('tag', _tag) // pars can be interrupted by type (6) html blocks
   .getRegex();
 
+// only non-empty lists starting from 1 can interrupt paragraphs
+const paragraph = createParagraph(/ {0,3}(?:[*+-]|1[.)])[ \t]+[^ \t\n]/);
+// blockquotes can be interrupted by lists starting from any number
+const blockquoteParagraph = createParagraph(/ {0,3}(?:[*+-]|\d{1,9}[.)])[ \t]+[^ \t\n]/);
+
 const blockquote = edit(/^( {0,3}> ?(paragraph|[^\n]*)(?:\n|$))+/)
-  .replace('paragraph', paragraph)
+  .replace('paragraph', blockquoteParagraph)
   .getRegex();
 
 /**

--- a/test/specs/new/ordered_list_after_blockquote.html
+++ b/test/specs/new/ordered_list_after_blockquote.html
@@ -1,0 +1,12 @@
+<ol>
+<li>test</li>
+</ol>
+<blockquote>
+<p>blockquote</p>
+</blockquote>
+<ol start="2">
+<li>test</li>
+</ol>
+<blockquote>
+<p>blockquote</p>
+</blockquote>

--- a/test/specs/new/ordered_list_after_blockquote.md
+++ b/test/specs/new/ordered_list_after_blockquote.md
@@ -1,0 +1,4 @@
+1. test
+> blockquote
+2. test
+> blockquote


### PR DESCRIPTION
**Marked version:**

18.0.5

**Markdown flavor:** Markdown.pl|CommonMark|GitHub Flavored Markdown|n/a

CommonMark / GitHub Flavored Markdown

## Description

- Fixes #4002.
- Keeps ordered lists that follow a blockquote as sibling blocks instead of lazy blockquote continuations.
- Adds a regression spec for an ordered list after a blockquote.

## Tests

- `npm test`

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
