### PR TITLE
fix: drop the leading whitespace after a hard line break

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -282,7 +282,7 @@ const blockPedantic: Record<BlockKeys, RegExp> = {
 
 const escape = /^\\([!"#$%&'()*+,\-./:;<=>?@\[\]\\^_`{|}~])/;
 const inlineCode = /^(`+)([^`]|[^`][\s\S]*?[^`])\1(?!`)/;
-const br = /^( {2,}|\\)\n(?!\s*$)/;
+const br = /^( {2,}|\\)\n(?!\s*$) */;
 const inlineText = /^(`+|[^`])(?:(?= {2,}\n)|[\s\S]*?(?:(?=[\\<!\[`*_]|\b_|$)|[^ ](?= {2,}\n)))/;
 
 // list of unicode punctuation marks, plus any missing characters from CommonMark spec

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -282,7 +282,7 @@ const blockPedantic: Record<BlockKeys, RegExp> = {
 
 const escape = /^\\([!"#$%&'()*+,\-./:;<=>?@\[\]\\^_`{|}~])/;
 const inlineCode = /^(`+)([^`]|[^`][\s\S]*?[^`])\1(?!`)/;
-const br = /^( {2,}|\\)\n(?!\s*$) */;
+const br = /^( {2,}|\\)\n(?!\s*$)[ \t]*/;
 const inlineText = /^(`+|[^`])(?:(?= {2,}\n)|[\s\S]*?(?:(?=[\\<!\[`*_]|\b_|$)|[^ ](?= {2,}\n)))/;
 
 // list of unicode punctuation marks, plus any missing characters from CommonMark spec

--- a/test/specs/new/hardbreak_leading_whitespace.html
+++ b/test/specs/new/hardbreak_leading_whitespace.html
@@ -1,0 +1,8 @@
+<p>foo<br>bar</p>
+<p>foo<br>bar</p>
+<p>foo<br>bar</p>
+<p>foo<br>bar</p>
+<p>foo
+	bar</p>
+<p>foo
+bar</p>

--- a/test/specs/new/hardbreak_leading_whitespace.md
+++ b/test/specs/new/hardbreak_leading_whitespace.md
@@ -1,0 +1,20 @@
+---
+renderExact: true
+---
+foo  
+     bar
+
+foo\
+     bar
+
+foo  
+	bar
+
+foo  
+  	 bar
+
+foo
+	bar
+
+foo
+bar

--- a/test/unit/marked.test.js
+++ b/test/unit/marked.test.js
@@ -22,6 +22,20 @@ describe('marked unit', () => {
     });
   });
 
+  describe('hard line break', () => {
+    it('should drop the leading whitespace of the continuation line', () => {
+      assert.strictEqual(marked.parse('foo  \n     bar\n'), '<p>foo<br>bar</p>\n');
+    });
+
+    it('should do the same for a backslash break', () => {
+      assert.strictEqual(marked.parse('foo\\\n     bar\n'), '<p>foo<br>bar</p>\n');
+    });
+
+    it('should keep a soft break unchanged', () => {
+      assert.strictEqual(marked.parse('foo\nbar\n'), '<p>foo\nbar</p>\n');
+    });
+  });
+
   describe('changeDefaults', () => {
     it('should change global defaults', async() => {
       const { defaults, setOptions } = await import('../../lib/marked.esm.js');

--- a/test/unit/marked.test.js
+++ b/test/unit/marked.test.js
@@ -31,6 +31,18 @@ describe('marked unit', () => {
       assert.strictEqual(marked.parse('foo\\\n     bar\n'), '<p>foo<br>bar</p>\n');
     });
 
+    it('should drop a leading tab as well', () => {
+      assert.strictEqual(marked.parse('foo  \n\tbar\n'), '<p>foo<br>bar</p>\n');
+    });
+
+    it('should drop a mix of spaces and tabs', () => {
+      assert.strictEqual(marked.parse('foo  \n  \t bar\n'), '<p>foo<br>bar</p>\n');
+    });
+
+    it('should keep the leading tab of a soft break', () => {
+      assert.strictEqual(marked.parse('foo\n\tbar\n'), '<p>foo\n\tbar</p>\n');
+    });
+
     it('should keep a soft break unchanged', () => {
       assert.strictEqual(marked.parse('foo\nbar\n'), '<p>foo\nbar</p>\n');
     });

--- a/test/unit/marked.test.js
+++ b/test/unit/marked.test.js
@@ -22,32 +22,6 @@ describe('marked unit', () => {
     });
   });
 
-  describe('hard line break', () => {
-    it('should drop the leading whitespace of the continuation line', () => {
-      assert.strictEqual(marked.parse('foo  \n     bar\n'), '<p>foo<br>bar</p>\n');
-    });
-
-    it('should do the same for a backslash break', () => {
-      assert.strictEqual(marked.parse('foo\\\n     bar\n'), '<p>foo<br>bar</p>\n');
-    });
-
-    it('should drop a leading tab as well', () => {
-      assert.strictEqual(marked.parse('foo  \n\tbar\n'), '<p>foo<br>bar</p>\n');
-    });
-
-    it('should drop a mix of spaces and tabs', () => {
-      assert.strictEqual(marked.parse('foo  \n  \t bar\n'), '<p>foo<br>bar</p>\n');
-    });
-
-    it('should keep the leading tab of a soft break', () => {
-      assert.strictEqual(marked.parse('foo\n\tbar\n'), '<p>foo\n\tbar</p>\n');
-    });
-
-    it('should keep a soft break unchanged', () => {
-      assert.strictEqual(marked.parse('foo\nbar\n'), '<p>foo\nbar</p>\n');
-    });
-  });
-
   describe('changeDefaults', () => {
     it('should change global defaults', async() => {
       const { defaults, setOptions } = await import('../../lib/marked.esm.js');


### PR DESCRIPTION
**Marked version:** 18.0.11 (53cb13f1)

**Markdown flavor:** CommonMark

## Description

CommonMark ignores leading spaces at the start of the line following a hard line break. The `br` rule is:

```js
const br = /^( {2,}|\)\n(?!\s*$)/;
```

It consumes the break itself but not the next line's indentation, so that indentation stays on the following text token and is rendered.

## Expectation

```
foo··
·····bar
```

gives `<p>foo<br />\nbar</p>`.

## Result

`<p>foo<br>     bar</p>`. The five spaces survive.

## What was attempted

Appending ` *` to the rule, so the break consumes the indentation that follows it.

This one is easy to measure wrongly, which is worth writing down. Neither of the comparisons normally used here can see it:

- marked's own suite compares through `htmlIsEqual`, which leaves `ignoreWhitespaces` at its default of `true`, so the difference is invisible and examples 636 and 637 already report as passing with no `shouldFail` flag.
- An exact string comparison fails both before and after the change, because marked emits `<br>` where the spec's reference output has `<br />` followed by a newline.

Under the spec's own `test/normalize.py`, which normalises the self-closing slash but keeps a single space that begins a text node after a tag, the whole-spec count goes from 28 to 26. The two that move are exactly 636 and 637, and nothing else changes, in both the CommonMark and GFM runs.

Credit where it is due: I originally measured this with the two comparisons above, concluded it was not a bug, and said so in #4050. @exit0-run showed the `normalize.py` measurement and was right.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

Three tests in `test/unit/marked.test.js` under `hard line break`, covering the two-space and backslash spellings plus a soft break as a control. The first two fail without the change; the control passes either way. Full spec suite (1789) and unit suite (194) pass.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
