### PR TITLE
fix: Avoid O(n^2) masked source rebuild in inline tokenizer

### DIFF
--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -304,33 +304,26 @@ export class _Lexer<ParserOutput = string, RendererOutput = string> {
     this.tokenizer.lexer = this;
     // String with links masked to avoid interference with em and strong
     let maskedSrc = src;
-    let match: RegExpExecArray | null = null;
 
     // Mask out reflinks
     if (this.tokens.links) {
       const links = Object.keys(this.tokens.links);
       if (links.length > 0) {
-        while ((match = this.tokenizer.rules.inline.reflinkSearch.exec(maskedSrc)) !== null) {
-          if (links.includes(match[0].slice(match[0].lastIndexOf('[') + 1, -1))) {
-            maskedSrc = maskedSrc.slice(0, match.index)
-              + '[' + 'a'.repeat(match[0].length - 2) + ']'
-              + maskedSrc.slice(this.tokenizer.rules.inline.reflinkSearch.lastIndex);
-          }
-        }
+        maskedSrc = maskedSrc.replace(this.tokenizer.rules.inline.reflinkSearch, match0 =>
+          links.includes(match0.slice(match0.lastIndexOf('[') + 1, -1))
+            ? '[' + 'a'.repeat(match0.length - 2) + ']'
+            : match0);
       }
     }
 
     // Mask out escaped characters
-    while ((match = this.tokenizer.rules.inline.anyPunctuation.exec(maskedSrc)) !== null) {
-      maskedSrc = maskedSrc.slice(0, match.index) + '++' + maskedSrc.slice(this.tokenizer.rules.inline.anyPunctuation.lastIndex);
-    }
+    maskedSrc = maskedSrc.replace(this.tokenizer.rules.inline.anyPunctuation, '++');
 
     // Mask out other blocks
-    let offset;
-    while ((match = this.tokenizer.rules.inline.blockSkip.exec(maskedSrc)) !== null) {
-      offset = match[2] ? match[2].length : 0;
-      maskedSrc = maskedSrc.slice(0, match.index + offset) + '[' + 'a'.repeat(match[0].length - offset - 2) + ']' + maskedSrc.slice(this.tokenizer.rules.inline.blockSkip.lastIndex);
-    }
+    maskedSrc = maskedSrc.replace(this.tokenizer.rules.inline.blockSkip, (match0, _link, context) => {
+      const offset = context ? context.length : 0;
+      return match0.slice(0, offset) + '[' + 'a'.repeat(match0.length - offset - 2) + ']';
+    });
 
     // Mask out blocks from extensions
     maskedSrc = this.options.hooks?.emStrongMask?.call({ lexer: this }, maskedSrc) ?? maskedSrc;

--- a/test/specs/redos/quadratic_inline_masking.cjs
+++ b/test/specs/redos/quadratic_inline_masking.cjs
@@ -1,0 +1,14 @@
+module.exports = [
+  {
+    markdown: '\\.'.repeat(100000),
+    html: `<p>${'.'.repeat(100000)}</p>`,
+  },
+  {
+    markdown: '`x` '.repeat(60000),
+    html: `<p>${'<code>x</code> '.repeat(60000)}</p>`,
+  },
+  {
+    markdown: '[a]: x\n\n' + '[a] '.repeat(100000),
+    html: `<p>${'<a href="x">a</a> '.repeat(100000)}</p>`,
+  },
+];


### PR DESCRIPTION
While looking for remaining quadratic paths after #4013/#4014, I found that the link-masking step in `Lexer.tokenize` is O(n²) on some ordinary inputs.

Before em/strong processing, `tokenize` masks out reflinks, escaped characters, and other inline blocks so they don't interfere. Each of the three masks ran a `while ((match = rule.exec(maskedSrc)))` loop that rebuilt the *entire* `maskedSrc` string on every match:

```js
while ((match = this.tokenizer.rules.inline.anyPunctuation.exec(maskedSrc)) !== null) {
  maskedSrc = maskedSrc.slice(0, match.index) + '++' + maskedSrc.slice(...lastIndex);
}
```

For an input with *k* matches that's *k* full-length string rebuilds — O(k·n), i.e. quadratic when the matches are dense. It's easy to hit with perfectly normal markdown: a paragraph full of escaped punctuation, many inline `` `code` `` spans, or many reference-style `[ref]` links. On my machine (`marked.parse` at HEAD):

| input | time |
|-------|------|
| `'\\.'.repeat(100000)` | ~2.4 s |
| `` '`x` '.repeat(60000) `` | ~1.6 s |
| `'[a]: x\n\n' + '[a] '.repeat(100000)` | ~4.3 s |

The masking regexes match linearly on their own — the cost is purely the repeated `slice`+concat rebuild, not the regex. This is the string-rebuild sibling of the em-mask work in #2818 (which fixed the *regex* side).

The fix replaces each hand-rolled loop with a single-pass `String.prototype.replace`, so the masked string is built once instead of *k* times. Every replacement is exactly the same length as what it replaces (reflink → `[` + `a`×(len−2) + `]`, escapes → `++`, blockSkip → context prefix + same-length padding), so the global regex's `lastIndex` bookkeeping is unaffected and the output is byte-identical — the whole spec suite (CommonMark, GFM, original, redos) passes unchanged. The three inputs above drop to ~5 ms / ~40 ms / ~68 ms and scale linearly.

I added `test/specs/redos/quadratic_inline_masking.cjs` covering the three shapes; each exceeds the redos harness's 1-second budget on `master` and passes with this change.
