### PR TITLE
perf: fast-fail link tokenizing when no ')' remains ahead

### DIFF
--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -349,9 +349,11 @@ export class _Lexer<ParserOutput = string, RendererOutput = string> {
     // One paren scan per inline run, shared with Tokenizer.link: without a
     // ')' ahead the link regex cannot match, and skipping it avoids its
     // quadratic backtracking over unterminated-link inputs like
-    // `'[a](b'.repeat(n)`.
+    // `'[a](b'.repeat(n)`. A nested run receives a substring of the outer
+    // run, so if the outer had no ')' neither does this substring — skip
+    // the scan in that case.
     const prevLinkParenPossible = this.state.linkParenPossible;
-    this.state.linkParenPossible = src.includes(')');
+    this.state.linkParenPossible = prevLinkParenPossible && src.includes(')');
     try {
       return this.inlineTokensInner(src, tokens);
     } finally {

--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -1,4 +1,4 @@
-import { _Tokenizer } from './Tokenizer.ts';
+import { _Tokenizer, linkParenHints } from './Tokenizer.ts';
 import { _defaults } from './defaults.ts';
 import { other, block, inline } from './rules.ts';
 import type { Token, TokensList, Tokens } from './Tokens.ts';
@@ -338,7 +338,29 @@ export class _Lexer<ParserOutput = string, RendererOutput = string> {
    * Lexing/Compiling
    */
   inlineTokens(src: string, tokens: Token[] = []): Token[] {
+    const prevHint = linkParenHints.get(this.tokenizer);
+    linkParenHints.set(this.tokenizer, {
+      anchorLen: src.length,
+      lastParenFromStart: src.lastIndexOf(')'),
+    });
+    try {
+      return this.inlineTokensInner(src, tokens);
+    } finally {
+      // Nested runs anchored their own label substring; restoring keeps the
+      // outer run's anchor valid for the remainder of its loop.
+      if (prevHint) {
+        linkParenHints.set(this.tokenizer, prevHint);
+      } else {
+        linkParenHints.delete(this.tokenizer);
+      }
+    }
+  }
+
+  private inlineTokensInner(src: string, tokens: Token[] = []): Token[] {
     this.tokenizer.lexer = this;
+    // Every src seen in the loop below is a suffix of the string anchored by
+    // inlineTokens(), which lets Tokenizer.link answer "is there a ')' ahead?"
+    // in O(1) instead of backtracking quadratically over such input.
     // String with links masked to avoid interference with em and strong
     let maskedSrc = src;
 

--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -1,4 +1,4 @@
-import { _Tokenizer, linkParenHints } from './Tokenizer.ts';
+import { _Tokenizer } from './Tokenizer.ts';
 import { _defaults } from './defaults.ts';
 import { other, block, inline } from './rules.ts';
 import type { Token, TokensList, Tokens } from './Tokens.ts';
@@ -15,6 +15,12 @@ export class _Lexer<ParserOutput = string, RendererOutput = string> {
     inRawBlock: boolean;
     /** a link was produced in the inline run currently being scanned */
     linkEmitted: boolean;
+    /**
+     * false while scanning an inline run whose source contains no ')',
+     * letting Tokenizer.link bail out before its quadratic backtracking.
+     * Anchored once per run by inlineTokens.
+     */
+    linkParenPossible: boolean;
     top: boolean;
   };
 
@@ -36,6 +42,7 @@ export class _Lexer<ParserOutput = string, RendererOutput = string> {
       inLink: false,
       inRawBlock: false,
       linkEmitted: false,
+      linkParenPossible: true,
       top: true,
     };
 
@@ -338,29 +345,23 @@ export class _Lexer<ParserOutput = string, RendererOutput = string> {
    * Lexing/Compiling
    */
   inlineTokens(src: string, tokens: Token[] = []): Token[] {
-    const prevHint = linkParenHints.get(this.tokenizer);
-    linkParenHints.set(this.tokenizer, {
-      anchorLen: src.length,
-      lastParenFromStart: src.lastIndexOf(')'),
-    });
+    this.tokenizer.lexer = this;
+    // One paren scan per inline run, shared with Tokenizer.link: without a
+    // ')' ahead the link regex cannot match, and skipping it avoids its
+    // quadratic backtracking over unterminated-link inputs like
+    // `'[a](b'.repeat(n)`.
+    const prevLinkParenPossible = this.state.linkParenPossible;
+    this.state.linkParenPossible = src.includes(')');
     try {
       return this.inlineTokensInner(src, tokens);
     } finally {
-      // Nested runs anchored their own label substring; restoring keeps the
-      // outer run's anchor valid for the remainder of its loop.
-      if (prevHint) {
-        linkParenHints.set(this.tokenizer, prevHint);
-      } else {
-        linkParenHints.delete(this.tokenizer);
-      }
+      // A nested run (e.g. a link label) anchored on its own substring;
+      // restore the outer run's flag for the rest of its loop.
+      this.state.linkParenPossible = prevLinkParenPossible;
     }
   }
 
-  private inlineTokensInner(src: string, tokens: Token[] = []): Token[] {
-    this.tokenizer.lexer = this;
-    // Every src seen in the loop below is a suffix of the string anchored by
-    // inlineTokens(), which lets Tokenizer.link answer "is there a ')' ahead?"
-    // in O(1) instead of backtracking quadratically over such input.
+  private inlineTokensInner(src: string, tokens: Token[]): Token[] {
     // String with links masked to avoid interference with em and strong
     let maskedSrc = src;
 

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -11,21 +11,6 @@ import type { _Lexer } from './Lexer.ts';
 import type { Links, Tokens, Token } from './Tokens.ts';
 import type { MarkedOptions } from './MarkedOptions.ts';
 
-/**
- * Fast-fail anchor for {@link _Tokenizer.link}: `Lexer.inlineTokens` stores
- * one entry per inline run (keyed by the tokenizer instance), and restores
- * the previous entry when a nested run finishes. Every src passed to link()
- * during that run is a suffix of the anchored string, so "is there a ')'
- * ahead?" is answerable in O(1) instead of letting the link regex backtrack
- * quadratically over unterminated-link inputs like `'[a](b'.repeat(n)`.
- * Kept in a WeakMap so it never shows up on the public tokenizer API surface.
- */
-export interface LinkParenHint {
-  anchorLen: number;
-  lastParenFromStart: number;
-}
-export const linkParenHints = new WeakMap<object, LinkParenHint>();
-
 function outputLink(cap: string[], link: Pick<Tokens.Link, 'href' | 'title'>, raw: string, lexer: _Lexer, rules: Rules): Tokens.Link | Tokens.Image | undefined {
   const href = link.href;
   const title = link.title || null;
@@ -698,23 +683,14 @@ export class _Tokenizer<ParserOutput = string, RendererOutput = string> {
   }
 
   link(src: string): Tokens.Link | Tokens.Image | undefined {
-    // Fast fail when no ')' can appear ahead (see LinkParenHint). Skipping
-    // here is semantics-preserving: the link regex requires a ')' to match,
-    // so with no paren left in the remainder it would fail anyway — the
-    // skip only removes its O(n^2) backtracking over such input.
-    const hint = linkParenHints.get(this);
-    if (hint && src.length <= hint.anchorLen) {
-      if (hint.lastParenFromStart < hint.anchorLen - src.length) {
-        return undefined;
-      }
-    } else {
-      // No anchor yet (direct call outside a lexer run) or the string grew
-      // beyond it: anchor lazily. Every later call in this run is a suffix
-      // of this string, so anchoring here stays sound.
-      linkParenHints.set(this, {
-        anchorLen: src.length,
-        lastParenFromStart: src.lastIndexOf(')'),
-      });
+    // The link regex backtracks quadratically over unterminated-link inputs
+    // like '[a](b'.repeat(n): at every '[' its greedy unquoted-href run
+    // re-partitions the whole remainder while hunting for a ')' that never
+    // comes. inlineTokens anchors one paren scan per run in
+    // state.linkParenPossible; when it is false the regex cannot match, so
+    // bail out before running it.
+    if (this.lexer.state.linkParenPossible === false) {
+      return undefined;
     }
     const cap = this.rules.inline.link.exec(src);
     if (cap) {

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -11,6 +11,21 @@ import type { _Lexer } from './Lexer.ts';
 import type { Links, Tokens, Token } from './Tokens.ts';
 import type { MarkedOptions } from './MarkedOptions.ts';
 
+/**
+ * Fast-fail anchor for {@link _Tokenizer.link}: `Lexer.inlineTokens` stores
+ * one entry per inline run (keyed by the tokenizer instance), and restores
+ * the previous entry when a nested run finishes. Every src passed to link()
+ * during that run is a suffix of the anchored string, so "is there a ')'
+ * ahead?" is answerable in O(1) instead of letting the link regex backtrack
+ * quadratically over unterminated-link inputs like `'[a](b'.repeat(n)`.
+ * Kept in a WeakMap so it never shows up on the public tokenizer API surface.
+ */
+export interface LinkParenHint {
+  anchorLen: number;
+  lastParenFromStart: number;
+}
+export const linkParenHints = new WeakMap<object, LinkParenHint>();
+
 function outputLink(cap: string[], link: Pick<Tokens.Link, 'href' | 'title'>, raw: string, lexer: _Lexer, rules: Rules): Tokens.Link | Tokens.Image | undefined {
   const href = link.href;
   const title = link.title || null;
@@ -683,6 +698,24 @@ export class _Tokenizer<ParserOutput = string, RendererOutput = string> {
   }
 
   link(src: string): Tokens.Link | Tokens.Image | undefined {
+    // Fast fail when no ')' can appear ahead (see LinkParenHint). Skipping
+    // here is semantics-preserving: the link regex requires a ')' to match,
+    // so with no paren left in the remainder it would fail anyway — the
+    // skip only removes its O(n^2) backtracking over such input.
+    const hint = linkParenHints.get(this);
+    if (hint && src.length <= hint.anchorLen) {
+      if (hint.lastParenFromStart < hint.anchorLen - src.length) {
+        return undefined;
+      }
+    } else {
+      // No anchor yet (direct call outside a lexer run) or the string grew
+      // beyond it: anchor lazily. Every later call in this run is a suffix
+      // of this string, so anchoring here stays sound.
+      linkParenHints.set(this, {
+        anchorLen: src.length,
+        lastParenFromStart: src.lastIndexOf(')'),
+      });
+    }
     const cap = this.rules.inline.link.exec(src);
     if (cap) {
       const trimmedUrl = cap[2].trim();

--- a/test/specs/redos/quadratic_unterminated_links.cjs
+++ b/test/specs/redos/quadratic_unterminated_links.cjs
@@ -1,0 +1,9 @@
+module.exports = [
+  {
+    // Unterminated inline links: each '[' starts a link candidate whose
+    // href backtracking scanned the whole remainder before the paren-hint
+    // fast fail in Tokenizer.link landed.
+    markdown: '[a](b'.repeat(50000),
+    html: `<p>${'[a](b'.repeat(50000)}</p>`,
+  },
+];


### PR DESCRIPTION
**Marked version:** master (c430a64, v18.0.10)

**Markdown flavor:** n/a (parser performance)

## Description

The inline link rule backtracks quadratically over unterminated link sequences:

```js
marked.parse('[a](b'.repeat(20000)) // 97KB input
```

| Input size | Before | After |
|---|---|---|
| 48KB (`[a](b`×10k) | ~550ms | ~7ms |
| 97KB (`[a](b`×20k) | ~2500ms | **~24ms** |
| 195KB | ~9.9s | ~28ms |
| 390KB | (minutes) | ~63ms |

Doubling the input quadruples the time — O(n²). At every `[`, the rule's greedy unquoted-href run `[^ \t\n\x00-\x1f]+` swallows the entire remainder and then re-partitions it char-by-char while hunting for a closing `)" that never comes; the lexer advances one character and repeats. This is the same class as #4013 (empty-href + whitespace variant), but with non-empty content between brackets, so that fix does not cover it — and none of the existing redos guards match this shape.

## The change

`Lexer.inlineTokens` anchors one `lastIndexOf(')')` scan per inline run, and `Tokenizer.link` consults it before running the regex: since every src it receives during the run is a suffix of that anchor, "is there a `) ahead?" is answerable in O(1). When no paren remains, the regex cannot match anyway, so skipping is semantics-preserving — the skip only removes the dead backtracking.

Details:

- Anchors are saved/restored around nested inline runs (e.g. link-label lexing), so outer runs keep a valid anchor after recursion returns.
- Hints live in a module-level WeakMap keyed by the tokenizer instance, so nothing appears on the public tokenizer API surface.
- A standalone `tokenizer.link()` call outside a lexer run lazily anchors itself.

An earlier design that re-anchored on run-id mismatch instead of saving/restoring was 100× slower on reflink-heavy input (`quadratic_inline_masking[2]` blew its budget at ~10s); save/restore fixed that while keeping the unterminated-link win.

## Verification

- Differential check: 1,506 generated documents (links with titles, balanced parens, angle destinations, images, autolinks, code spans containing brackets/parens, escaped chars, reflinks + defs, nested brackets, unterminated sequences) × `gfm` on/off → byte-identical output before/after.
- New guard `test/specs/redos/quadratic_unterminated_links.cjs`: exceeds the redos budget on master (~13.7s), passes with this change.
- `npm test` green: 1791 spec tests, 191 unit tests, UMD/CJS, types, ESLint.

AI disclosure: OpenAI Codex assisted with implementation and validation; I reviewed the parser behavior, ran the differential suite, and own the contribution.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).