### PR TITLE
fix: reject invalid characters in HTML tag names

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -155,8 +155,8 @@ const html = edit(
 + '|<![A-Z][\\s\\S]*?(?:>[^\\n]*\\n*|$)' // (4)
 + '|<!\\[CDATA\\[[\\s\\S]*?(?:\\]\\]>[^\\n]*\\n*|$)' // (5)
 + '|</?(tag)(?: +|\\n|/?>)[\\s\\S]*?(?:(?:\\n[ \t]*)+\\n|$)' // (6)
-+ '|<(?!script|pre|style|textarea)([a-z][\\w-]*)(?:attribute)*? */?>(?=[ \\t]*(?:\\n|$))[\\s\\S]*?(?:(?:\\n[ \t]*)+\\n|$)' // (7) open tag
-+ '|</(?!script|pre|style|textarea)[a-z][\\w-]*\\s*>(?=[ \\t]*(?:\\n|$))[\\s\\S]*?(?:(?:\\n[ \t]*)+\\n|$)' // (7) closing tag
++ '|<(?!script|pre|style|textarea)([a-z][a-z0-9-]*)(?:attribute)*? */?>(?=[ \\t]*(?:\\n|$))[\\s\\S]*?(?:(?:\\n[ \t]*)+\\n|$)' // (7) open tag
++ '|</(?!script|pre|style|textarea)[a-z][a-z0-9-]*\\s*>(?=[ \\t]*(?:\\n|$))[\\s\\S]*?(?:(?:\\n[ \t]*)+\\n|$)' // (7) closing tag
 + ')', 'i')
   .replace('comment', _comment)
   .replace('tag', _tag)
@@ -432,8 +432,8 @@ const autolink = edit(/^<(scheme:[^\s\x00-\x1f<>]*|email)>/)
 const _inlineComment = edit(_comment).replace('(?:-->|$)', '-->').getRegex();
 const tag = edit(
   '^comment'
-    + '|^</[a-zA-Z][\\w:-]*\\s*>' // self-closing tag
-    + '|^<[a-zA-Z][\\w-]*(?:attribute)*?\\s*/?>' // open tag
+    + '|^</[a-zA-Z][a-zA-Z0-9-]*\\s*>' // self-closing tag
+    + '|^<[a-zA-Z][a-zA-Z0-9-]*(?:attribute)*?\\s*/?>' // open tag
     + '|^<\\?[\\s\\S]*?\\?>' // processing instruction, e.g. <?php ?>
     + '|^<![a-zA-Z]+\\s[\\s\\S]*?>' // declaration, e.g. <!DOCTYPE html>
     + '|^<!\\[CDATA\\[[\\s\\S]*?\\]\\]>') // CDATA section

--- a/test/specs/new/html_invalid_tag_name.html
+++ b/test/specs/new/html_invalid_tag_name.html
@@ -1,0 +1,3 @@
+<p>foo &lt;bar_baz&gt; qux</p>
+<p>foo &lt;/a:b&gt; qux</p>
+<p>&lt;div_&gt;</p>

--- a/test/specs/new/html_invalid_tag_name.md
+++ b/test/specs/new/html_invalid_tag_name.md
@@ -1,0 +1,5 @@
+foo <bar_baz> qux
+
+foo </a:b> qux
+
+<div_>


### PR DESCRIPTION
Per CommonMark (Raw HTML, and HTML blocks type 7) and GFM, an HTML tag name is `[A-Za-z][A-Za-z0-9-]*`. The block and inline tag regexes used `[\w-]` (and `[\w:-]` for the inline closing tag), so `_` — and `:` on closing tags — were accepted. As a result sequences like `<bar_baz>`, `<em_>…</em_>` and `</a:b>` were emitted as raw HTML instead of being escaped as text.

This also removes an inconsistency where the inline opening-tag rule rejected `:` but the closing-tag rule accepted it.

Example:

```
foo <bar_baz> qux
```

before: `<p>foo <bar_baz> qux</p>` — after: `<p>foo &lt;bar_baz&gt; qux</p>` (matching commonmark.js).

Attribute names still accept `_`/`:` — only tag names are affected. Added a `test/specs/new` case covering inline open/close and block tags with `_`/`:`. Full spec and unit suites pass.
