### PR TITLE
perf: avoid repeated raw string copies in nested lists

### DIFF
--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -258,6 +258,10 @@ export class _Tokenizer<ParserOutput = string, RendererOutput = string> {
   list(src: string): Tokens.List | undefined {
     let cap = this.rules.block.list.exec(src);
     if (cap) {
+      // src is only consumed from the front, so every raw below is a slice of
+      // listSrc rather than a string built up line by line
+      const listSrc = src;
+      const taken = () => listSrc.length - src.length;
       let bull = cap[1].trim();
       const isordered = bull.length > 1;
 
@@ -282,7 +286,6 @@ export class _Tokenizer<ParserOutput = string, RendererOutput = string> {
       // Check if current bullet point can start a new List Item
       while (src) {
         let endEarly = false;
-        let raw = '';
         let itemContents = '';
         if (!(cap = itemRegex.exec(src))) {
           break;
@@ -292,8 +295,8 @@ export class _Tokenizer<ParserOutput = string, RendererOutput = string> {
           break;
         }
 
-        raw = cap[0];
-        src = src.substring(raw.length);
+        const itemStart = taken();
+        src = src.substring(cap[0].length);
 
         let line = expandTabs(cap[2].split('\n', 1)[0], cap[1].length);
         let nextLine = src.split('\n', 1)[0];
@@ -313,7 +316,6 @@ export class _Tokenizer<ParserOutput = string, RendererOutput = string> {
         }
 
         if (blankLine && this.rules.other.blankLine.test(nextLine)) { // Items begin with at most one blank line
-          raw += nextLine + '\n';
           src = src.substring(nextLine.length + 1);
           endEarly = true;
         }
@@ -397,11 +399,15 @@ export class _Tokenizer<ParserOutput = string, RendererOutput = string> {
 
             blankLine = !nextLine.trim();
 
-            raw += rawLine + '\n';
             src = src.substring(rawLine.length + 1);
             line = nextLineWithoutTabs.slice(indent);
           }
         }
+
+        // The loops above appended a '\n' the source may not have had. It could
+        // only land on the item that exhausts src, whose raw is trimmed below,
+        // and after which nothing reads endsWithBlankLine
+        const raw = listSrc.slice(itemStart, taken());
 
         if (!list.loose) {
           // If the previous item ended with a blank line, the list is loose
@@ -420,8 +426,6 @@ export class _Tokenizer<ParserOutput = string, RendererOutput = string> {
           text: itemContents,
           tokens: [],
         });
-
-        list.raw += raw;
       }
 
       // Do not consume newlines at end of final item. Alternatively, make itemRegex *start* with any newlines to simplify/speed up endsWithBlankLine logic
@@ -433,7 +437,7 @@ export class _Tokenizer<ParserOutput = string, RendererOutput = string> {
         // not a list since there were no items
         return;
       }
-      list.raw = list.raw.trimEnd();
+      list.raw = listSrc.slice(0, taken()).trimEnd();
 
       // Item child tokens handled here at end because we needed to have the final item to trim it first
       // First pass: tokenize items and finalize list.loose from spacers before placing checkboxes


### PR DESCRIPTION
**Marked version:**

18.0.11 / `63841d3b`

**Markdown flavor:** CommonMark

## Description

`Tokenizer.list()` builds each item's `raw` a line at a time (`raw += rawLine + '\n'`) and the
list's `raw` by concatenating its items. `src` is only ever consumed from the front, so both are
contiguous spans of the input; this computes their bounds and slices them out instead. V8 keeps a
slice as a view onto one backing string, so the per-item and per-list copies go away. Token values
are unchanged.

Local measurements from my machine:

- cmark's `deeply nested lists` pathological case (500 levels): 222-226 MB RSS and 132-140 ms
  before, 157 MB and 124-127 ms after, across four rounds. The rest of cmark's pathological corpus
  is unchanged.
- `npm run bench`: unchanged, 1278/1319/1320 ms before against 1276/1312/1302 ms after. The saving
  is proportional to nesting depth, so ordinary documents get no marked benefit from the improvement.
- Maximum nesting depth before `RangeError: Maximum call stack size exceeded` is 2237 both before
  and after, so there is no stack cost.

`blockquote()` does not accumulate line by line, and its continuation paths splice a re-lexed
`newToken.raw` into the middle of `raw`, so it is not expressible as one slice. Left alone.

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests
      covering this PR); or,
- [x] no tests required for this PR.
- [x] If submitting new feature, it has been documented in the appropriate places. n/a, this is not
      a new feature.

Covered by the existing list coverage in `test/specs/commonmark`, `test/specs/new` and
`test/unit/Lexer.test.js`; full `npm test` passes locally. I also diffed this branch against
`master` on the full token tree and rendered HTML for every input in `test/specs` across five option
sets, and on 40,000 seeded-random list documents across three and observed no differences in either run.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
