### PR TITLE
fix: Avoid O(n^2) backtracking in HTML block close and tilde interrupt regexes

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -169,7 +169,7 @@ const createParagraph = (listInterrupt: RegExp) => edit(_paragraph)
   .replace('|lheading', '') // setext headings don't interrupt commonmark paragraphs
   .replace('|table', '')
   .replace('blockquote', ' {0,3}>')
-  .replace('fences', ' {0,3}(?:`{3,}(?=[^`\\n]*\\n)|~{3,})[^\\n]*\\n')
+  .replace('fences', ' {0,3}(?:`{3,}(?=[^`\\n]*\\n)|~~~)[^\\n]*\\n')
   .replace('list', listInterrupt)
   .replace('html', '</?(?:tag)(?: +|\\n|/?>)|<(?:script|pre|style|textarea|!--)')
   .replace('tag', _tag) // pars can be interrupted by type (6) html blocks
@@ -218,7 +218,7 @@ const gfmTable = edit(
   .replace('heading', ' {0,3}#{1,6}(?:\\s|$)')
   .replace('blockquote', ' {0,3}>')
   .replace('code', '(?: {4}| {0,3}\t)[^\\n]')
-  .replace('fences', ' {0,3}(?:`{3,}(?=[^`\\n]*\\n)|~{3,})[^\\n]*\\n')
+  .replace('fences', ' {0,3}(?:`{3,}(?=[^`\\n]*\\n)|~~~)[^\\n]*\\n')
   .replace('list', ' {0,3}(?:[*+-]|1[.)])[ \\t]') // any bullet ends the table rows
   .replace('html', '</?(?:tag)(?: +|\\n|/?>)|<(?:script|pre|style|textarea|!--)')
   .replace('tag', _tag) // tables can be interrupted by type (6) html blocks
@@ -234,7 +234,7 @@ const blockGfm: Record<BlockKeys, RegExp> = {
     .replace('|lheading', '') // setext headings don't interrupt commonmark paragraphs
     .replace('table', gfmTable) // interrupt paragraphs with table
     .replace('blockquote', ' {0,3}>')
-    .replace('fences', ' {0,3}(?:`{3,}(?=[^`\\n]*\\n)|~{3,})[^\\n]*\\n')
+    .replace('fences', ' {0,3}(?:`{3,}(?=[^`\\n]*\\n)|~~~)[^\\n]*\\n')
     .replace('list', ' {0,3}(?:[*+-]|1[.)])[ \\t]+[^ \\t\\n]') // only non-empty lists starting from 1 can interrupt
     .replace('html', '</?(?:tag)(?: +|\\n|/?>)|<(?:script|pre|style|textarea|!--)')
     .replace('tag', _tag) // pars can be interrupted by type (6) html blocks

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -149,11 +149,11 @@ const _tag = 'address|article|aside|base|basefont|blockquote|body|caption'
 const _comment = /<!--(?:-?>|[\s\S]*?(?:-->|$))/;
 const html = edit(
   '^ {0,3}(?:' // optional indentation
-+ '<(script|pre|style|textarea)[\\s>][\\s\\S]*?(?:</\\1>[^\\n]*\\n+|$)' // (1)
++ '<(script|pre|style|textarea)[\\s>][\\s\\S]*?(?:</\\1>[^\\n]*\\n*|$)' // (1)
 + '|comment[^\\n]*(\\n+|$)' // (2)
-+ '|<\\?[\\s\\S]*?(?:\\?>[^\\n]*\\n+|$)' // (3)
-+ '|<![A-Z][\\s\\S]*?(?:>[^\\n]*\\n+|$)' // (4)
-+ '|<!\\[CDATA\\[[\\s\\S]*?(?:\\]\\]>[^\\n]*\\n+|$)' // (5)
++ '|<\\?[\\s\\S]*?(?:\\?>[^\\n]*\\n*|$)' // (3)
++ '|<![A-Z][\\s\\S]*?(?:>[^\\n]*\\n*|$)' // (4)
++ '|<!\\[CDATA\\[[\\s\\S]*?(?:\\]\\]>[^\\n]*\\n*|$)' // (5)
 + '|</?(tag)(?: +|\\n|/?>)[\\s\\S]*?(?:(?:\\n[ \t]*)+\\n|$)' // (6)
 + '|<(?!script|pre|style|textarea)([a-z][\\w-]*)(?:attribute)*? */?>(?=[ \\t]*(?:\\n|$))[\\s\\S]*?(?:(?:\\n[ \t]*)+\\n|$)' // (7) open tag
 + '|</(?!script|pre|style|textarea)[a-z][\\w-]*\\s*>(?=[ \\t]*(?:\\n|$))[\\s\\S]*?(?:(?:\\n[ \t]*)+\\n|$)' // (7) closing tag

--- a/test/specs/redos/quadratic_html_block_close.cjs
+++ b/test/specs/redos/quadratic_html_block_close.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  markdown: '<!x ' + 'a>'.repeat(50000),
+  html: '<!x ' + 'a>'.repeat(50000),
+};

--- a/test/specs/redos/quadratic_tilde_paragraph_interrupt.cjs
+++ b/test/specs/redos/quadratic_tilde_paragraph_interrupt.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  markdown: 'intro\n' + '~'.repeat(50000),
+  html: `<p>intro\n${'~'.repeat(50000)}</p>\n`,
+};


### PR DESCRIPTION
Follow-up to #4013 — two more spots in `src/rules.ts` where a block-level regex backtracks quadratically on a long single line. Split into one commit each.

The first is the HTML block close. #3991 rewrote the close of the closing-tag, processing-instruction, declaration, and CDATA branches to `[^\n]*\n+` so trailing text on the close line is kept. Keeping the trailing text is right, but the `\n+` isn't: it requires at least one newline, so when the input ends without a trailing newline the close can never match and the engine retries every split point of the preceding lazy `[\s\S]*?` before finally falling through to `$`. That's O(n²):

```js
marked.parse('<!x ' + 'a>'.repeat(80000));            // ~5s
marked.parse('<script>' + 'a</script>'.repeat(40000)); // ~6.5s
```

Switching `\n+` back to `\n*` closes on the first match. Whenever a trailing newline is present (the normal case) `\n*` and `\n+` consume exactly the same text, so output is unchanged — #3991's own trailing-text fixtures still pass.

The second is the paragraph/table/blockquote interrupt check. Its fence sub-pattern is `` (?:`{3,}(?=[^`\n]*\n)|~{3,})[^\n]*\n ``. The backtick branch is guarded by a lookahead, but `~{3,}` isn't, and it overlaps with the following `[^\n]*`, so a long run of tildes with no newline backtracks quadratically:

```js
marked.parse('intro\n' + '~'.repeat(80000));           // ~5s
```

Because `~{3,}` is always immediately followed by `[^\n]*`, `~~~[^\n]*` matches exactly the same strings, so replacing `~{3,}` with `~~~` removes the overlap without changing what matches. The real fenced-code tokenizer (which captures the fence length via a group and a `$` alternative) is left untouched — only the three interrupt copies change.

Both changes are behavior-preserving: the full spec and unit suites pass with identical output, and I added a `quadratic_*.cjs` guard next to #4013's for each.
