### PR TITLE
perf: optimize reference link masking

### DIFF
--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -1,7 +1,7 @@
 import { _Tokenizer } from './Tokenizer.ts';
 import { _defaults } from './defaults.ts';
 import { other, block, inline } from './rules.ts';
-import type { Links, Token, TokensList, Tokens } from './Tokens.ts';
+import type { Token, TokensList, Tokens } from './Tokens.ts';
 import type { MarkedOptions } from './MarkedOptions.ts';
 
 /**
@@ -19,7 +19,7 @@ export class _Lexer<ParserOutput = string, RendererOutput = string> {
   public inlineQueue: { src: string, tokens: Token[] }[];
 
   private tokenizer: _Tokenizer<ParserOutput, RendererOutput>;
-  private linksForInline: Links | null = null;
+
   constructor(options?: MarkedOptions<ParserOutput, RendererOutput>) {
     // TokenList cannot be created in one go
     this.tokens = [] as unknown as TokensList;
@@ -90,16 +90,9 @@ export class _Lexer<ParserOutput = string, RendererOutput = string> {
 
     this.blockTokens(src, this.tokens);
 
-    if (Object.keys(this.tokens.links).length > 0) {
-      this.linksForInline = this.tokens.links;
-    }
-    try {
-      for (let i = 0; i < this.inlineQueue.length; i++) {
-        const next = this.inlineQueue[i];
-        this.inlineTokens(next.src, next.tokens);
-      }
-    } finally {
-      this.linksForInline = null;
+    for (let i = 0; i < this.inlineQueue.length; i++) {
+      const next = this.inlineQueue[i];
+      this.inlineTokens(next.src, next.tokens);
     }
     this.inlineQueue = [];
 
@@ -313,23 +306,10 @@ export class _Lexer<ParserOutput = string, RendererOutput = string> {
     let maskedSrc = src;
 
     // Mask out reflinks
-    if (this.tokens.links) {
-      const linksForInline = this.linksForInline;
-      if (linksForInline) {
-        maskedSrc = maskedSrc.replace(this.tokenizer.rules.inline.reflinkSearch, match0 =>
-          Object.hasOwn(linksForInline, match0.slice(match0.lastIndexOf('[') + 1, -1))
-            ? '[' + 'a'.repeat(match0.length - 2) + ']'
-            : match0);
-      } else {
-        const links = Object.keys(this.tokens.links);
-        if (links.length > 0) {
-          maskedSrc = maskedSrc.replace(this.tokenizer.rules.inline.reflinkSearch, match0 =>
-            links.includes(match0.slice(match0.lastIndexOf('[') + 1, -1))
-              ? '[' + 'a'.repeat(match0.length - 2) + ']'
-              : match0);
-        }
-      }
-    }
+    maskedSrc = maskedSrc.replace(this.tokenizer.rules.inline.reflinkSearch, match0 =>
+      Object.hasOwn(this.tokens.links, match0.slice(match0.lastIndexOf('[') + 1, -1))
+        ? '[' + 'a'.repeat(match0.length - 2) + ']'
+        : match0);
 
     // Mask out escaped characters.
     // Every mask must keep the length it replaces: emStrong and del line

--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -1,7 +1,7 @@
 import { _Tokenizer } from './Tokenizer.ts';
 import { _defaults } from './defaults.ts';
 import { other, block, inline } from './rules.ts';
-import type { Token, TokensList, Tokens } from './Tokens.ts';
+import type { Links, Token, TokensList, Tokens } from './Tokens.ts';
 import type { MarkedOptions } from './MarkedOptions.ts';
 
 /**
@@ -19,7 +19,7 @@ export class _Lexer<ParserOutput = string, RendererOutput = string> {
   public inlineQueue: { src: string, tokens: Token[] }[];
 
   private tokenizer: _Tokenizer<ParserOutput, RendererOutput>;
-
+  private linksForInline: Links | null = null;
   constructor(options?: MarkedOptions<ParserOutput, RendererOutput>) {
     // TokenList cannot be created in one go
     this.tokens = [] as unknown as TokensList;
@@ -90,9 +90,16 @@ export class _Lexer<ParserOutput = string, RendererOutput = string> {
 
     this.blockTokens(src, this.tokens);
 
-    for (let i = 0; i < this.inlineQueue.length; i++) {
-      const next = this.inlineQueue[i];
-      this.inlineTokens(next.src, next.tokens);
+    if (Object.keys(this.tokens.links).length > 0) {
+      this.linksForInline = this.tokens.links;
+    }
+    try {
+      for (let i = 0; i < this.inlineQueue.length; i++) {
+        const next = this.inlineQueue[i];
+        this.inlineTokens(next.src, next.tokens);
+      }
+    } finally {
+      this.linksForInline = null;
     }
     this.inlineQueue = [];
 
@@ -307,12 +314,20 @@ export class _Lexer<ParserOutput = string, RendererOutput = string> {
 
     // Mask out reflinks
     if (this.tokens.links) {
-      const links = Object.keys(this.tokens.links);
-      if (links.length > 0) {
+      const linksForInline = this.linksForInline;
+      if (linksForInline) {
         maskedSrc = maskedSrc.replace(this.tokenizer.rules.inline.reflinkSearch, match0 =>
-          links.includes(match0.slice(match0.lastIndexOf('[') + 1, -1))
+          Object.hasOwn(linksForInline, match0.slice(match0.lastIndexOf('[') + 1, -1))
             ? '[' + 'a'.repeat(match0.length - 2) + ']'
             : match0);
+      } else {
+        const links = Object.keys(this.tokens.links);
+        if (links.length > 0) {
+          maskedSrc = maskedSrc.replace(this.tokenizer.rules.inline.reflinkSearch, match0 =>
+            links.includes(match0.slice(match0.lastIndexOf('[') + 1, -1))
+              ? '[' + 'a'.repeat(match0.length - 2) + ']'
+              : match0);
+        }
       }
     }
 


### PR DESCRIPTION
**Marked version:** 681373ccc058b5dc93c1f63291d755d7d714c2fa

**Markdown flavor:** n/a

## Description

Reference-link masking rebuilt `Object.keys(this.tokens.links)` for every
queued inline source, then linearly searched it for every candidate. At 2,000
definitions and paragraphs, that is about four million temporary key entries
and two million string comparisons.

This checks the existing table with `Object.hasOwn`, removing both costs without
adding lexer state or changing output.

## Performance

Thirty alternating fresh-process pairs on Node.js 26.7.0, with per-process
warmup. Values are medians; intervals are paired 95% bootstrap intervals.

| References | Baseline | Current | Change (95% interval) |
| ---: | ---: | ---: | ---: |
| 100 | 0.805 ms/op | 0.489 ms/op | -39.2% (-40.3, -38.8) |
| 500 | 11.512 ms/op | 2.265 ms/op | -80.4% (-80.5, -80.2) |
| 2,000 | 164.115 ms/op | 10.095 ms/op | -93.8% (-93.9, -93.8) |

A 2,000-paragraph no-definition control moved +1.3% (+0.3, +2.3). Guards that
avoid that scan also re-enumerated the link table and erased most of the target
gain, so this keeps the smaller implementation and scopes the claim.

## Validation

- `npm test`
- 1,779 specification tests and 190 unit tests passed
- ESM/UMD/CJS, type, build, and lint checks passed

## Contributor

- [x] Existing reference-link unit and CommonMark/GFM specification tests cover
  the unchanged parsing behavior.
- [x] No documentation is required because this does not add or change a
  feature.

## Committer

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following conventional commit guidelines.
