### PR TITLE
fix: escape character references in autolink destinations

### DIFF
--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -157,18 +157,24 @@ export class _Renderer<ParserOutput = string, RendererOutput = string> {
     return `<del>${this.parser.parseInline(tokens)}</del>` as RendererOutput;
   }
 
-  link({ href, title, tokens }: Tokens.Link): RendererOutput {
-    const text = this.parser.parseInline(tokens) as string;
+  link({ href, title, text, tokens, autolink }: Tokens.Link): RendererOutput {
+    // Character references are not resolved inside an autolink, so its
+    // destination and text are literal and every `&` has to be escaped.
+    // Elsewhere the destination still holds the source text, which is already
+    // valid in an attribute.
+    const parsedText = autolink
+      ? escapeHtmlEntities(text, true)
+      : this.parser.parseInline(tokens) as string;
     const cleanHref = cleanUrl(href);
     if (cleanHref === null) {
-      return text as RendererOutput;
+      return parsedText as RendererOutput;
     }
-    href = cleanHref;
+    href = autolink ? escapeHtmlEntities(cleanHref, true) : cleanHref;
     let out = '<a href="' + href + '"';
     if (title) {
       out += ' title="' + (escapeHtmlEntities(title)) + '"';
     }
-    out += '>' + text + '</a>';
+    out += '>' + parsedText + '</a>';
     return out as RendererOutput;
   }
 

--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -158,10 +158,8 @@ export class _Renderer<ParserOutput = string, RendererOutput = string> {
   }
 
   link({ href, title, text, tokens, autolink }: Tokens.Link): RendererOutput {
-    // Character references are not resolved inside an autolink, so its
-    // destination and text are literal and every `&` has to be escaped.
-    // Elsewhere the destination still holds the source text, which is already
-    // valid in an attribute.
+    // References are not resolved inside an autolink, so every `&` there is
+    // literal. Elsewhere only an `&` that cannot start one needs escaping.
     const parsedText = autolink
       ? escapeHtmlEntities(text, true)
       : this.parser.parseInline(tokens) as string;
@@ -169,7 +167,7 @@ export class _Renderer<ParserOutput = string, RendererOutput = string> {
     if (cleanHref === null) {
       return parsedText as RendererOutput;
     }
-    href = autolink ? escapeHtmlEntities(cleanHref, true) : cleanHref;
+    href = escapeHtmlEntities(cleanHref, autolink);
     let out = '<a href="' + href + '"';
     if (title) {
       out += ' title="' + (escapeHtmlEntities(title)) + '"';
@@ -188,7 +186,7 @@ export class _Renderer<ParserOutput = string, RendererOutput = string> {
     }
     href = cleanHref;
 
-    let out = `<img src="${href}" alt="${escapeHtmlEntities(text)}"`;
+    let out = `<img src="${escapeHtmlEntities(href)}" alt="${escapeHtmlEntities(text)}"`;
     if (title) {
       out += ` title="${escapeHtmlEntities(title)}"`;
     }

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -914,6 +914,7 @@ export class _Tokenizer<ParserOutput = string, RendererOutput = string> {
         raw: cap[0],
         text,
         href,
+        autolink: true,
         tokens: [
           {
             type: 'text',
@@ -951,6 +952,7 @@ export class _Tokenizer<ParserOutput = string, RendererOutput = string> {
         raw: cap[0],
         text,
         href,
+        autolink: true,
         tokens: [
           {
             type: 'text',

--- a/src/Tokens.ts
+++ b/src/Tokens.ts
@@ -136,6 +136,11 @@ export namespace Tokens {
     title?: string | null;
     text: string;
     tokens: Token[];
+    /**
+     * Set for autolinks and extended (GFM) urls, where character references are
+     * not resolved, so the destination and text are literal.
+     */
+    autolink?: boolean;
   }
 
   export interface List {

--- a/test/specs/new/link_destination_character_references.html
+++ b/test/specs/new/link_destination_character_references.html
@@ -1,7 +1,15 @@
 <p><a href="https://example.com/?x=1&amp;lt;2">https://example.com/?x=1&amp;lt;2</a></p>
+<p><a href="https://example.com/?y=1&amp;amp;2">https://example.com/?y=1&amp;amp;2</a></p>
+<p><a href="https://example.com/?a=1&amp;b=2">https://example.com/?a=1&amp;b=2</a></p>
 <p><a href="https://example.com/?x=1&amp;lt;2">https://example.com/?x=1&amp;lt;2</a></p>
-<p><a href="https://example.com/?a=1&amp;b=2">t</a></p>
-<p><a href="http://example.com?foo=1&amp;bar=2">example</a></p>
-<p><img src="http://example.com?foo=1&amp;bar=2" alt="i"></p>
-<p><a href="http://example.com?a=1&lt;2">t</a></p>
-<p><a href="https://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean">https://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean</a></p>
+<p><a href="https://example.com/?y=1&amp;amp;2">https://example.com/?y=1&amp;amp;2</a></p>
+<p><a href="https://example.com/?a=1&amp;b=2">https://example.com/?a=1&amp;b=2</a></p>
+<p><a href="https://example.com/?x=1&lt;2">https://example.com/?x=1&lt;2</a></p>
+<p><a href="https://example.com/?y=1&amp;2">https://example.com/?y=1&amp;2</a></p>
+<p><a href="https://example.com/?a=1&amp;b=2">https://example.com/?a=1&amp;b=2</a></p>
+<p><a href="https://example.com/?x=1&lt;2">https://example.com/?x=1&lt;2</a></p>
+<p><a href="https://example.com/?y=1&amp;2">https://example.com/?y=1&amp;2</a></p>
+<p><a href="https://example.com/?a=1&amp;b=2">https://example.com/?a=1&amp;b=2</a></p>
+<p><img src="https://example.com/?x=1&lt;2" alt="https://example.com/?x=1&lt;2"></p>
+<p><img src="https://example.com/?y=1&amp;2" alt="https://example.com/?y=1&amp;2"></p>
+<p><img src="https://example.com/?a=1&amp;b=2" alt="https://example.com/?a=1&amp;b=2"></p>

--- a/test/specs/new/link_destination_character_references.html
+++ b/test/specs/new/link_destination_character_references.html
@@ -1,0 +1,7 @@
+<p><a href="https://example.com/?x=1&amp;lt;2">https://example.com/?x=1&amp;lt;2</a></p>
+<p><a href="https://example.com/?x=1&amp;lt;2">https://example.com/?x=1&amp;lt;2</a></p>
+<p><a href="https://example.com/?a=1&amp;b=2">t</a></p>
+<p><a href="http://example.com?foo=1&amp;bar=2">example</a></p>
+<p><img src="http://example.com?foo=1&amp;bar=2" alt="i"></p>
+<p><a href="http://example.com?a=1&lt;2">t</a></p>
+<p><a href="https://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean">https://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean</a></p>

--- a/test/specs/new/link_destination_character_references.md
+++ b/test/specs/new/link_destination_character_references.md
@@ -1,4 +1,13 @@
 ---
+# Character references resolve in a link destination but not in an autolink, so
+# the same query string has to be escaped differently depending on where it is
+# written.
+#
+# The `&lt;` inline links, reference links and images below do not match
+# CommonMark. It resolves the reference and percent-encodes the result, giving
+# `?x=1%3C2`, where marked keeps `?x=1&lt;2`. That difference comes from URL
+# encoding rather than from this escaping, and it is the same on `master`.
+# Everything else here matches CommonMark.
 renderExact: true
 ---
 https://example.com/?x=1&lt;2

--- a/test/specs/new/link_destination_character_references.md
+++ b/test/specs/new/link_destination_character_references.md
@@ -1,16 +1,36 @@
 ---
 renderExact: true
 ---
-<https://example.com/?x=1&lt;2>
-
 https://example.com/?x=1&lt;2
 
-[t](https://example.com/?a=1&amp;b=2)
+https://example.com/?y=1&amp;2
 
-[example](http://example.com?foo=1&bar=2)
+https://example.com/?a=1&b=2
 
-![i](http://example.com?foo=1&bar=2)
+<https://example.com/?x=1&lt;2>
 
-[t](http://example.com?a=1&lt;2)
+<https://example.com/?y=1&amp;2>
 
-<https://foo.bar.baz/test?q=hello&id=22&boolean>
+<https://example.com/?a=1&b=2>
+
+[https://example.com/?x=1&lt;2](https://example.com/?x=1&lt;2)
+
+[https://example.com/?y=1&amp;2](https://example.com/?y=1&amp;2)
+
+[https://example.com/?a=1&b=2](https://example.com/?a=1&b=2)
+
+[https://example.com/?x=1&lt;2][link1]
+
+[https://example.com/?y=1&amp;2][link2]
+
+[https://example.com/?a=1&b=2][link3]
+
+![https://example.com/?x=1&lt;2](https://example.com/?x=1&lt;2)
+
+![https://example.com/?y=1&amp;2](https://example.com/?y=1&amp;2)
+
+![https://example.com/?a=1&b=2](https://example.com/?a=1&b=2)
+
+[link1]: https://example.com/?x=1&lt;2
+[link2]: https://example.com/?y=1&amp;2
+[link3]: https://example.com/?a=1&b=2

--- a/test/specs/new/link_destination_character_references.md
+++ b/test/specs/new/link_destination_character_references.md
@@ -1,0 +1,16 @@
+---
+renderExact: true
+---
+<https://example.com/?x=1&lt;2>
+
+https://example.com/?x=1&lt;2
+
+[t](https://example.com/?a=1&amp;b=2)
+
+[example](http://example.com?foo=1&bar=2)
+
+![i](http://example.com?foo=1&bar=2)
+
+[t](http://example.com?a=1&lt;2)
+
+<https://foo.bar.baz/test?q=hello&id=22&boolean>

--- a/test/unit/Lexer.test.js
+++ b/test/unit/Lexer.test.js
@@ -2042,6 +2042,7 @@ paragraph
                 raw: '<https://example.com>',
                 text: 'https://example.com',
                 href: 'https://example.com',
+                autolink: true,
                 tokens: [
                   {
                     type: 'text',
@@ -2064,6 +2065,7 @@ paragraph
                 raw: '<test@example.com>',
                 text: 'test@example.com',
                 href: 'mailto:test@example.com',
+                autolink: true,
                 tokens: [
                   {
                     type: 'text',
@@ -2085,6 +2087,7 @@ paragraph
                 raw: 'https://example.com',
                 text: 'https://example.com',
                 href: 'https://example.com',
+                autolink: true,
                 tokens: [
                   {
                     type: 'text',
@@ -2107,6 +2110,7 @@ paragraph
                 raw: 'test@example.com',
                 text: 'test@example.com',
                 href: 'mailto:test@example.com',
+                autolink: true,
                 tokens: [
                   {
                     type: 'text',

--- a/test/unit/marked.test.js
+++ b/test/unit/marked.test.js
@@ -10,64 +10,6 @@ describe('marked unit', () => {
     setOptions(getDefaults());
   });
 
-  describe('Character references in link destinations', () => {
-    // Character references are not resolved inside an autolink, so a `&` there
-    // is literal and has to be escaped. These assert on the exact output
-    // because the spec runner compares parsed HTML, where `&lt;` and `&amp;lt;`
-    // in an attribute are indistinguishable.
-    // https://github.com/markedjs/marked/issues/4052
-
-    it('should escape an ampersand in an autolink', () => {
-      assert.strictEqual(
-        marked.parse('<https://example.com/?x=1&lt;2>').trim(),
-        '<p><a href="https://example.com/?x=1&amp;lt;2">https://example.com/?x=1&amp;lt;2</a></p>',
-      );
-    });
-
-    it('should escape an ampersand in an extended url', () => {
-      assert.strictEqual(
-        marked.parse('https://example.com/?x=1&lt;2').trim(),
-        '<p><a href="https://example.com/?x=1&amp;lt;2">https://example.com/?x=1&amp;lt;2</a></p>',
-      );
-    });
-
-    it('should keep the destination of an inline link unchanged', () => {
-      assert.strictEqual(
-        marked.parse('[t](https://example.com/?a=1&amp;b=2)').trim(),
-        '<p><a href="https://example.com/?a=1&amp;b=2">t</a></p>',
-      );
-    });
-
-    it('should escape an ampersand that cannot start a reference', () => {
-      assert.strictEqual(
-        marked.parse('[example](http://example.com?foo=1&bar=2)').trim(),
-        '<p><a href="http://example.com?foo=1&amp;bar=2">example</a></p>',
-      );
-    });
-
-    it('should escape an ampersand in an image source', () => {
-      assert.strictEqual(
-        marked.parse('![i](http://example.com?foo=1&bar=2)').trim(),
-        '<p><img src="http://example.com?foo=1&amp;bar=2" alt="i"></p>',
-      );
-    });
-
-    it('should leave a reference in an inline destination alone', () => {
-      assert.strictEqual(
-        marked.parse('[t](http://example.com?a=1&lt;2)').trim(),
-        '<p><a href="http://example.com?a=1&lt;2">t</a></p>',
-      );
-    });
-
-    it('should match the CommonMark autolink example', () => {
-      // https://spec.commonmark.org/0.31.2/#example-595
-      assert.strictEqual(
-        marked.parse('<https://foo.bar.baz/test?q=hello&id=22&boolean>').trim(),
-        '<p><a href="https://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean">https://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean</a></p>',
-      );
-    });
-  });
-
   describe('Test paragraph token type', () => {
     it('should use the "paragraph" type on top level', () => {
       const md = 'A Paragraph.\n\n> A blockquote\n\n- list item\n';

--- a/test/unit/marked.test.js
+++ b/test/unit/marked.test.js
@@ -10,6 +10,43 @@ describe('marked unit', () => {
     setOptions(getDefaults());
   });
 
+  describe('Character references in link destinations', () => {
+    // Character references are not resolved inside an autolink, so a `&` there
+    // is literal and has to be escaped. These assert on the exact output
+    // because the spec runner compares parsed HTML, where `&lt;` and `&amp;lt;`
+    // in an attribute are indistinguishable.
+    // https://github.com/markedjs/marked/issues/4052
+
+    it('should escape an ampersand in an autolink', () => {
+      assert.strictEqual(
+        marked.parse('<https://example.com/?x=1&lt;2>').trim(),
+        '<p><a href="https://example.com/?x=1&amp;lt;2">https://example.com/?x=1&amp;lt;2</a></p>',
+      );
+    });
+
+    it('should escape an ampersand in an extended url', () => {
+      assert.strictEqual(
+        marked.parse('https://example.com/?x=1&lt;2').trim(),
+        '<p><a href="https://example.com/?x=1&amp;lt;2">https://example.com/?x=1&amp;lt;2</a></p>',
+      );
+    });
+
+    it('should keep the destination of an inline link unchanged', () => {
+      assert.strictEqual(
+        marked.parse('[t](https://example.com/?a=1&amp;b=2)').trim(),
+        '<p><a href="https://example.com/?a=1&amp;b=2">t</a></p>',
+      );
+    });
+
+    it('should match the CommonMark autolink example', () => {
+      // https://spec.commonmark.org/0.31.2/#example-595
+      assert.strictEqual(
+        marked.parse('<https://foo.bar.baz/test?q=hello&id=22&boolean>').trim(),
+        '<p><a href="https://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean">https://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean</a></p>',
+      );
+    });
+  });
+
   describe('Test paragraph token type', () => {
     it('should use the "paragraph" type on top level', () => {
       const md = 'A Paragraph.\n\n> A blockquote\n\n- list item\n';

--- a/test/unit/marked.test.js
+++ b/test/unit/marked.test.js
@@ -38,6 +38,27 @@ describe('marked unit', () => {
       );
     });
 
+    it('should escape an ampersand that cannot start a reference', () => {
+      assert.strictEqual(
+        marked.parse('[example](http://example.com?foo=1&bar=2)').trim(),
+        '<p><a href="http://example.com?foo=1&amp;bar=2">example</a></p>',
+      );
+    });
+
+    it('should escape an ampersand in an image source', () => {
+      assert.strictEqual(
+        marked.parse('![i](http://example.com?foo=1&bar=2)').trim(),
+        '<p><img src="http://example.com?foo=1&amp;bar=2" alt="i"></p>',
+      );
+    });
+
+    it('should leave a reference in an inline destination alone', () => {
+      assert.strictEqual(
+        marked.parse('[t](http://example.com?a=1&lt;2)').trim(),
+        '<p><a href="http://example.com?a=1&lt;2">t</a></p>',
+      );
+    });
+
     it('should match the CommonMark autolink example', () => {
       // https://spec.commonmark.org/0.31.2/#example-595
       assert.strictEqual(


### PR DESCRIPTION
Fixes #4052.

Following up on [my comment there](https://github.com/markedjs/marked/issues/4052#issuecomment-5302818703) — the one-line change the issue suggests regresses inline links, so this takes the narrower route instead.

## Why it is autolink-specific

CommonMark resolves character references in [link destinations](https://spec.commonmark.org/0.31.2/#link-destination) but [not in autolinks](https://spec.commonmark.org/0.31.2/#autolinks) ("backslash-escapes and entity references do not work in autolinks"). marked never resolves them anywhere — `token.href` keeps the literal source text — and that produces two different outcomes:

- **Inline link** `[t](…?x=1&lt;2)` — the destination value should be `?x=1<2`, which is written back into an attribute as `&lt;`. The unresolved source text is already exactly that, so the current output is right.
- **Autolink** `<…?x=1&lt;2>` — the destination value is the literal text `?x=1&lt;2`, which has to be written as `&amp;lt;`. Emitting it raw lets the browser decode it, so the link points at `?x=1<2`.

That is why escaping every destination breaks the first case while fixing the second:

| Input | before | escape everything | this PR |
| --- | --- | --- | --- |
| `<https://example.com/?x=1&lt;2>` | `?x=1&lt;2` ❌ | `?x=1&amp;lt;2` ✅ | `?x=1&amp;lt;2` ✅ |
| `[t](https://example.com/?a=1&amp;b=2)` | `?a=1&amp;b=2` ✅ | `?a=1&amp;amp;b=2` ❌ | `?a=1&amp;b=2` ✅ |

## The change

`Tokenizer.autolink()` and `Tokenizer.url()` now set `autolink: true` on the token, and `Renderer.link()` escapes the destination and the text with `escapeHtmlEntities(…, true)` when it is set. The flag is an optional addition to `Tokens.Link`, so existing custom renderers and extensions are unaffected.

The text needed it too, not just the href — for `<…?x=1&lt;2>` the anchor text was also rendering as `&lt;`, because the default text escaping deliberately skips anything that already looks like a reference. Both halves now match the expected output in the issue.

## This also fixes CommonMark example 595

[Example 595](https://spec.commonmark.org/0.31.2/#example-595) is in `test/specs/commonmark` with `shouldFail: false`, so it is expected to pass — but marked's actual output for it was:

```html
<a href="https://foo.bar.baz/test?q=hello&id=22&boolean">…&amp;id=22&amp;boolean</a>
```

against an expected `href` of `…?q=hello&amp;id=22&amp;boolean`. The href and the link text disagreed with each other.

It was reported as passing because the spec runner compares with `HtmlDiffer`, which parses both sides — and in an attribute, `&id=22` and `&amp;id=22` parse to the same value. That normalisation hides the difference whenever the text is not a valid reference. It only becomes visible with something like `&lt;`, where the two parse to *different* values, which is what the issue reporter demonstrated with parse5.

So the spec suite could not have caught this, and still cannot. I've written the new tests as exact string comparisons in `test/unit/marked.test.js` rather than adding spec fixtures, for that reason.

I have deliberately not touched the unresolved-reference behaviour itself — examples 32 and 33 are still marked `shouldFail`, and `[foo](/f&ouml;&ouml;)` still renders unchanged. That is the larger gap tracked in #4050 and wants its own discussion.

## Verification

- `test:specs` — 1779 pass, 0 fail, unchanged before and after.
- `test:unit` — 189 pass, up from 185; the 5 `exec` failures are pre-existing on `main` and fail identically with this change stashed.
- `tsc --noEmit` and `eslint` clean on the touched files.
- Removing the source change makes 3 of the 4 new tests fail; the fourth is the inline-link guard, which passes either way by design.

The four `Lexer` token assertions for autolinks and urls were updated for the new field.
