### PR TITLE
docs: explain partial extensions in use

### DIFF
--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -18,7 +18,20 @@ export class Marked<ParserOutput = string, RendererOutput = string> {
   defaults = _getDefaults<ParserOutput, RendererOutput>();
   options = this.setOptions;
 
+  /**
+   * Compiles markdown to HTML.
+   *
+   * To configure hooks, a renderer, or a tokenizer, create a separate `Marked`
+   * instance and use `Marked#use` instead of passing them on each call.
+   */
   parse = this.parseMarkdown(true);
+
+  /**
+   * Compiles inline markdown to HTML.
+   *
+   * To configure hooks, a renderer, or a tokenizer, create a separate `Marked`
+   * instance and use `Marked#use` instead of passing them on each call.
+   */
   parseInline = this.parseMarkdown(false);
 
   Parser = _Parser<ParserOutput, RendererOutput>;
@@ -80,8 +93,7 @@ export class Marked<ParserOutput = string, RendererOutput = string> {
    * methods that should be overridden. Their methods are merged with built-in
    * behavior and extensions registered by earlier calls.
    *
-   * Use this method when supplying only some hook methods. In contrast, hooks
-   * passed in per-call parse or lexer options must be a complete Hooks instance.
+   * Use this method when supplying only some hook methods.
    */
   use(...args: MarkedExtension<ParserOutput, RendererOutput>[]) {
     const extensions: MarkedOptions<ParserOutput, RendererOutput>['extensions'] = this.defaults.extensions || { renderers: {}, childTokens: {} };

--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -73,6 +73,16 @@ export class Marked<ParserOutput = string, RendererOutput = string> {
     return values;
   }
 
+  /**
+   * Registers extensions with this Marked instance.
+   *
+   * The `renderer`, `tokenizer`, and `hooks` objects may each contain only the
+   * methods that should be overridden. Their methods are merged with built-in
+   * behavior and extensions registered by earlier calls.
+   *
+   * Use this method when supplying only some hook methods. In contrast, hooks
+   * passed in per-call parse or lexer options must be a complete Hooks instance.
+   */
   use(...args: MarkedExtension<ParserOutput, RendererOutput>[]) {
     const extensions: MarkedOptions<ParserOutput, RendererOutput>['extensions'] = this.defaults.extensions || { renderers: {}, childTokens: {} };
 

--- a/src/marked.ts
+++ b/src/marked.ts
@@ -39,6 +39,20 @@ export function marked(src: string, opt?: MarkedOptions | null): string | Promis
   return markedInstance.parse(src, opt);
 }
 
+export declare namespace marked {
+  /**
+   * Registers extensions with the default Marked instance.
+   *
+   * The `renderer`, `tokenizer`, and `hooks` objects may each contain only the
+   * methods that should be overridden. Their methods are merged with built-in
+   * behavior and extensions registered by earlier calls.
+   *
+   * Use this function when supplying only some hook methods. In contrast, hooks
+   * passed in per-call parse or lexer options must be a complete Hooks instance.
+   */
+  let use: (...args: MarkedExtension[]) => typeof marked;
+}
+
 /**
  * Sets the default options.
  *
@@ -60,15 +74,26 @@ marked.getDefaults = _getDefaults;
 marked.defaults = _defaults;
 
 /**
- * Use Extension
+ * Registers extensions with the default Marked instance.
+ *
+ * The `renderer`, `tokenizer`, and `hooks` objects may each contain only the
+ * methods that should be overridden. Their methods are merged with built-in
+ * behavior and extensions registered by earlier calls.
+ *
+ * Use this function when supplying only some hook methods. In contrast, hooks
+ * passed in per-call parse or lexer options must be a complete Hooks instance.
+ *
+ * @param args Extensions to register
+ * @return The `marked` function
  */
-
-marked.use = function(...args: MarkedExtension[]) {
+function useExtension(...args: MarkedExtension[]) {
   markedInstance.use(...args);
   marked.defaults = markedInstance.defaults;
   changeDefaults(marked.defaults);
   return marked;
-};
+}
+
+marked.use = useExtension;
 
 /**
  * Run callback for every token
@@ -102,7 +127,6 @@ marked.parse = marked;
 
 export const options = marked.options;
 export const setOptions = marked.setOptions;
-export const use = marked.use;
 export const walkTokens = marked.walkTokens;
 export const parseInline = marked.parseInline;
 export const parse = marked;
@@ -116,5 +140,6 @@ export { _Renderer as Renderer } from './Renderer.ts';
 export { _TextRenderer as TextRenderer } from './TextRenderer.ts';
 export { _Hooks as Hooks } from './Hooks.ts';
 export { Marked } from './Instance.ts';
+export { useExtension as use };
 export type * from './MarkedOptions.ts';
 export type * from './Tokens.ts';

--- a/src/marked.ts
+++ b/src/marked.ts
@@ -19,6 +19,9 @@ const markedInstance = new Marked();
 /**
  * Compiles markdown to HTML asynchronously.
  *
+ * To configure hooks, a renderer, or a tokenizer, create a `Marked` instance
+ * and use `Marked#use` instead of passing them as options on each call.
+ *
  * @param src String of markdown source to be compiled
  * @param options Hash of options, having async: true
  * @return Promise of string of compiled HTML
@@ -27,6 +30,9 @@ export function marked(src: string, options: MarkedOptions & { async: true }): P
 
 /**
  * Compiles markdown to HTML.
+ *
+ * To configure hooks, a renderer, or a tokenizer, create a `Marked` instance
+ * and use `Marked#use` instead of passing them as options on each call.
  *
  * @param src String of markdown source to be compiled
  * @param options Optional hash of options
@@ -41,14 +47,21 @@ export function marked(src: string, opt?: MarkedOptions | null): string | Promis
 
 export declare namespace marked {
   /**
+   * Compiles inline markdown to HTML.
+   *
+   * To configure hooks, a renderer, or a tokenizer, create a `Marked` instance
+   * and use `Marked#use` instead of passing them as options on each call.
+   */
+  let parseInline: typeof markedInstance.parseInline;
+
+  /**
    * Registers extensions with the default Marked instance.
    *
    * The `renderer`, `tokenizer`, and `hooks` objects may each contain only the
    * methods that should be overridden. Their methods are merged with built-in
    * behavior and extensions registered by earlier calls.
    *
-   * Use this function when supplying only some hook methods. In contrast, hooks
-   * passed in per-call parse or lexer options must be a complete Hooks instance.
+   * Use this function when supplying only some hook methods.
    */
   let use: (...args: MarkedExtension[]) => typeof marked;
 }
@@ -80,8 +93,7 @@ marked.defaults = _defaults;
  * methods that should be overridden. Their methods are merged with built-in
  * behavior and extensions registered by earlier calls.
  *
- * Use this function when supplying only some hook methods. In contrast, hooks
- * passed in per-call parse or lexer options must be a complete Hooks instance.
+ * Use this function when supplying only some hook methods.
  *
  * @param args Extensions to register
  * @return The `marked` function
@@ -106,6 +118,9 @@ marked.walkTokens = function(tokens: Token[] | TokensList, callback: (token: Tok
 /**
  * Compiles markdown to HTML without enclosing `p` tag.
  *
+ * To configure hooks, a renderer, or a tokenizer, create a `Marked` instance
+ * and use `Marked#use` instead of passing them as options on each call.
+ *
  * @param src String of markdown source to be compiled
  * @param options Hash of options
  * @return String of compiled HTML
@@ -128,6 +143,12 @@ marked.parse = marked;
 export const options = marked.options;
 export const setOptions = marked.setOptions;
 export const walkTokens = marked.walkTokens;
+/**
+ * Compiles inline markdown to HTML.
+ *
+ * To configure hooks, a renderer, or a tokenizer, create a `Marked` instance
+ * and use `Marked#use` instead of passing them as options on each call.
+ */
 export const parseInline = marked.parseInline;
 export const parse = marked;
 export const parser = _Parser.parse;


### PR DESCRIPTION
**Marked version:** 58ed4af62e7383ca770ac68aa987ca39887f33f3

**Markdown flavor:** n/a

## Description

- Fixes #4016.
- Adds source-level documentation to `Marked#use`, `marked.use`, and the named `use` export.
- Explains that `renderer`, `tokenizer`, and `hooks` can be partial when registered through `use`, because they are merged with built-in and previously registered behavior.
- Documents the default, instance, and inline parse APIs with the recommended per-call pattern: create separate `Marked` instances and configure each through `use` instead of passing hooks, renderers, or tokenizers on every call.

The named `use` export now aliases the documented implementation function so generated declarations expose the same IntelliSense text for both `marked.use` and `import { use }`.

## Contributor

- [x] no tests required for this documentation-only PR.
- [x] If submitting new feature, it has been documented in the appropriate places. (Not a new feature.)

Verification:

- `npm test` (build, 1,767 spec tests, 190 unit tests, UMD, CJS, package/type checks, and lint)
- `npm run test:types`
- `npm run test:lint`
- Generated-declaration inspection for default, instance, inline, and named APIs
- `git diff --check`
- `npm run build:reset`

Note: `docs/CONTRIBUTING.md` still mentions `npm run test:all`, but that script is not present in `package.json`; `npm test` is the current full pipeline.
