### PR TITLE
fix: fall back to default checkbox renderer when extension returns false

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -50,7 +50,7 @@ export class _Parser<ParserOutput = string, RendererOutput = string> {
       if (this.options.extensions?.renderers?.[anyToken.type]) {
         const genericToken = anyToken as Tokens.Generic;
         const ret = this.options.extensions.renderers[genericToken.type].call({ parser: this }, genericToken);
-        if (ret !== false || !['space', 'hr', 'heading', 'code', 'table', 'blockquote', 'list', 'html', 'def', 'paragraph', 'text'].includes(genericToken.type)) {
+        if (ret !== false || !['space', 'hr', 'heading', 'code', 'table', 'blockquote', 'list', 'checkbox', 'html', 'def', 'paragraph', 'text'].includes(genericToken.type)) {
           out += ret || '';
           continue;
         }
@@ -136,7 +136,7 @@ export class _Parser<ParserOutput = string, RendererOutput = string> {
       // Run any renderer extensions
       if (this.options.extensions?.renderers?.[anyToken.type]) {
         const ret = this.options.extensions.renderers[anyToken.type].call({ parser: this }, anyToken);
-        if (ret !== false || !['escape', 'html', 'link', 'image', 'strong', 'em', 'codespan', 'br', 'del', 'text'].includes(anyToken.type)) {
+        if (ret !== false || !['escape', 'html', 'link', 'image', 'checkbox', 'strong', 'em', 'codespan', 'br', 'del', 'text'].includes(anyToken.type)) {
           out += ret || '';
           continue;
         }

--- a/test/unit/marked.test.js
+++ b/test/unit/marked.test.js
@@ -396,6 +396,32 @@ describe('marked unit', () => {
       assert.strictEqual(html, '<h1>extension1 RENDERER EXTENSION</h1>\n<pre><code>extension2 TOKENIZER EXTENSION\n</code></pre>\n');
     });
 
+    it('should fall back to the default checkbox renderer if the extension returns false', () => {
+      marked.use({
+        extensions: [{
+          name: 'checkbox',
+          renderer(token) {
+            return token.checked ? false : '<span class="todo"></span> ';
+          },
+        }],
+      });
+      const html = marked.parse('- [x] one\n- [ ] two\n');
+      assert.strictEqual(html, '<ul>\n<li><input checked="" disabled="" type="checkbox"> one</li>\n<li><span class="todo"></span> two</li>\n</ul>\n');
+    });
+
+    it('should fall back to the default checkbox renderer in a loose list if the extension returns false', () => {
+      marked.use({
+        extensions: [{
+          name: 'checkbox',
+          renderer() {
+            return false;
+          },
+        }],
+      });
+      const html = marked.parse('- [x] one\n\n- [ ] two\n');
+      assert.strictEqual(html, '<ul>\n<li><p><input checked="" disabled="" type="checkbox"> one</p>\n</li>\n<li><p><input disabled="" type="checkbox"> two</p>\n</li>\n</ul>\n');
+    });
+
     it('should walk only specified child tokens', () => {
       const walkableDescription = {
         extensions: [{


### PR DESCRIPTION
**Markdown flavor:** GitHub Flavored Markdown

A renderer extension named after a built-in token can return `false` to fall back to the default renderer — that's the documented contract in USING_PRO, and it works for `code`, `heading`, `text` and the rest. It doesn't work for `checkbox`: the checkbox silently disappears instead.

```js
const marked = new Marked({
  extensions: [{
    name: 'checkbox',
    renderer(token) {
      return token.checked ? false : '<span class="todo"></span> ';
    },
  }],
});

marked.parse('- [x] one\n- [ ] two\n');
```

I expected the checked item to fall back to the default `<input checked="" disabled="" type="checkbox">`, but it renders as just `<li>one</li>`. The unchecked item never returns `false`, and it renders fine, so only the fallback path is broken.

`Parser` decides whether a `false` return should fall through to the built-in renderer by testing the token type against a hardcoded list of built-in type names. `checkbox` was added to both parse switches in #3755 but never to either list, so the fallback branch is unreachable for it and the `ret || ''` path wins.

Added `checkbox` to the block and inline lists. Both matter in practice: a tight list puts the checkbox token at block level while a loose list puts it inline, so there's a test for each.

## Contributor

- [x] Tests added (checkbox extension fallback, tight and loose list)
- [x] No new feature to document
