### PR TITLE
fix: allow a tab before the closing sequence of an ATX heading

### DIFF
--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -138,8 +138,8 @@ export class _Tokenizer<ParserOutput = string, RendererOutput = string> {
         const trimmed = rtrim(text, '#');
         if (this.options.pedantic) {
           text = trimmed.trim();
-        } else if (!trimmed || this.rules.other.endingSpaceChar.test(trimmed)) {
-          // CommonMark requires space before trailing #s
+        } else if (!trimmed || this.rules.other.endingSpaceTabChar.test(trimmed)) {
+          // CommonMark requires a space or tab before trailing #s
           text = trimmed.trim();
         }
       }

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -48,6 +48,7 @@ export const other = {
   endingHash: /#$/,
   startingSpaceChar: /^ /,
   endingSpaceChar: / $/,
+  endingSpaceTabChar: /[ \t]$/,
   nonSpaceChar: /[^ ]/,
   newLineCharGlobal: /\n/g,
   tabCharGlobal: /\t/g,

--- a/test/specs/new/atx_heading_closing_sequence_tab.html
+++ b/test/specs/new/atx_heading_closing_sequence_tab.html
@@ -1,0 +1,5 @@
+<h1>foo</h1>
+<h2>bar</h2>
+<h3>baz #</h3>
+<h4>qux</h4>
+<h5>quux#</h5>

--- a/test/specs/new/atx_heading_closing_sequence_tab.md
+++ b/test/specs/new/atx_heading_closing_sequence_tab.md
@@ -1,0 +1,8 @@
+---
+gfm: false
+---
+# foo	#
+## bar	###
+### baz #	#
+#### qux 	#
+##### quux#


### PR DESCRIPTION
**Marked version:** 18.0.11 (master, df57534)

**Markdown flavor:** CommonMark

## Description

No issue for this one.

`src/Tokenizer.ts:141` decides whether a trailing run of `#` closes an ATX heading:

```js
} else if (!trimmed || this.rules.other.endingSpaceChar.test(trimmed)) {
  // CommonMark requires space before trailing #s
  text = trimmed.trim();
}
```

`endingSpaceChar` is `/ $/` (`src/rules.ts:50`), so only U+0020 counts. A tab in that position does not, and the closing sequence stays in the heading text.

## Expectation

`<TAB>` below stands for one literal tab character.

```md
# foo<TAB>#
```

```html
<h1>foo</h1>
```

## Result

```html
<h1>foo<TAB>#</h1>
```

Minimal repro: `marked.parse('# foo\t#\n')` returns `'<h1>foo\t#</h1>\n'`.

## What was attempted

CommonMark 0.31.2, "ATX headings":

> The opening sequence of `#` characters must be followed by spaces or tabs, or by the end of line. The optional closing sequence of `#`s must be preceded by spaces or tabs and may be followed by spaces or tabs only.

and again above example 75:

> The closing sequence must be preceded by a space or tab:

(source: https://github.com/commonmark/commonmark-spec/blob/0.31.2/spec.txt, lines 1102 to 1104 and 1257)

marked already handles the other two halves of that sentence with tabs: the opening sequence uses `(?=\s|$)` in the `heading` rule, and "followed by spaces or tabs only" falls out of `String.prototype.trim`. Only "preceded by" was space-only.

`endingSpaceChar` cannot simply be widened, because its other caller is the code span normalization at `src/Tokenizer.ts:848`, and there the spec really does mean U+0020:

> If the resulting string both begins *and* ends with a [space] character, but does not consist entirely of [space] characters, a single [space] character is removed from the front and back.

So the heading path gets its own `endingSpaceTabChar` rule and the code span path keeps `endingSpaceChar`.

Pedantic mode is untouched: it takes the earlier branch and strips trailing hashes regardless of what precedes them.

## Blast radius

I generated 33,075 documents (3 opening sequences x 5 separators after it x 7 bodies x 7 separators before the closing sequence x 9 tails, over 5 wrappings: bare, in a blockquote, in a list item, after a paragraph, before a paragraph) and diffed master against this branch, using the `commonmark` 0.31.2 package already in devDependencies as the reference. Comparison ignores whitespace between tags.

| | agreement with commonmark 0.31.2 |
|---|---|
| master | 26,595 / 33,075 (80.41%) |
| this branch | 33,075 / 33,075 (100%) |

6,480 documents change output. All 6,480 go from disagreeing with the reference to matching it, and 0 go the other way.

CommonMark and GFM spec completion tables are identical before and after: no spec example covers a tab in this position, which is why the suite never caught it.

## ReDoS

`npm run test:redos` covers the `other` rules, and the new one checks clean:

```
endingSpaceTabChar status = safe {"type":"safe","summary":"safe","isFuzz":false}
```

It is a single anchored character class with no quantifier.

## Tests

One spec file in `test/specs/new` covering a tab before a one-hash and a multi-hash closing sequence, a hash that is part of the content followed by a tab and a real closing hash, a mixed space and tab run, and a control line (`##### quux#`) whose hash is not preceded by whitespace and must stay in the text. Its expected HTML is byte for byte what `commonmark` 0.31.2 produces.

On master the test fails with:

```
AssertionError [ERR_ASSERTION]: Expected: <h1>foo</h1><h2>bar</h2><h3>baz #</h3
  Actual: <h1>foo #</h1><h2>bar ###</h2><h3>baz
```

Local run: 1797 to 1799 spec tests, 191 unit tests, 0 failures. `test:lint`, `test:types`, `test:umd` and `test:cjs` pass.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
