### PR TITLE
test: add test case for parseInline with empty input

### DIFF
--- a/test/unit/marked.test.js
+++ b/test/unit/marked.test.js
@@ -56,6 +56,12 @@ describe('marked unit', () => {
 
       assert.strictEqual(html, '# header\n\n<em>em</em>');
     });
+
+    it('should return empty string for empty input', () => {
+      const html = parseInline('');
+
+      assert.strictEqual(html, '');
+    });
   });
 
   describe('link in link text', () => {


### PR DESCRIPTION
### Summary
- In `test/unit/marked.test.js`, add a unit test verifying that `parseInline('')` returns an empty string.