### PR TITLE
docs: replace nonexistent test:all script with npm test

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 - [ ] Be sure to run `npm install` or `npm update`.
 - [ ] Create a branch.
 - [ ] Update code in `src` folder. (`lib` folder is for auto compiled code)
-- [ ] Run `npm run test:all`, fix any broken things (for linting, you can run `npm run lint` to have the linter fix them for you).
+- [ ] Run `npm test`, fix any broken things (for linting, you can run `npm run lint` to have the linter fix them for you).
 - [ ] Run `npm run build:reset` to remove changes to compiled files.
 - [ ] Submit a Pull Request.
 


### PR DESCRIPTION
## Problem

The contributor checklist in `docs/CONTRIBUTING.md` tells contributors to run `npm run test:all`, but no script named `test:all` exists in `package.json`. Following the documented step fails:

```
$ npm run test:all
npm error Missing script: "test:all"
npm error
npm error Did you mean one of these?
npm error   npm install # Install a package
npm error   npm run test:cjs # run the "test:cjs" package script
```

## Solution

Replace `npm run test:all` with `npm test` in the checklist. The `test` script in `package.json` runs the full suite (`build:reset`, `build:docs`, `test:specs`, `test:unit`, `test:umd`, `test:cjs`, `test:types`, `test:lint`), which is the complete check a contributor needs before submitting.

## Verification

- Confirmed `test:all` does not exist in `package.json` (`rg '"test' package.json` lists all test scripts; none is `test:all`).
- Confirmed `npm run test:all` fails with "Missing script".
- Confirmed `npm test` is the full-suite script defined in `package.json`.
