### PR TITLE
fix: Avoid O(n^2) backtracking in inline link href regex

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -395,7 +395,7 @@ const _inlineLabel = /(?:\[(?:\\[\s\S]|[^\[\]\\])*\]|\\[\s\S]|`+(?!`)[^`]*?`+(?!
 
 const link = edit(/^!?\[(label)\]\(\s*(href)(?:(?:[ \t]+(?:\n[ \t]*)?|\n[ \t]*)(title))?\s*\)/)
   .replace('label', _inlineLabel)
-  .replace('href', /<(?:\\.|[^\n<>\\])+>|[^ \t\n\x00-\x1f]*/)
+  .replace('href', /<(?:\\.|[^\n<>\\])+>|[^ \t\n\x00-\x1f]+|(?=\))/)
   .replace('title', /"(?:\\"?|[^"\\])*"|'(?:\\'?|[^'\\])*'|\((?:\\\)?|[^)\\])*\)/)
   .getRegex();
 

--- a/test/specs/redos/quadratic_link_empty_href.cjs
+++ b/test/specs/redos/quadratic_link_empty_href.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  markdown: '[](' + ' '.repeat(50000),
+  html: '<p>[](' + ' '.repeat(50000) + '</p>',
+};


### PR DESCRIPTION
**Marked version:** current `master` (regex unchanged since 18.0.5)

**Markdown flavor:** n/a

## Description

The inline link regex parses an unclosed link followed by a long whitespace run in O(n²) time. `marked.parse('[](' + ' '.repeat(n))` is just text — an unclosed link — but with default options the parse time roughly quadruples each time the input doubles: n=16,000 → ~0.3 s, 32,000 → ~1.2 s, 64,000 → ~4.9 s, 125,000 → ~21 s.

The cause is the unquoted-href alternative `[^ \t\n\x00-\x1f]*` in `src/rules.ts`. Since it can match empty at any whitespace position, when there is no closing `)` the leading `\s*`, the (empty) href, the optional title separator, and the trailing `\s*\)` all re-partition the same whitespace run at ~n positions, so the engine backtracks quadratically. #3902 hardened the title separator (`[ \t]*` → `[ \t]+|\n`) against the same class of problem but left this zero-length href branch, so input that never reaches the title branch still backtracks.

The fix requires the unquoted-href branch to match at least one non-whitespace character (`*` → `+`) and keeps the legitimate empty-href case `[foo]()` via a `(?=\))` lookahead. CommonMark specifies that an unquoted link destination ends at whitespace, so requiring ≥1 non-whitespace character there is spec-correct. After the change the same input parses in linear time (64 KB → ~1 ms) and ordinary links are unaffected: the full spec and unit suites stay green (`test:specs` 1749/0, `test:unit` 188/0), and I added `test/specs/redos/quadratic_link_empty_href.cjs` next to the existing quadratic guards so any regression fails fast.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression: `test/specs/redos/quadratic_link_empty_href.cjs`.
- [ ] If submitting new feature, it has been documented in the appropriate places.
