### PR TITLE
fix: treat a line of only tabs as a blank line between paragraphs

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -128,7 +128,7 @@ const lheadingGfm = edit(lheadingCore)
   .replace(/html/g, / {0,3}<[^\n>]+>\n/) // block html can interrupt
   .replace(/table/g, / {0,3}\|?(?:[:\- ]*\|)+[\:\- ]*\n/) // table can interrupt
   .getRegex();
-const _paragraph = /^([^\n]+(?:\n(?!hr|heading|lheading|blockquote|fences|list|html|table| +\n)[^\n]+)*)/;
+const _paragraph = /^([^\n]+(?:\n(?!hr|heading|lheading|blockquote|fences|list|html|table|[ \t]+\n)[^\n]+)*)/;
 const blockText = /^[^\n]+/;
 const _blockLabel = /(?!\s*\])(?:\\[\s\S]|[^\[\]\\])+/;
 const def = edit(/^ {0,3}\[(label)\]: *(?:\n[ \t]*)?([^<\s][^\s]*|<.*?>)(?:(?: +(?:\n[ \t]*)?| *\n[ \t]*)(title))? *(?:\n+|$)/)

--- a/test/specs/new/blank_line_with_tabs.html
+++ b/test/specs/new/blank_line_with_tabs.html
@@ -1,0 +1,4 @@
+<p>foo</p>
+<p>bar</p>
+<p>baz</p>
+<p>qux</p>

--- a/test/specs/new/blank_line_with_tabs.md
+++ b/test/specs/new/blank_line_with_tabs.md
@@ -1,0 +1,10 @@
+---
+gfm: false
+---
+foo
+	
+bar
+
+baz
+	 	
+qux


### PR DESCRIPTION
**Markdown flavor:** CommonMark

A line that's only tabs (or tabs mixed with spaces) is a blank line in CommonMark, so it should separate paragraphs. Marked only treats a *spaces*-only line as blank, so when the blank line between two paragraphs happens to contain a tab, that line gets swallowed as a lazy continuation and the two paragraphs merge into one.

With a single tab on the middle line:

```
foo
	
bar
```

marked currently returns one paragraph (`<p>foo\tbar</p>`) instead of `<p>foo</p>\n<p>bar</p>`. A space-only middle line already works, which is what made this easy to miss.

The paragraph rule's continuation lookahead was checking for `` +\n`` (spaces only); I widened it to `[ \t]+\n` so a tab-only line counts as blank too. GFM and pedantic paragraphs build on the same base rule, so they pick up the fix as well. Added a spec test under `test/specs/new`.

## Contributor

- [x] Test added (`blank_line_with_tabs`)
- [x] No new feature to document
