### PR TITLE
fix: respect raw tokens when closing link labels

### DIFF
--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -77,6 +77,43 @@ function indentCodeCompensation(raw: string, text: string, rules: Rules) {
     .join('\n');
 }
 
+function isLabelEndInsideToken(src: string, label: string, labelStart: number, rules: Rules) {
+  if (!label.includes('<')) {
+    return false;
+  }
+
+  for (let i = 0; i < label.length; i++) {
+    if (label[i] === '\\') {
+      i++;
+      continue;
+    }
+
+    if (label[i] === '`') {
+      const code = rules.inline.code.exec(label.slice(i));
+      if (code) {
+        i += code[0].length - 1;
+        continue;
+      }
+    }
+
+    if (label[i] !== '<') {
+      continue;
+    }
+
+    const tokenSrc = src.slice(labelStart + i);
+    const token = rules.inline.tag.exec(tokenSrc) || rules.inline.autolink.exec(tokenSrc);
+    if (!token) {
+      continue;
+    }
+
+    if (token[0].length > label.length - i) {
+      return true;
+    }
+    i += token[0].length - 1;
+  }
+  return false;
+}
+
 /**
  * Tokenizer
  */
@@ -685,6 +722,11 @@ export class _Tokenizer<ParserOutput = string, RendererOutput = string> {
   link(src: string): Tokens.Link | Tokens.Image | undefined {
     const cap = this.rules.inline.link.exec(src);
     if (cap) {
+      const labelStart = cap[0].charAt(0) === '!' ? 2 : 1;
+      if (!this.options.pedantic && isLabelEndInsideToken(src, cap[1], labelStart, this.rules)) {
+        return;
+      }
+
       const trimmedUrl = cap[2].trim();
       if (!this.options.pedantic && this.rules.other.startAngleBracket.test(trimmedUrl)) {
         // commonmark requires matching angle brackets
@@ -747,6 +789,11 @@ export class _Tokenizer<ParserOutput = string, RendererOutput = string> {
     let cap;
     if ((cap = this.rules.inline.reflink.exec(src))
       || (cap = this.rules.inline.nolink.exec(src))) {
+      const labelStart = cap[0].charAt(0) === '!' ? 2 : 1;
+      if (!this.options.pedantic && isLabelEndInsideToken(src, cap[1], labelStart, this.rules)) {
+        return;
+      }
+
       const linkString = (cap[2] || cap[1]).replace(this.rules.other.multipleSpaceGlobal, ' ');
       const link = links[linkString.toLowerCase()];
       if (!link) {

--- a/test/specs/commonmark/commonmark.0.31.2.json
+++ b/test/specs/commonmark/commonmark.0.31.2.json
@@ -4194,8 +4194,7 @@
     "example": 524,
     "start_line": 7937,
     "end_line": 7941,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "[foo`](/uri)`\n",
@@ -4211,8 +4210,7 @@
     "example": 526,
     "start_line": 7951,
     "end_line": 7955,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "[foo][bar]\n\n[bar]: /url \"title\"\n",
@@ -4294,8 +4292,7 @@
     "example": 536,
     "start_line": 8089,
     "end_line": 8095,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "[foo`][ref]`\n\n[ref]: /uri\n",
@@ -4311,8 +4308,7 @@
     "example": 538,
     "start_line": 8107,
     "end_line": 8113,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "[foo][BaR]\n\n[bar]: /url \"title\"\n",

--- a/test/specs/gfm/commonmark.0.31.2.json
+++ b/test/specs/gfm/commonmark.0.31.2.json
@@ -4194,8 +4194,7 @@
     "example": 524,
     "start_line": 7937,
     "end_line": 7941,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "[foo`](/uri)`\n",
@@ -4211,8 +4210,7 @@
     "example": 526,
     "start_line": 7951,
     "end_line": 7955,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "[foo][bar]\n\n[bar]: /url \"title\"\n",
@@ -4294,8 +4292,7 @@
     "example": 536,
     "start_line": 8089,
     "end_line": 8095,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "[foo`][ref]`\n\n[ref]: /uri\n",
@@ -4311,8 +4308,7 @@
     "example": 538,
     "start_line": 8107,
     "end_line": 8113,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "[foo][BaR]\n\n[bar]: /url \"title\"\n",


### PR DESCRIPTION
**Marked version:** master (18.0.10)

**Markdown flavor:** CommonMark and GitHub Flavored Markdown

## Description

Addresses the independent raw-HTML/autolink precedence group in #4050 (CommonMark examples 524, 526, 536, and 538).

The inline link and reference-link regexes could treat a `]` inside a still-open raw HTML tag or autolink as the end of the link label. The tokenizer now checks labels containing `<` and rejects that candidate close when the matching raw token extends past it. Escaped characters and code spans are skipped during the check, and ordinary labels use an early fast path.

The existing CommonMark and GFM snapshots for all four examples are now passing, increasing link compliance from 80/90 to 84/90 in both suites.

AI disclosure: OpenAI Codex assisted with repository research, implementation, and validation. I reviewed the parser behavior, corrected the spec fixtures manually, ran the complete project test pipeline, and remain responsible for the contribution.

## Contributor

- [x] Tests exist to ensure functionality and minimize regression: CommonMark/GFM examples 524, 526, 536, and 538.
- [x] No documentation change is required; this brings existing supported-spec behavior into compliance.

## Validation

- `npm test` — passed
  - 1,783 specification tests
  - 191 unit tests
  - UMD and CommonJS tests
  - TypeScript/API compatibility checks
  - ESLint
- `npm run build:reset` — generated artifacts removed before submission
