### PR TITLE
fix: strip whitespace when normalizing link reference labels

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -131,7 +131,10 @@ export function trimTrailingBlankLines(str: string) {
  * keeps the folded label lower case, the form `def.tag` has always used.
  */
 export function normalizeLabel(label: string) {
-  return label.toLowerCase().toUpperCase().toLowerCase();
+  // The spec also asks for leading and trailing spaces, tabs and line endings
+  // to be stripped. Doing it here keeps every call site in agreement: the
+  // definition and the reference have to normalize to the same key.
+  return label.trim().toLowerCase().toUpperCase().toLowerCase();
 }
 
 export function findClosingBracket(str: string, b: string) {

--- a/test/specs/new/link_reference_label_whitespace.html
+++ b/test/specs/new/link_reference_label_whitespace.html
@@ -1,0 +1,3 @@
+<p><a href="/foo">foo </a></p>
+<p><a href="/bar"> bar</a></p>
+<p><a href="/baz">baz</a></p>

--- a/test/specs/new/link_reference_label_whitespace.md
+++ b/test/specs/new/link_reference_label_whitespace.md
@@ -1,0 +1,9 @@
+[foo ]
+
+[ bar]
+
+[baz]
+
+[foo]: /foo
+[bar]: /bar
+[baz ]: /baz


### PR DESCRIPTION
## Problem

CommonMark normalizes a link label in three steps — case-fold, **strip leading and trailing whitespace**, collapse internal runs. `normalizeLabel` does only the first:

```ts
export function normalizeLabel(label: string) {
  return label.toLowerCase().toUpperCase().toLowerCase();
}
```

The collapse is bolted onto one of its four call sites (`Tokenizer.ts:531`, the `def` rule); `reflink` and the two `Lexer` lookups don't have it, and nothing strips anywhere. A definition and a reference that differ only in surrounding whitespace therefore normalize to different keys and never match.

Compared against the `commonmark` 0.31.2 reference implementation already in devDependencies, normalizing away marked's `<img>` vs `<img />` difference:

```
DIFF  trailing space in the reference       [foo ] + [foo]: /url
        marked     : <p>[foo ]</p>
        commonmark : <p><a href="/url">foo </a></p>
DIFF  leading space in the reference        [ foo] + [foo]: /url
DIFF  trailing space in the definition      [foo]  + [foo ]: /url
DIFF  emphasis around a spaced reference    *[foo ]* + [foo]: /url
        marked     : <p><em>[foo ]</em></p>
        commonmark : <p><em><a href="/url">foo </a></em></p>
```

4 of 9 probe inputs diverge. The collapse cases (internal double space, tab, newline) all pass — the missing step is the strip.

The failure is silent: a valid reference link renders as literal bracket text, and in the masking case the surrounding emphasis is disturbed too.

## Fix

Do the strip inside `normalizeLabel`, so all four call sites agree by construction.

```ts
return label.trim().toLowerCase().toUpperCase().toLowerCase();
```

## Test plan

- Added `test/specs/new/link_reference_label_whitespace.{md,html}`. The expected HTML is the `commonmark` reference implementation's own output for that input, not hand-written.
- Ran: `node --test test/run-spec-tests.js` → **1815 passing** (1813 before, plus the new pair).
- Ran: `node --test test/unit/*.test.js` → **191 passing**.
- Checked: reverting only `helpers.ts` fails the new spec. Worth noting that the existing 1813 pass **identically with and without this change** — the CommonMark spec files in the repo don't cover surrounding whitespace in a label, which is why this survived.
- Ran: `eslint src/helpers.ts` → clean.