### PR TITLE
fix: strip a tab that follows spaces in an indented code block

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -41,7 +41,7 @@ try {
 })();
 
 export const other = {
-  codeRemoveIndent: /^(?: {1,4}| {0,3}\t)/gm,
+  codeRemoveIndent: /^(?: {0,3}\t| {1,4})/gm,
   outputLinkReplace: /\\([\[\]])/g,
   indentCodeCompensation: /^(\s+)(?:```)/,
   beginningSpace: /^\s+/,

--- a/test/specs/new/tabs_indented_code.html
+++ b/test/specs/new/tabs_indented_code.html
@@ -1,0 +1,14 @@
+<pre><code>foo	baz		bim
+</code></pre>
+<p>sep</p>
+<pre><code>three spaces and a tab
+</code></pre>
+<p>sep</p>
+<pre><code>lone tab
+</code></pre>
+<p>sep</p>
+<pre><code>four spaces
+</code></pre>
+<p>sep</p>
+<pre><code> five spaces
+</code></pre>

--- a/test/specs/new/tabs_indented_code.md
+++ b/test/specs/new/tabs_indented_code.md
@@ -1,0 +1,20 @@
+---
+renderExact: true
+---
+  	foo	baz		bim
+
+sep
+
+   	three spaces and a tab
+
+sep
+
+	lone tab
+
+sep
+
+    four spaces
+
+sep
+
+     five spaces

--- a/test/unit/marked.test.js
+++ b/test/unit/marked.test.js
@@ -22,34 +22,6 @@ describe('marked unit', () => {
     });
   });
 
-  // The spec suite compares through htmlIsEqual, which leaves ignoreWhitespaces at its default
-  // of true, so it cannot see indentation inside pre. These assert exact output.
-  describe('tab expansion in block structure', () => {
-    it('should treat spaces then a tab as reaching the next four column stop', () => {
-      assert.strictEqual(marked.parse('  \tfoo\n'), '<pre><code>foo\n</code></pre>\n');
-    });
-
-    it('should keep tabs in the content of an indented code block', () => {
-      assert.strictEqual(marked.parse('  \tfoo\tbaz\t\tbim\n'), '<pre><code>foo\tbaz\t\tbim\n</code></pre>\n');
-    });
-
-    it('should strip three spaces and a tab', () => {
-      assert.strictEqual(marked.parse('   \tfoo\n'), '<pre><code>foo\n</code></pre>\n');
-    });
-
-    it('should still strip a lone leading tab', () => {
-      assert.strictEqual(marked.parse('\tfoo\n'), '<pre><code>foo\n</code></pre>\n');
-    });
-
-    it('should still strip exactly four spaces', () => {
-      assert.strictEqual(marked.parse('    foo\n'), '<pre><code>foo\n</code></pre>\n');
-    });
-
-    it('should keep a fifth space as content', () => {
-      assert.strictEqual(marked.parse('     foo\n'), '<pre><code> foo\n</code></pre>\n');
-    });
-  });
-
   describe('changeDefaults', () => {
     it('should change global defaults', async() => {
       const { defaults, setOptions } = await import('../../lib/marked.esm.js');

--- a/test/unit/marked.test.js
+++ b/test/unit/marked.test.js
@@ -22,6 +22,34 @@ describe('marked unit', () => {
     });
   });
 
+  // The spec suite compares through htmlIsEqual, which leaves ignoreWhitespaces at its default
+  // of true, so it cannot see indentation inside pre. These assert exact output.
+  describe('tab expansion in block structure', () => {
+    it('should treat spaces then a tab as reaching the next four column stop', () => {
+      assert.strictEqual(marked.parse('  \tfoo\n'), '<pre><code>foo\n</code></pre>\n');
+    });
+
+    it('should keep tabs in the content of an indented code block', () => {
+      assert.strictEqual(marked.parse('  \tfoo\tbaz\t\tbim\n'), '<pre><code>foo\tbaz\t\tbim\n</code></pre>\n');
+    });
+
+    it('should strip three spaces and a tab', () => {
+      assert.strictEqual(marked.parse('   \tfoo\n'), '<pre><code>foo\n</code></pre>\n');
+    });
+
+    it('should still strip a lone leading tab', () => {
+      assert.strictEqual(marked.parse('\tfoo\n'), '<pre><code>foo\n</code></pre>\n');
+    });
+
+    it('should still strip exactly four spaces', () => {
+      assert.strictEqual(marked.parse('    foo\n'), '<pre><code>foo\n</code></pre>\n');
+    });
+
+    it('should keep a fifth space as content', () => {
+      assert.strictEqual(marked.parse('     foo\n'), '<pre><code> foo\n</code></pre>\n');
+    });
+  });
+
   describe('changeDefaults', () => {
     it('should change global defaults', async() => {
       const { defaults, setOptions } = await import('../../lib/marked.esm.js');


### PR DESCRIPTION
**Marked version:** 18.0.11 (53cb13f1)

**Markdown flavor:** CommonMark

## Description

CommonMark example 2. A line indented with spaces and then a tab keeps the tab as code content:

```
in     "··\tfoo\tbaz\t\tbim"

want   <pre><code>foo\tbaz\t\tbim
got    <pre><code>\tfoo\tbaz\t\tbim
```

A tab advances to the next four column stop, so `··\t` is four columns of indentation and all of it belongs to the block structure, not to the content.

## Cause

`codeRemoveIndent` is `/^(?: {1,4}| {0,3}\t)/gm`. Regex alternation takes the first branch that matches, so on `··\tfoo` the ` {1,4}` branch matches the two spaces and stops, and the tab is left in the content. The tab branch only ever gets a chance when the line has no leading space at all, which is why example 1 (`\tfoo…`) has always passed and example 2 has not.

Swapping the order fixes it, because the tab branch already carries its own ` {0,3}` prefix:

```js
codeRemoveIndent: /^(?: {0,3}\t| {1,4})/gm,
```

Every space-only input is unaffected, since the tab branch cannot match without a tab:

| line | before | after |
|---|---|---|
| `··\tfoo` | `\tfoo` | `foo` |
| `···\tfoo` | `\tfoo` | `foo` |
| `\tfoo` | `foo` | `foo` |
| `····foo` | `foo` | `foo` |
| `·····foo` | `·foo` | `·foo` |
| `······foo` | `··foo` | `··foo` |

The regex is used in one place, `Tokenizer.ts:108`, inside the indented code tokenizer, so it cannot reach fenced content.

## Measurement

Whole spec through the CommonMark repository's own `test/normalize.py`, 0.31.2, `gfm: false`:

| | fails |
|---|---:|
| 18.0.11 | 28 |
| with this change | 27 |

The one that moves is example 2, and nothing else moves in either direction. That measurement matters here because marked's own suite cannot see this bug: `htmlIsEqual` leaves `ignoreWhitespaces` at `true`, and the difference is indentation inside `pre`. Example 2 reports as passing today with no `shouldFail` flag against it, the same blind spot as #4073.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

Six tests in `test/unit/marked.test.js`, asserting exact output for the reason above. Three fail without the change; the other three are controls that must pass either way, and do. Full spec suite (1789) and unit suite (200) pass.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).

---

Context: this is the first half of the tab work discussed in #4050. Example 6 is the other half and I am not sending it, for reasons I have written up in that issue.