### PR TITLE
fix: case fold reference link labels

### DIFF
--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -1,6 +1,7 @@
 import { _Tokenizer } from './Tokenizer.ts';
 import { _defaults } from './defaults.ts';
 import { other, block, inline } from './rules.ts';
+import { normalizeLabel } from './helpers.ts';
 import type { Token, TokensList, Tokens } from './Tokens.ts';
 import type { MarkedOptions } from './MarkedOptions.ts';
 
@@ -321,7 +322,7 @@ export class _Lexer<ParserOutput = string, RendererOutput = string> {
     for (const match of text.matchAll(this.tokenizer.rules.inline.reflinkSearch)) {
       const match0 = match[0];
       const refStart = match0.lastIndexOf('[');
-      if (match0.charAt(0) === '!' || !Object.hasOwn(this.tokens.links, match0.slice(refStart + 1, -1))) {
+      if (match0.charAt(0) === '!' || !Object.hasOwn(this.tokens.links, normalizeLabel(match0.slice(refStart + 1, -1)))) {
         continue;
       }
       // a candidate holding a link is not a link either, so it does not count
@@ -347,7 +348,7 @@ export class _Lexer<ParserOutput = string, RendererOutput = string> {
       const reflinkSearch = this.tokenizer.rules.inline.reflinkSearch;
       const maskReflink = (match0: string): string => {
         const refStart = match0.lastIndexOf('[');
-        if (!Object.hasOwn(this.tokens.links, match0.slice(refStart + 1, -1))) {
+        if (!Object.hasOwn(this.tokens.links, normalizeLabel(match0.slice(refStart + 1, -1)))) {
           return match0;
         }
         // CommonMark: "Links may not contain other links, at any level of

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -4,6 +4,7 @@ import {
   splitCells,
   findClosingBracket,
   expandTabs,
+  normalizeLabel,
   trimTrailingBlankLines,
 } from './helpers.ts';
 import type { Rules } from './rules.ts';
@@ -529,7 +530,7 @@ export class _Tokenizer<ParserOutput = string, RendererOutput = string> {
   def(src: string): Tokens.Def | undefined {
     const cap = this.rules.block.def.exec(src);
     if (cap) {
-      const tag = cap[1].toLowerCase().replace(this.rules.other.multipleSpaceGlobal, ' ');
+      const tag = normalizeLabel(cap[1]).replace(this.rules.other.multipleSpaceGlobal, ' ');
       const href = cap[2] ? cap[2].replace(this.rules.other.hrefBrackets, '$1').replace(this.rules.inline.anyPunctuation, '$1') : '';
       const title = cap[3] ? cap[3].substring(1, cap[3].length - 1).replace(this.rules.inline.anyPunctuation, '$1') : cap[3];
       return {
@@ -748,7 +749,7 @@ export class _Tokenizer<ParserOutput = string, RendererOutput = string> {
     if ((cap = this.rules.inline.reflink.exec(src))
       || (cap = this.rules.inline.nolink.exec(src))) {
       const linkString = (cap[2] || cap[1]).replace(this.rules.other.multipleSpaceGlobal, ' ');
-      const link = links[linkString.toLowerCase()];
+      const link = links[normalizeLabel(linkString)];
       if (!link) {
         const text = cap[0].charAt(0);
         return {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -123,6 +123,17 @@ export function trimTrailingBlankLines(str: string) {
   return lines.slice(0, end + 1).join('\n');
 }
 
+/**
+ * Normalizes a link label so definitions and references can be matched.
+ * CommonMark asks for a Unicode case fold, which `toLowerCase()` does not
+ * reach: `ẞ` lowercases to `ß` and so never meets `SS`. Round-tripping
+ * through upper case does, as in commonmark.js; the final `toLowerCase()`
+ * keeps the folded label lower case, the form `def.tag` has always used.
+ */
+export function normalizeLabel(label: string) {
+  return label.toLowerCase().toUpperCase().toLowerCase();
+}
+
 export function findClosingBracket(str: string, b: string) {
   if (str.indexOf(b[1]) === -1) {
     return -1;

--- a/test/specs/commonmark/commonmark.0.31.2.json
+++ b/test/specs/commonmark/commonmark.0.31.2.json
@@ -4327,8 +4327,7 @@
     "example": 540,
     "start_line": 8129,
     "end_line": 8135,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "[Foo\n  bar]: /url\n\n[Baz][Foo bar]\n",

--- a/test/specs/gfm/commonmark.0.31.2.json
+++ b/test/specs/gfm/commonmark.0.31.2.json
@@ -4327,8 +4327,7 @@
     "example": 540,
     "start_line": 8129,
     "end_line": 8135,
-    "section": "Links",
-    "shouldFail": true
+    "section": "Links"
   },
   {
     "markdown": "[Foo\n  bar]: /url\n\n[Baz][Foo bar]\n",

--- a/test/specs/new/reflink_case_folding.html
+++ b/test/specs/new/reflink_case_folding.html
@@ -1,0 +1,1 @@
+<p><a href="/sharp-s">ẞ</a> and <a href="/street">Straße</a> and <a href="/digraph">ǅ</a> and <a href="/ligature">ﬁ</a>.</p>

--- a/test/specs/new/reflink_case_folding.md
+++ b/test/specs/new/reflink_case_folding.md
@@ -1,0 +1,6 @@
+[ẞ] and [Straße] and [ǅ] and [ﬁ].
+
+[SS]: /sharp-s
+[STRASSE]: /street
+[Ǆ]: /digraph
+[FI]: /ligature


### PR DESCRIPTION
## Description

Reference link labels are matched with `toLowerCase()`, but CommonMark asks for a Unicode case fold:

> To normalize a label, strip off the opening and closing brackets, perform the *Unicode case fold*, strip leading and trailing spaces, tabs, and line endings, and collapse consecutive internal spaces, tabs, and line endings to a single space.

`toLowerCase()` doesn't get there, so labels that only agree once folded never match:

```md
[ẞ] and [Straße].

[SS]: /sharp-s
[STRASSE]: /street
```

renders as literal text today, because `'ẞ'.toLowerCase()` is `'ß'` — never `'ss'`. Round-tripping through upper case reaches the fold, which is what commonmark.js does in `normalizeReference()`:

```js
.toLowerCase()
.toUpperCase();
```

I lowercase once more afterwards so `def.tag` and the `tokens.links` keys stay in the lower case form they've always had — an uppercase key would be a visible change for anyone reading `lexer.tokens.links` or a `def` token, and it isn't needed to get the fold.

The two link-map lookups in `Lexer` (`linkInText` and the reflink mask) used the label verbatim rather than normalized, so they go through the same helper. Without that they'd start missing definitions they used to find as soon as the stored keys are folded. As a side effect the mask now also handles labels whose case differs from the definition.

This enables CommonMark example 540, taking Links from 81/90 to 82/90.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR)
- [x] Docs have been added/updated (for bug fixes/features)

Verification notes:

- Removed the `shouldFail` flag from example 540 in both `test/specs/commonmark` and `test/specs/gfm`.
- Added `test/specs/new/reflink_case_folding.{md,html}` covering `ẞ`/`SS`, `Straße`/`STRASSE`, `ǅ`/`Ǆ` and `ﬁ`/`FI`. I generated the expected HTML from commonmark.js 0.32 and it is byte-identical to marked's output with this change; the fixture fails on `master`.
- `npm test` is green: specs 1789 -> 1791 passing, unit 191 passing, 0 failures, lint clean. No existing test needed adjusting.
