### PR TITLE
fix: place task checkboxes after list loose is finalized

### DIFF
--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -416,9 +416,22 @@ export class _Tokenizer<ParserOutput = string, RendererOutput = string> {
       list.raw = list.raw.trimEnd();
 
       // Item child tokens handled here at end because we needed to have the final item to trim it first
+      // First pass: tokenize items and finalize list.loose from spacers before placing checkboxes
       for (const item of list.items) {
         this.lexer.state.top = false;
         item.tokens = this.lexer.blockTokens(item.text, []);
+
+        if (!list.loose) {
+          // Check if list should be loose
+          const spacers = item.tokens.filter(t => t.type === 'space');
+          const hasMultipleLineBreaks = spacers.length > 0 && spacers.some(t => this.rules.other.anyLine.test(t.raw));
+
+          list.loose = hasMultipleLineBreaks;
+        }
+      }
+
+      // Second pass: place task checkboxes using the final list.loose
+      for (const item of list.items) {
         const itemToken = item.tokens[0];
         if (item.task && (itemToken?.type === 'text' || itemToken?.type === 'paragraph')) {
           // Remove checkbox markdown from item tokens
@@ -459,14 +472,6 @@ export class _Tokenizer<ParserOutput = string, RendererOutput = string> {
           }
         } else if (item.task) {
           item.task = false;
-        }
-
-        if (!list.loose) {
-          // Check if list should be loose
-          const spacers = item.tokens.filter(t => t.type === 'space');
-          const hasMultipleLineBreaks = spacers.length > 0 && spacers.some(t => this.rules.other.anyLine.test(t.raw));
-
-          list.loose = hasMultipleLineBreaks;
         }
       }
 

--- a/test/specs/new/list_loose_nested_tasks.html
+++ b/test/specs/new/list_loose_nested_tasks.html
@@ -1,0 +1,20 @@
+<ul>
+<li><p><input disabled="" type="checkbox"> Prepare the project</p>
+<ul>
+<li><input disabled="" type="checkbox"> Install dependencies</li>
+<li><input checked="" disabled="" type="checkbox"> Update Marked</li>
+<li><input disabled="" type="checkbox"> Check the rendering</li>
+</ul>
+</li>
+<li><p><input checked="" disabled="" type="checkbox"> Run the tests</p>
+<ul>
+<li><p><input checked="" disabled="" type="checkbox"> Test lists</p>
+</li>
+<li><p><input disabled="" type="checkbox"> Test tables</p>
+<ul>
+<li><input disabled="" type="checkbox"> Test nested cases</li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>

--- a/test/specs/new/list_loose_nested_tasks.md
+++ b/test/specs/new/list_loose_nested_tasks.md
@@ -1,0 +1,11 @@
+* [ ] Prepare the project
+
+  * [ ] Install dependencies
+  * [x] Update Marked
+  * [ ] Check the rendering
+* [x] Run the tests
+
+  * [x] Test lists
+  * [ ] Test tables
+
+    * [ ] Test nested cases


### PR DESCRIPTION
## Summary
- Finalize `list.loose` (including spacer-based detection) before placing task checkboxes in `Tokenizer.list()`.
- Nested loose task lists no longer leave early item checkboxes outside `<p>` while later items nest correctly.
- Adds a regression fixture for the nested loose task list case from #4045.

Fixes #4045

## Test plan
- [x] `npm run build`
- [x] `npm run test:specs` (1781 passed, including new `list_loose_nested_tasks` and existing task/list fixtures)
- [x] Manually confirmed loose items render checkboxes inside `<p>`; tight nested items stay without `<p>`