### PR TITLE
docs: add commonmark and gfm as versions in demo

### DIFF
--- a/docs/demo/demo.js
+++ b/docs/demo/demo.js
@@ -25,6 +25,8 @@ let latestVersion = 'master';
 const search = searchToObject();
 const markedVersions = {
   master: '../',
+  commonmark: 'commonmark',
+  gfm: 'gfm',
 };
 let delayTime = 1;
 let checkChangeTimeout = null;
@@ -287,8 +289,18 @@ function handleIframeLoad() {
   }
 }
 
+let debounceInputDirty;
 function handleInput() {
-  inputDirty = true;
+  if ($markedVerElem.value === 'gfm') {
+    // GFM api limits requests to 60 per hour so we
+    // are debouncing here to limit unneccessary requests
+    clearTimeout(debounceInputDirty);
+    debounceInputDirty = setTimeout(() => {
+      inputDirty = true;
+    }, 500);
+  } else {
+    inputDirty = true;
+  }
 }
 
 function handleVersionChange() {
@@ -419,7 +431,7 @@ function updateVersion() {
 }
 
 function checkForChanges() {
-  if (inputDirty && $markedVerElem.value !== 'pr') {
+  if (inputDirty) {
     inputDirty = false;
 
     updateLink();
@@ -498,9 +510,15 @@ function messageWorker(message) {
           break;
         }
         case 'parse': {
-          $previewElem.classList.remove('error');
-          $htmlElem.classList.remove('error');
-          $lexerElem.classList.remove('error');
+          if (e.data.error) {
+            $previewElem.classList.add('error');
+            $htmlElem.classList.add('error');
+            $lexerElem.classList.add('error');
+          } else {
+            $previewElem.classList.remove('error');
+            $htmlElem.classList.remove('error');
+            $lexerElem.classList.remove('error');
+          }
           const scrollPercent = getScrollPercent();
           setParsed(e.data.parsed, e.data.lexed);
           setScrollPercent(scrollPercent);
@@ -511,7 +529,7 @@ function messageWorker(message) {
       clearTimeout(checkChangeTimeout);
       delayTime = 10;
       checkForChanges();
-      workerPromises[e.data.id]();
+      workerPromises[e.data.id](e.data);
       delete workerPromises[e.data.id];
     };
     markedWorker.onerror = markedWorker.onmessageerror = (err) => {

--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -96,7 +96,9 @@
             <a id="permalink">Permalink</a> ·
             <span>Version: </span>
             <select id="markedVersion">
-              <option value="master"selected>master</option>
+              <option value="master" selected>master</option>
+              <option value="commonmark">CommonMark</option>
+              <option value="gfm">GFM</option>
             </select> ·
             <button id="clear">Clear</button>
             <select id="inputType">

--- a/docs/demo/worker.js
+++ b/docs/demo/worker.js
@@ -1,4 +1,5 @@
 const versionCache = {};
+const gfmCache = new Map();
 let currentVersion;
 
 onunhandledrejection = (e) => {
@@ -16,6 +17,9 @@ onmessage = function(e) {
 };
 
 function getDefaults() {
+  if (currentVersion === 'commonmark' || currentVersion === 'gfm') {
+    return {};
+  }
   const marked = versionCache[currentVersion];
   let defaults = {};
   if (typeof marked.getDefaults === 'function') {
@@ -61,6 +65,33 @@ function parse(e) {
       break;
     }
     case 'parse': {
+      if (currentVersion === 'commonmark' || currentVersion === 'gfm') {
+        const startTime = new Date();
+        Promise.resolve(versionCache[currentVersion].parse(e.data.markdown))
+          .then((parsed) => {
+            const endTime = new Date();
+            postMessage({
+              id: e.data.id,
+              task: e.data.task,
+              version: currentVersion,
+              lexed: '',
+              parsed,
+              time: endTime - startTime,
+            });
+          })
+          .catch((err) => {
+            postMessage({
+              id: e.data.id,
+              task: e.data.task,
+              version: currentVersion,
+              lexed: '',
+              parsed: `Error: ${err.message}`,
+              time: 0,
+              error: true,
+            });
+          });
+        break;
+      }
       const marked = versionCache[currentVersion];
       // marked 0.0.1 had tokens array as the second parameter of lexer and no options
       const options = currentVersion.endsWith('@0.0.1') ? [] : mergeOptions(e.data.options);
@@ -72,6 +103,7 @@ function parse(e) {
       postMessage({
         id: e.data.id,
         task: e.data.task,
+        version: currentVersion,
         lexed: lexedList,
         parsed,
         time: endTime - startTime,
@@ -132,6 +164,47 @@ function loadVersion(ver) {
   let promise;
   if (versionCache[ver]) {
     promise = Promise.resolve();
+  } else if (ver === 'commonmark') {
+    promise = import('https://cdn.jsdelivr.net/npm/commonmark@0.31.2/+esm')
+      .then((cm) => {
+        const reader = new cm.Parser();
+        const writer = new cm.HtmlRenderer();
+        versionCache[ver] = {
+          parse: (markdown) => writer.render(reader.parse(markdown)),
+        };
+      });
+  } else if (ver === 'gfm') {
+    versionCache[ver] = {
+      parse: async(markdown) => {
+        if (gfmCache.has(markdown)) {
+          return gfmCache.get(markdown);
+        }
+        const res = await fetch('https://api.github.com/markdown', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            text: markdown,
+            mode: 'gfm',
+          }),
+        });
+        const text = await res.text();
+        if (!res.ok) {
+          let errorMsg = `HTTP Error ${res.status}`;
+          try {
+            const json = JSON.parse(text);
+            if (json.message) {
+              errorMsg = json.message;
+            }
+          } catch {}
+          throw new Error(errorMsg);
+        }
+        gfmCache.set(markdown, text);
+        return text;
+      },
+    };
+    promise = Promise.resolve();
   } else {
     promise = import(ver + '/lib/marked.esm.js')
       .catch(fetchMarked(ver + '/marked.min.js'))
@@ -155,6 +228,12 @@ function loadVersion(ver) {
     currentVersion = ver;
   }).catch((err) => {
     console.error(err);
-    throw new Error('Cannot load that version of marked');
+    let errorMsg = 'Cannot load that version of marked';
+    if (ver === 'commonmark') {
+      errorMsg = 'Cannot load commonmark';
+    } else if (ver === 'gfm') {
+      errorMsg = 'Cannot load gfm';
+    }
+    throw new Error(errorMsg);
   });
 }


### PR DESCRIPTION
## Description

Add CommonMark and GFM as version on the demo page.

<img width="1135" height="282" alt="image" src="https://github.com/user-attachments/assets/b2bef4f8-f40d-4888-8454-44031342a2ef" />

CommonMark runs loads commonmark.js in the worker, and GFM calls https://api.github.com/markdown in the worker.

[GFM demo](https://marked-website-git-fork-uzitech-gfm-demo-output-markedjs.vercel.app/demo/?outputType=html&text=%7C%20a%20%7C%20b%20%7C%0A%7C---%7C---%7C%0A%7C%201%20%7C%202%20%7C&options=%7B%0A%20%22async%22%3A%20false%2C%0A%20%22breaks%22%3A%20false%2C%0A%20%22extensions%22%3A%20null%2C%0A%20%22gfm%22%3A%20true%2C%0A%20%22hooks%22%3A%20null%2C%0A%20%22pedantic%22%3A%20false%2C%0A%20%22silent%22%3A%20false%2C%0A%20%22tokenizer%22%3A%20null%2C%0A%20%22walkTokens%22%3A%20null%0A%7D&version=gfm)

## Contributor

- [ ] Test(s) exist to ensure functionality and minimize regression (if no tests added, list tests covering this PR); or,
- [x] no tests required for this PR.
- [ ] If submitting new feature, it has been documented in the appropriate places.

## Committer

In most cases, this should be a different person than the contributor.

- [ ] CI is green (no forced merge required).
- [ ] Squash and Merge PR following [conventional commit guidelines](https://www.conventionalcommits.org/).
