### PR TITLE
fix: keep emphasis in the text of a rejected reference link

### DIFF
--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -301,6 +301,40 @@ export class _Lexer<ParserOutput = string, RendererOutput = string> {
   }
 
   /**
+   * Does this link text hold a link already? An image does not count: an image
+   * may hold a link, a link may not.
+   */
+  private linkInText(text: string, links: string[]): boolean {
+    if (!text.includes('[')) {
+      return false;
+    }
+
+    const linkRule = this.tokenizer.rules.inline.link;
+    for (const match of text.matchAll(this.tokenizer.rules.inline.blockSkip)) {
+      // blockSkip also matches code spans and html, and the `!` of an image is
+      // left out of the match, so read the character before it.
+      if (linkRule.test(match[0]) && text.charAt(match.index - 1) !== '!') {
+        return true;
+      }
+    }
+
+    for (const match of text.matchAll(this.tokenizer.rules.inline.reflinkSearch)) {
+      const match0 = match[0];
+      const refStart = match0.lastIndexOf('[');
+      if (match0.charAt(0) === '!' || !links.includes(match0.slice(refStart + 1, -1))) {
+        continue;
+      }
+      // a candidate holding a link is not a link either, so it does not count
+      if (refStart > 1 && this.linkInText(match0.slice(1, refStart - 1), links)) {
+        continue;
+      }
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
    * Lexing/Compiling
    */
   inlineTokens(src: string, tokens: Token[] = []): Token[] {
@@ -312,10 +346,27 @@ export class _Lexer<ParserOutput = string, RendererOutput = string> {
     if (this.tokens.links) {
       const links = Object.keys(this.tokens.links);
       if (links.length > 0) {
-        maskedSrc = maskedSrc.replace(this.tokenizer.rules.inline.reflinkSearch, match0 =>
-          links.includes(match0.slice(match0.lastIndexOf('[') + 1, -1))
-            ? '[' + 'a'.repeat(match0.length - 2) + ']'
-            : match0);
+        const reflinkSearch = this.tokenizer.rules.inline.reflinkSearch;
+        const maskReflink = (match0: string): string => {
+          const refStart = match0.lastIndexOf('[');
+          if (!links.includes(match0.slice(refStart + 1, -1))) {
+            return match0;
+          }
+          // CommonMark: "Links may not contain other links, at any level of
+          // nesting." A candidate whose text already holds one never becomes a
+          // link, so flattening the whole span would hide the emphasis that
+          // does still apply inside it. Mask the links it holds instead.
+          // Images are exempt: their text is flattened into an alt attribute.
+          if (refStart > 1 && match0.charAt(0) !== '!') {
+            const text = match0.slice(1, refStart - 1);
+            if (this.linkInText(text, links)) {
+              return '[' + text.replace(reflinkSearch, maskReflink)
+                + '][' + 'a'.repeat(match0.length - refStart - 2) + ']';
+            }
+          }
+          return '[' + 'a'.repeat(match0.length - 2) + ']';
+        };
+        maskedSrc = maskedSrc.replace(reflinkSearch, maskReflink);
       }
     }
 

--- a/test/specs/commonmark/commonmark.0.31.2.json
+++ b/test/specs/commonmark/commonmark.0.31.2.json
@@ -4269,8 +4269,7 @@
     "example": 533,
     "start_line": 8053,
     "end_line": 8059,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "*[foo*][ref]\n\n[ref]: /uri\n",

--- a/test/specs/gfm/commonmark.0.31.2.json
+++ b/test/specs/gfm/commonmark.0.31.2.json
@@ -4269,8 +4269,7 @@
     "example": 533,
     "start_line": 8053,
     "end_line": 8059,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "*[foo*][ref]\n\n[ref]: /uri\n",

--- a/test/specs/new/emphasis_in_link_text_with_link.html
+++ b/test/specs/new/emphasis_in_link_text_with_link.html
@@ -1,0 +1,4 @@
+<p>[foo <em>bar <a href="/url">baz</a> qux</em>]<a href="/uri">ref</a></p>
+<p>[foo <em>bar <a href="/uri">baz</a> qux</em>]<a href="/uri">ref</a></p>
+<p><a href="/uri">foo <em>bar <img src="/img.png" alt="baz"> qux</em></a></p>
+<p>*foo <a href="/uri">bar*</a></p>

--- a/test/specs/new/emphasis_in_link_text_with_link.md
+++ b/test/specs/new/emphasis_in_link_text_with_link.md
@@ -1,0 +1,9 @@
+[foo *bar [baz](/url) qux*][ref]
+
+[foo _bar [baz][ref] qux_][ref]
+
+[foo *bar ![baz](/img.png) qux*][ref]
+
+*foo [bar*][ref]
+
+[ref]: /uri


### PR DESCRIPTION
**Marked version:** `18.0.10`, current `main` at e250e31

**Markdown flavor:** CommonMark|GitHub Flavored Markdown

## Description

No issue for this one. It is what is left of the group I listed in #4050 after #4051 landed: the tokenizer now refuses to nest a link inside a link, but the mask that `emStrong` reads was not told, so it still treats the rejected candidate as a link and hides every emphasis marker inside it.

## Expectation

```
[foo *bar [baz](/url) qux*][ref]

[ref]: /uri
```

```html
<p>[foo <em>bar <a href="/url">baz</a> qux</em>]<a href="/uri">ref</a></p>
```

`commonmark` 0.31.2, already a dev dependency here, returns exactly that.

## Result

```html
<p>[foo *bar <a href="/url">baz</a> qux*]<a href="/uri">ref</a></p>
```

The asterisks are printed as text. The reference link and the inner link are both right, only the emphasis is gone. Same with `_`, with `**`, and when the inner link is a reference link instead of an inline one, which is CommonMark example 533.

The trigger is narrow but it is ordinary prose: a reference link whose text happens to hold another link. Nothing warns the author, the markers just disappear from the output.

## What was attempted

`inlineTokens` masks a reference link candidate by replacing the whole span with `[aaaa...]`, so `emStrong` cannot pair a delimiter outside a link with one inside it. That is the right call when the candidate really is a link, because the link text is tokenized separately.

When the text already holds a link the candidate is not a link, #4051 made `outputLink` say so, and the span goes back through the loop as ordinary text. The mask built before the loop still reads `[aaaa...]` there, so the `*` never reaches `emStrong`.

The mask now follows the same rule the tokenizer follows. A candidate whose text holds a link keeps its brackets and its emphasis markers visible, and the links inside it are masked instead. Images are left on the old path, since an image may hold a link.

`linkInText` answers the question. It returns on `text.includes('[')` before touching a regex, so text without brackets costs nothing, and it skips images in both directions: an image inside link text does not disqualify the outer candidate, and an image candidate is never disqualified by what it holds.

I first tried rebuilding the mask from the lexer loop whenever a candidate was rejected. It is a smaller diff and it reads better, but it is quadratic in the number of rejections in one inline run, and a paragraph with 400 of them went from 10.1 ms to 44.6 ms. Given #4040 and #4048 are open on this very block, that seemed like the wrong thing to hand you.

## Scope

Fixes CommonMark example 533. `shouldFail` cleared in `test/specs/commonmark/` and in `test/specs/gfm/`, Links goes from 80 to 81 of 90.

512, 520 and 528 are still failing and are not touched here. They share a title with 533 in my grouping but not a cause: they need `_inlineLabel` to match more than one level of nested brackets, which is a different change.

## Measurements

Differential run over 317 inputs, combinations of brackets, emphasis, inline links, reference links, images and code spans, plus every file in `test/specs/new`, in both flavors, against the bundled `commonmark`:

* 18 outputs changed, which is the same 9 inputs once per flavor
* 8 of those 9 went from disagreeing with the reference to matching it byte for byte
* the 9th is the new spec file, where the only remaining difference is `<img ...>` against `<img ... />`
* nothing moved away from the reference

Timing on Node 22.20.0, best of five runs:

| input | before | after |
| --- | --- | --- |
| README plus USING_PRO, 20 copies | 21.12 ms | 20.77 ms |
| 2000 reference definitions and 2000 uses | 206.01 ms | 205.69 ms |
| 400 rejected candidates in one paragraph | 5.22 ms | 4.62 ms |
| 300 levels of nesting | 0.63 ms | 0.59 ms |

`npm test` is green: 1785 spec tests, 191 unit tests, plus umd, cjs, types and lint.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.
