### PR TITLE
fix: avoid O(n^2) scanning in reflinkSearch

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -466,9 +466,32 @@ const nolink = edit(/^!?\[(ref)\](?:\[\])?/)
   .replace('ref', _blockLabel)
   .getRegex();
 
+// `reflink` and `nolink` are anchored, so the tokenizer tries each of them at a
+// single position. `reflinkSearch` drops the anchors and runs with the global
+// flag, which makes every '[' in the source a start position. A label crosses a
+// bracket only by escaping it, and nothing caps how often it does, so a
+// candidate that can never match still scans to the end of the source and the
+// whole pass costs O(n^2).
+//
+// The labels below bound that scan. `_boundedInlineLabel` limits how many
+// escapes, code spans and nested brackets a link text may hold, leaving runs of
+// ordinary characters unbounded so link text of any length is still found.
+// `_boundedBlockLabel` limits the label itself to 999 items, which is every
+// label CommonMark allows: "A link label can have at most 999 characters
+// inside the square brackets."
+const _boundedBlockLabel = /(?!\s*\])(?:\\[\s\S]|[^\[\]\\]){1,999}/;
+const _boundedInlineLabel = edit(/(?:[^\[\]\\`]*(?:\[(?:brackets|\\[\s\S]|[^\[\]\\])*\]|\\[\s\S]|`+(?!`)[^`]*?`+(?!`)|``+(?=\]))){0,999}?[^\[\]\\`]*?/)
+  .replace('brackets', _inlineLabelBrackets)
+  .getRegex();
+
 const reflinkSearch = edit('reflink|nolink(?!\\()', 'g')
-  .replace('reflink', reflink)
-  .replace('nolink', nolink)
+  .replace('reflink', edit(/^!?\[(label)\]\[(ref)\]/)
+    .replace('label', _boundedInlineLabel)
+    .replace('ref', _boundedBlockLabel)
+    .getRegex())
+  .replace('nolink', edit(/^!?\[(ref)\](?:\[\])?/)
+    .replace('ref', _boundedBlockLabel)
+    .getRegex())
   .getRegex();
 
 const _caseInsensitiveProtocol = /[hH][tT][tT][pP][sS]?|[fF][tT][pP]/;

--- a/test/specs/redos/quadratic_reflink_search.cjs
+++ b/test/specs/redos/quadratic_reflink_search.cjs
@@ -1,0 +1,18 @@
+// Regression: `reflinkSearch` is unanchored and runs with the global flag, so
+// every '[' in the source is a start position. A label crosses a bracket only
+// by escaping it, and nothing capped how often it could, so a candidate that
+// can never match still scanned to the end of the source. 188 KB of the first
+// shape took 21s to parse with default options.
+const escapedBracket = 18000;
+const escapedPair = 14000;
+
+module.exports = [
+  {
+    markdown: '[' + '\t\\['.repeat(escapedBracket) + '[',
+    html: `<p>[${'\t['.repeat(escapedBracket)}[</p>`,
+  },
+  {
+    markdown: '[' + '\t\\[\\]'.repeat(escapedPair) + '[',
+    html: `<p>[${'\t[]'.repeat(escapedPair)}[</p>`,
+  },
+];


### PR DESCRIPTION
**Marked version:** current `master` (a43c064); reproduces on the released 18.0.12

**Markdown flavor:** CommonMark

## Description

With default options, a run of escaped brackets parses in O(n²). The input is just text — it contains no `]` at all, so nothing in it can ever become a link:

```js
marked.parse('[' + '\t\\['.repeat(n) + '[');
```

| input | `master` | this PR |
|---|---|---|
| 23 KB | 0.34 s | 0.14 s |
| 94 KB | 5.16 s | 0.57 s |
| 188 KB | **20.9 s** | 1.09 s |

Doubling the input quadruples the time on `master`. After the change it doubles it, measured out to 1.5 MB (×1.94 to ×2.02 per doubling). For scale, 190 KB of ordinary markdown parses in 50 ms.

The cost is `inline.reflinkSearch`. `reflink` and `nolink` are anchored, so the tokenizer tries each of them at a single position, but `reflinkSearch` drops the anchors and runs with the global flag — every `[` in the source becomes a start position. A label crosses a bracket only by escaping it, and nothing capped how often it could, so a candidate that can never match still scans to the end of the source. Isolating the rule at n=32,000 gives 3.3 s for zero matches.

The fix bounds the label runs that `reflinkSearch` is built from, leaving `reflink`, `nolink` and `link` untouched:

- `_boundedInlineLabel` bounds how many escapes, code spans and nested brackets a link *text* may hold. Runs of ordinary characters stay unbounded, so link text of any length is still found — CommonMark puts no limit on link text, only on link labels.
- `_boundedBlockLabel` bounds the *label* to 999 items, which covers every label the spec permits: *"A link label can have at most 999 characters inside the square brackets."*

### Verification

`test:specs` 1813/1813, `test:unit` 191/191, `test:umd`, `test:cjs`, `test:types`, `test:lint` all pass.

To check that nothing else moved, I diffed `master`'s output against this branch over 247,768 document × option comparisons — 421 real-world `.md` files, all 1,521 markdown samples in `test/specs`, and 60,000 seeded bracket/escape/backtick fuzz cases, each under default, `gfm: false`, `breaks` and `pedantic`. **Zero output differences.** Shrinking the bounds to 3 makes that same harness report 24 differences and 10 spec failures, so it does detect change.

Output does change for one input class: a reference label longer than 999 characters. `master` accepts it as a link, this branch does not — which is what `commonmark.js` does:

| label length | commonmark.js | marked `master` | this PR |
|---|---|---|---|
| 904 | link | link | link |
| 1003 | text | **link** | text |
| 2004 | text | **link** | text |

One note on tooling: `recheck` reports this rule as `vulnerable` both before and after, because a bound of 999 is still a large constant. It also flags `inline.normal.link` and `inline.gfm._backpedal`, which measure as fast end to end, so I went by measured parse time rather than by its verdict.

`test/specs/redos/quadratic_reflink_search.cjs` sits next to the existing quadratic guards. With the fix its two cases take 0.32 s and 0.23 s; with `src/rules.ts` reverted they take 1.63 s and 1.65 s and both fail the runner's `took too long` assertion.

## Contributor

- [x] Test(s) exist to ensure functionality and minimize regression: `test/specs/redos/quadratic_reflink_search.cjs`.
- [ ] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
