### PR TITLE
fix: support GFM protocol autolinks

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -464,6 +464,10 @@ const reflinkSearch = edit('reflink|nolink(?!\\()', 'g')
   .getRegex();
 
 const _caseInsensitiveProtocol = /[hH][tT][tT][pP][sS]?|[fF][tT][pP]/;
+const _extendedEmail = /[A-Za-z0-9._+-]+@[a-zA-Z0-9-_]+(?:\.[a-zA-Z0-9-_]*[a-zA-Z0-9])+(?![\w-])/;
+const _extendedEmailProtocol = edit(/(?:mailto:email|xmpp:email(?:\/[A-Za-z0-9@.]+)?)/)
+  .replace(/email/g, _extendedEmail)
+  .getRegex();
 
 /**
  * Normal Inline Grammar
@@ -522,14 +526,16 @@ const inlineGfm: Record<InlineKeys, RegExp> = {
   emStrongLDelim: emStrongLDelimGfm,
   delLDelim,
   delRDelim,
-  url: edit(/^((?:protocol):\/\/|www\.)(?:[a-zA-Z0-9\-]+\.?)+[^\s<]*|^email/)
+  url: edit(/^emailProtocol|^((?:protocol):\/\/|www\.)(?:[a-zA-Z0-9\-]+\.?)+[^\s<]*|^email/)
+    .replace('emailProtocol', _extendedEmailProtocol)
     .replace('protocol', _caseInsensitiveProtocol)
     .replace('email', /[A-Za-z0-9._+-]+(@)[a-zA-Z0-9-_]+(?:\.[a-zA-Z0-9-_]*[a-zA-Z0-9])+(?![-_])/)
     .getRegex(),
   _backpedal: /(?:[^?!.,:;*_'"~()&]+|\([^)]*\)|&(?![a-zA-Z0-9]+;$)|[?!.,:;*_'"~)]+(?!$))+/,
   del: /^(~~?)(?=[^\s~])((?:\\[\s\S]|[^\\])*?(?:\\[\s\S]|[^\s~\\]))\1(?=[^~]|$)/,
-  text: edit(/^(`+|~+|[^`~])(?:(?=[`~])|(?= {2,}\n)|(?=[a-zA-Z0-9.!#$%&'*+\/=?_`{\|}~-]+@)|[\s\S]*?(?:(?=[\\<!\[`*~_]|\b_|protocol:\/\/|www\.|$)|[^ ](?= {2,}\n)|[^a-zA-Z0-9.!#$%&'*+\/=?_`{\|}~-](?=[a-zA-Z0-9.!#$%&'*+\/=?_`{\|}~-]+@)))/)
+  text: edit(/^(?:[^a-zA-Z0-9](?=emailProtocol)|(`+|~+|[^`~])(?:(?=[`~])|(?= {2,}\n)|(?=[a-zA-Z0-9.!#$%&'*+\/=?_`{\|}~-]+@)|[\s\S]*?(?:(?=[\\<!\[`*~_]|\b_|protocol:\/\/|www\.|$)|[^ ](?= {2,}\n)|[^a-zA-Z0-9](?=emailProtocol)|[^a-zA-Z0-9.!#$%&'*+\/=?_`{\|}~-](?=[a-zA-Z0-9.!#$%&'*+\/=?_`{\|}~-]+@))))/)
     .replace('protocol', _caseInsensitiveProtocol)
+    .replace(/emailProtocol/g, /(?:mailto|xmpp):/)
     .getRegex(),
 };
 

--- a/test/specs/gfm/gfm.0.29.json
+++ b/test/specs/gfm/gfm.0.29.json
@@ -147,22 +147,19 @@
     "section": "[extension] Autolinks",
     "html": "<p><a href=\"mailto:foo@bar.baz\">mailto:foo@bar.baz</a></p>\n<p><a href=\"mailto:a.b-c_d@a.b\">mailto:a.b-c_d@a.b</a></p>\n<p><a href=\"mailto:a.b-c_d@a.b\">mailto:a.b-c_d@a.b</a>.</p>\n<p><a href=\"mailto:a.b-c_d@a.b\">mailto:a.b-c_d@a.b</a>/</p>\n<p>mailto:a.b-c_d@a.b-</p>\n<p>mailto:a.b-c_d@a.b_</p>\n<p><a href=\"xmpp:foo@bar.baz\">xmpp:foo@bar.baz</a></p>\n<p><a href=\"xmpp:foo@bar.baz\">xmpp:foo@bar.baz</a>.</p>",
     "markdown": "mailto:foo@bar.baz\n\nmailto:a.b-c_d@a.b\n\nmailto:a.b-c_d@a.b.\n\nmailto:a.b-c_d@a.b/\n\nmailto:a.b-c_d@a.b-\n\nmailto:a.b-c_d@a.b_\n\nxmpp:foo@bar.baz\n\nxmpp:foo@bar.baz.",
-    "example": 633,
-    "shouldFail": true
+    "example": 633
   },
   {
     "section": "[extension] Autolinks",
     "html": "<p><a href=\"xmpp:foo@bar.baz/txt\">xmpp:foo@bar.baz/txt</a></p>\n<p><a href=\"xmpp:foo@bar.baz/txt@bin\">xmpp:foo@bar.baz/txt@bin</a></p>\n<p><a href=\"xmpp:foo@bar.baz/txt@bin.com\">xmpp:foo@bar.baz/txt@bin.com</a></p>",
     "markdown": "xmpp:foo@bar.baz/txt\n\nxmpp:foo@bar.baz/txt@bin\n\nxmpp:foo@bar.baz/txt@bin.com",
-    "example": 634,
-    "shouldFail": true
+    "example": 634
   },
   {
     "section": "[extension] Autolinks",
     "html": "<p><a href=\"xmpp:foo@bar.baz/txt\">xmpp:foo@bar.baz/txt</a>/bin</p>",
     "markdown": "xmpp:foo@bar.baz/txt/bin",
-    "example": 635,
-    "shouldFail": true
+    "example": 635
   },
   {
     "section": "[extension] Disallowed Raw HTML",

--- a/test/unit/Lexer.test.js
+++ b/test/unit/Lexer.test.js
@@ -2118,6 +2118,59 @@ paragraph
             ],
           });
         });
+
+        it('url email protocols', () => {
+          expectInlineTokens({
+            md: 'Contact mailto:foo@bar.baz and (xmpp:bar@baz.qux/resource).',
+            options: { gfm: true },
+            tokens: [
+              {
+                type: 'text',
+                raw: 'Contact ',
+                text: 'Contact ',
+                escaped: false,
+              },
+              {
+                type: 'link',
+                raw: 'mailto:foo@bar.baz',
+                text: 'mailto:foo@bar.baz',
+                href: 'mailto:foo@bar.baz',
+                tokens: [
+                  {
+                    type: 'text',
+                    raw: 'mailto:foo@bar.baz',
+                    text: 'mailto:foo@bar.baz',
+                  },
+                ],
+              },
+              {
+                type: 'text',
+                raw: ' and (',
+                text: ' and (',
+                escaped: false,
+              },
+              {
+                type: 'link',
+                raw: 'xmpp:bar@baz.qux/resource',
+                text: 'xmpp:bar@baz.qux/resource',
+                href: 'xmpp:bar@baz.qux/resource',
+                tokens: [
+                  {
+                    type: 'text',
+                    raw: 'xmpp:bar@baz.qux/resource',
+                    text: 'xmpp:bar@baz.qux/resource',
+                  },
+                ],
+              },
+              {
+                type: 'text',
+                raw: ').',
+                text: ').',
+                escaped: false,
+              },
+            ],
+          });
+        });
       });
 
       it('text', () => {


### PR DESCRIPTION
**Marked version:** master

**Markdown flavor:** GitHub Flavored Markdown

## Description

- Addresses the protocol-autolink subgroup of #4050 (GFM 0.29 examples 633–635).
- Recognizes mailto: and xmpp: extended autolinks using the GFM email grammar.
- Supports one optional XMPP resource segment and stops before a second slash.
- Leaves the bare-email domain fix in #4063 untouched.

AI disclosure: OpenAI Codex assisted with implementation and validation; I reviewed and own the contribution.

## Contributor

- [x] Tests exist to ensure functionality and minimize regression.
- [x] This is existing GFM behavior, so no feature documentation is required.

## Testing

- npm test
- npm run rules

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following conventional commit guidelines.