### PR TITLE
docs: move theme button to menu

### DIFF
--- a/docs/_document.html
+++ b/docs/_document.html
@@ -167,6 +167,17 @@
             />
           </a>
         </div>
+        <div class="flex justify-center px-4 mb-6">
+          <button
+            id="theme-toggle"
+            data-theme-mode="system"
+            aria-label="Switch theme"
+            class="flex items-center gap-2 px-4 py-2 rounded-lg text-subtle-light dark:text-subtle-dark hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors border border-border-light dark:border-border-dark"
+          >
+            <span class="material-icons" data-theme-icon>brightness_auto</span>
+            <span class="text-sm font-medium" data-theme-text>System</span>
+          </button>
+        </div>
         <nav class="flex flex-col space-y-6 w-52 pl-4 pt-2">
           <div>
             <h3
@@ -451,15 +462,6 @@
             <h1 class="text-5xl font-bold text-text-light dark:text-text-dark">
               Marked Documentation
             </h1>
-            <button
-              id="theme-toggle"
-              data-theme-mode="system"
-              aria-label="Switch theme"
-              class="flex items-center gap-2 px-4 py-2 rounded-lg text-subtle-light dark:text-subtle-dark hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-            >
-              <span class="material-icons" data-theme-icon>brightness_auto</span>
-              <span class="text-sm font-medium" data-theme-text>System</span>
-            </button>
           </div>
 
           <article

--- a/docs/css/shared.css
+++ b/docs/css/shared.css
@@ -33,10 +33,3 @@ a.github-corner:hover .octo-arm {
 	20%, 60% { transform: rotate(-25deg); }
 	40%, 80% { transform: rotate(10deg); }
 }
-
-/* Mobile: Hide GitHub corner on small screens */
-@media (max-width: 768px) {
-	a.github-corner {
-		display: none;
-	}
-}

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -162,10 +162,6 @@ pre {
   opacity: 1;
 }
 
-#theme-toggle:not(.demo) {
-  margin-right: 40px;
-}
-
 /* Mobile Styles - Changed breakpoint from 768px to 1024px */
 @media (max-width: 1024px) {
   /* Show mobile menu button */
@@ -196,26 +192,6 @@ pre {
     width: 100%;
   }
 
-  /* Adjust theme toggle button position on mobile */
-  #theme-toggle:not(.demo) {
-    position: fixed;
-    margin-right: 0;
-    top: 16px;
-    right: 80px;
-    z-index: 9998;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-    background-color: var(--background-color);
-  }
-
-  .dark #theme-toggle:not(.demo) {
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  }
-
-  /* Adjust GitHub corner for mobile */
-  .github-corner {
-    display: none;
-  }
-
   /* Make sidebar full height on mobile */
   .sidebar {
     width: 280px;
@@ -243,13 +219,6 @@ pre {
   .prose pre {
     font-size: 0.875rem;
     padding: 1rem;
-  }
-}
-
-@media (max-width: 768px) {
-  /* When github corner is invisible */
-  #theme-toggle:not(.demo) {
-    right: 16px;
   }
 }
 

--- a/docs/demo/demo.css
+++ b/docs/demo/demo.css
@@ -85,6 +85,10 @@ header h1 {
   .theme-toggle {
     margin-right: 0;
   }
+  
+  a.github-corner {
+	display: none !important;
+  }
 }
 
 .theme-toggle:hover {


### PR DESCRIPTION
## Description

Move the light/dark theme button to the menu. No need to have it in a fix position.

Always show the GitHub banner so it is easier to get to the GitHub repo on mobile.

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
