### PR TITLE
fix: escape HTML entities in link href and image src attributes

### DIFF
--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -163,7 +163,7 @@ export class _Renderer<ParserOutput = string, RendererOutput = string> {
     if (cleanHref === null) {
       return text as RendererOutput;
     }
-    href = cleanHref;
+    href = cleanHref.replace(/&/g, '&amp;');
     let out = '<a href="' + href + '"';
     if (title) {
       out += ' title="' + (escapeHtmlEntities(title)) + '"';
@@ -180,7 +180,7 @@ export class _Renderer<ParserOutput = string, RendererOutput = string> {
     if (cleanHref === null) {
       return escapeHtmlEntities(text) as RendererOutput;
     }
-    href = cleanHref;
+    href = cleanHref.replace(/&/g, '&amp;');
 
     let out = `<img src="${href}" alt="${escapeHtmlEntities(text)}"`;
     if (title) {

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -5,6 +5,7 @@ import {
   findClosingBracket,
   expandTabs,
   trimTrailingBlankLines,
+  decodeHtmlEntities,
 } from './helpers.ts';
 import type { Rules } from './rules.ts';
 import type { _Lexer } from './Lexer.ts';
@@ -736,8 +737,12 @@ export class _Tokenizer<ParserOutput = string, RendererOutput = string> {
           href = href.slice(1, -1);
         }
       }
+      // Decode HTML entities in inline link destinations per CommonMark spec.
+      // Entity references (e.g. &amp;) are recognized in link destinations
+      // but not in autolinks. The renderer will re-escape on output.
+      const decodedHref = href ? decodeHtmlEntities(href.replace(this.rules.inline.anyPunctuation, '$1')) : href;
       return outputLink(cap, {
-        href: href ? href.replace(this.rules.inline.anyPunctuation, '$1') : href,
+        href: decodedHref,
         title: title ? title.replace(this.rules.inline.anyPunctuation, '$1') : title,
       }, cap[0], this.lexer, this.rules);
     }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -26,6 +26,28 @@ export function escapeHtmlEntities(html: string, encode?: boolean) {
   return html;
 }
 
+/**
+ * Decode HTML character entities (e.g. &amp; -> &, &lt; -> <).
+ * Used for inline link destinations where CommonMark requires
+ * entity decoding before output escaping.
+ */
+export function decodeHtmlEntities(html: string): string {
+  return html
+    .replace(/&(?:#x([0-9a-fA-F]+)|#(\d+)|(\w+));/g, (_, hex, dec, named) => {
+      if (hex) return String.fromCodePoint(parseInt(hex, 16));
+      if (dec) return String.fromCodePoint(parseInt(dec, 10));
+      switch (named) {
+        case 'amp': return '&';
+        case 'lt': return '<';
+        case 'gt': return '>';
+        case 'quot': return '"';
+        case 'apos': return "'";
+        case '#39': return "'";
+        default: return _;
+      }
+    });
+}
+
 export function cleanUrl(href: string) {
   try {
     href = encodeURI(href).replace(other.percentDecode, '%');

--- a/test/unit/marked.test.js
+++ b/test/unit/marked.test.js
@@ -1122,4 +1122,34 @@ br
       assert.strictEqual(html.trim(), '<p><em>text</em></p>');
     });
   });
+
+    describe('HTML entity escaping in link hrefs', () => {
+      it('should escape & in autolink hrefs (CommonMark example 595)', () => {
+        const result = marked.parse('<https://foo.bar.baz/test?q=hello&id=22&boolean>');
+        assert.strictEqual(
+          result.trim(),
+          '<p><a href="https://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean">https://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean</a></p>',
+        );
+      });
+
+      it('should decode &amp; in inline link hrefs and re-escape on output', () => {
+        const result = marked.parse('[t](https://example.com/?a=1&amp;b=2)');
+        assert.ok(result.includes('href="https://example.com/?a=1&amp;b=2"'));
+      });
+
+      it('should escape & in plain autolink URLs', () => {
+        const result = marked.parse('<https://example.com/?a=1&b=2>');
+        assert.ok(result.includes('href="https://example.com/?a=1&amp;b=2"'));
+      });
+
+      it('should escape &lt; in autolink hrefs', () => {
+        const result = marked.parse('<https://example.com/?x=1&lt;2>');
+        assert.ok(result.includes('href="https://example.com/?x=1&amp;lt;2"'));
+      });
+
+      it('should escape & in image src attributes', () => {
+        const result = marked.parse('![img](https://example.com/?a=1&b=2)');
+        assert.ok(result.includes('src="https://example.com/?a=1&amp;b=2"'));
+      });
+    });
 });


### PR DESCRIPTION
## Summary

Fixes #4052

The renderer wrote `cleanUrl(href)` directly into `href`/ attributes without escaping `&` to `&amp;`. This caused silent link-target corruption for URLs containing valid HTML entity sequences (`&lt;`, `&amp;`, `&copy;`, etc.).

### The bug

```js
marked('<https://example.com/?x=1&lt;2>')
// Actual:   href="...?x=1&lt;2"    (browser decodes to ...?x=1<2 — WRONG)
// Expected: href="...?x=1&amp;lt;2" (browser decodes to ...?x=1&lt;2 — CORRECT)
```

Any URL containing a valid entity sequence silently changes the link target. This also affects CommonMark example 595.

### Root cause

Two issues:

1. **Renderer** — `cleanUrl()` runs `encodeURI()` which never encodes `&`, so the raw `&` reaches the HTML attribute unescaped.
2. **Tokenizer** — inline link destinations (`[text](url)`) kept HTML entities literal (`&amp;` stayed as `&amp;`), which is correct per CommonMark, but the renderer never escaped them on output.

### Fix (2 parts)

1. **Tokenizer** (`src/Tokenizer.ts`) — Decode HTML entities in inline link destinations before rendering, per CommonMark spec (entity references are recognized in link destinations but not in autolinks).

2. **Renderer** (`src/Renderer.ts`) — Escape `&` → `&amp;` in `href`/ attributes after `cleanUrl()`, ensuring valid HTML output.

3. **Helper** (`src/helpers.ts`) — Added `decodeHtmlEntities()` function for named/numeric character reference decoding.

### Test results

- ✅ All 1783 CommonMark spec tests pass (no regressions)
- ✅ All 196 unit tests pass (including 5 new regression tests)
- ✅ CommonMark example 595 now produces correct output

### Regression tests added

5 new test cases in `test/unit/marked.test.js` covering:
- Autolink with `&` (CommonMark example 595)
- Inline link with `&amp;` entity
- Plain autolink URL with `&`
- Autolink with `&lt;` entity
- Image with `&` in src